### PR TITLE
Replace public todos and document `.front-commerce.js`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,7 @@ sidebar_categories:
   Magento2:
     - docs/magento2/overview
   Reference:
+    - docs/reference/front-commerce-js
     - docs/reference/configurations
     - docs/reference/environment-variables
     - docs/reference/graphql-module-definition

--- a/source/docs/advanced/server/add-http-endpoint.md
+++ b/source/docs/advanced/server/add-http-endpoint.md
@@ -13,7 +13,7 @@ Technically, Front-Commerce’s server is based on [Express](http://expressjs.co
 
 ## What is a module?
 
-A module is declared using the `module` entry from the [`.front-commerce.js`](#TODO) file. Each module can contain client code (See [Extend the theme](/docs/essentials/extend-the-theme.html)), and server code (current guide).
+A module is declared using the [`modules` entry from the `.front-commerce.js` file](/docs/reference/front-commerce-js.html#modules). Each module can contain client code (See [Extend the theme](/docs/essentials/extend-the-theme.html)), and server code (current guide).
 
 Once the module is declared, Front-Commerce will automatically add your custom server entrypoints following your module configuration in `my-module/server/module.config.js`.
 

--- a/source/docs/essentials/add-a-page-client-side.md
+++ b/source/docs/essentials/add-a-page-client-side.md
@@ -47,7 +47,7 @@ const Recipes = () => <div>
 export default Recipes;
 ```
   <blockquote class="note">
-  Note that there is a `RecipesList` component here. It is in fact a business component that you can create by refering to <a href="#TODO">Add a business component</a>.
+  Note that there is a `RecipesList` component here. It is in fact a business component that you can create by refering to [Create a business component](/docs/essentials/create-a-business-component.html).
   </blockquote>
 * `my-module/web/theme/pages/Recipes/index.js`: will proxy the `Recipes.js` file in order to be able to do imports on the folder directly. See [this blog post](http://bradfrost.com/blog/post/this-or-that-component-names-index-js-or-component-js/) for more context about this pattern.
 <!-- TODO add comment about code splitting and link to our documentation -->

--- a/source/docs/essentials/add-component-to-storybook.md
+++ b/source/docs/essentials/add-component-to-storybook.md
@@ -185,7 +185,7 @@ documentation Front-Commerce base theme's core components.
 However, you might not use each one of them in your final theme, and some
 stories might become irrelevant in your design system. To chose which one to
 display, you need to update the `.frontcommerce.js` configuration file, and
-add the key `styleguidePaths`.
+add the key [`styleguidePaths`](/docs/reference/front-commerce-js.html#styleguidePaths).
 
 ```diff
 module.exports = {
@@ -208,12 +208,12 @@ module.exports = {
 The value is an array containing the regex that matches the stories you want
 to use in your styleguide. In this example, we only want to display atoms and
 molecules from our UI Components. But please remember that this will fetch
-the stories within all the `web/theme` folder within the `modules` defined in
+the stories within all the `web/theme` folder within the [`modules`](/docs/reference/front-commerce-js.html#modules) defined in
 `.front-commerce.js`.
 
 Hence, if you don't want to have an atom that is defined within
 Front-Commerce core, but still want the other atoms, you will need to be more
-specific within your `styleguidePaths` array. For instance, if you only want
+specific within your [`styleguidePaths`](/docs/reference/front-commerce-js.html#styleguidePaths) array. For instance, if you only want
 the `Typography` related stories, and the `Button` related stories, you will
 need to write like this:
 
@@ -226,6 +226,6 @@ need to write like this:
   ]
 ```
 
-Finally, if you don't define the `styleguidePaths` key in your
+Finally, if you don't define the [`styleguidePaths`](/docs/reference/front-commerce-js.html#styleguidePaths) key in your
 `.front-commerce.js` file, each story found in the `web/theme` folder will be
-used (the value used for `styleguidePaths` is `[ /.*.story.js$/ ]`).
+used.

--- a/source/docs/essentials/add-component-to-storybook.md
+++ b/source/docs/essentials/add-component-to-storybook.md
@@ -208,8 +208,8 @@ module.exports = {
 The value is an array containing the regex that matches the stories you want
 to use in your styleguide. In this example, we only want to display atoms and
 molecules from our UI Components. But please remember that this will fetch
-the stories within all the `web/theme` folder within the [`modules`](/docs/reference/front-commerce-js.html#modules) defined in
-`.front-commerce.js`.
+the stories within all the `web/theme` folder from [`modules` defined in
+`.front-commerce.js`](/docs/reference/front-commerce-js.html#modules).
 
 Hence, if you don't want to have an atom that is defined within
 Front-Commerce core, but still want the other atoms, you will need to be more
@@ -226,6 +226,4 @@ need to write like this:
   ]
 ```
 
-Finally, if you don't define the [`styleguidePaths`](/docs/reference/front-commerce-js.html#styleguidePaths) key in your
-`.front-commerce.js` file, each story found in the `web/theme` folder will be
-used.
+Finally, if you don't define the [`styleguidePaths` key in your `.front-commerce.js` file](/docs/reference/front-commerce-js.html#styleguidePaths), each story found in the `web/theme` folder will be used.

--- a/source/docs/essentials/create-a-business-component.md
+++ b/source/docs/essentials/create-a-business-component.md
@@ -9,7 +9,7 @@ components available in the `web/theme/modules` and `web/theme/pages` folders.
 
 <blockquote class="note">
 If you feel the need to understand why we went for this organization, feel
-free to refer to [React components structure](#TODO)
+free to refer to [React components structure](/docs/concepts/react-components-structure.html)
 first.
 </blockquote>
 
@@ -217,7 +217,7 @@ storiesOf("modules.StoreLocator", module).add("default", () => {
 ```
     <blockquote class="note">
     We won't focus on the story in this guide. But you can refer to the
-    [Storybook guide](#TODO) to learn how to add any kind of stories
+    [Storybook guide](/docs/essentials/add-component-to-storybook.html) to learn how to add any kind of stories
     to your Storybook.
     </blockquote>
 

--- a/source/docs/essentials/create-a-ui-component.md
+++ b/source/docs/essentials/create-a-ui-component.md
@@ -9,7 +9,7 @@ components available in the `theme/modules` and `theme/pages` folders.
 
 <blockquote class="info">
 If you feel the need to understand why we went for this organization, feel
-free to refer to [React components structure](#TODO)
+free to refer to [React components structure](/docs/concepts/react-components-structure.html)
 first.
 </blockquote>
 
@@ -64,7 +64,7 @@ First, let's split the mockup in several UI components following the [Atomic Des
   regardless of the device size.
 
 As you can see, each UI component will take place in the `web/theme/components` folder.
-To better understand why, please refer to our [React component structure](#TODO) documentation.
+To better understand why, please refer to our [React components structure](/docs/concepts/react-components-structure.html) documentation.
 
 <blockquote class="note">
 If you have trouble splitting your mockups, you can refer to

--- a/source/docs/essentials/extend-the-graphql-schema.md
+++ b/source/docs/essentials/extend-the-graphql-schema.md
@@ -68,8 +68,8 @@ your application yet. You need to register it.
 
 ## Register the module in the application
 
-Front-Commerce allows you to manage your modules in the `serverModules` key of
-the [`.frontcommerce.js`](#TODO) file located in your project’s root.
+Front-Commerce allows you to manage your modules in the [`serverModules` key of
+the `.frontcommerce.js` file](/docs/reference/front-commerce-js.html#serverModules) located in your project’s root.
 
 Let’s add a `ClicksCounters` GraphQL module by adding it to the existing list:
 

--- a/source/docs/essentials/extend-the-theme.md
+++ b/source/docs/essentials/extend-the-theme.md
@@ -42,7 +42,7 @@ my-module
     └── theme
 ```
 
-Then, we need to tell Front-Commerce that this module exists in your [`.frontcommerce.js`](#TODO) file. If the module has been created at the root of your project, it would look like this:
+Then, we need to tell Front-Commerce that this module exists in your [`.frontcommerce.js`](/docs/reference/front-commerce-js.html) file. If the module has been created at the root of your project, it would look like this:
 
 ```diff
 module.exports = {
@@ -66,7 +66,7 @@ Let's add the description of a `Product` to a `ProductItem` as an example of ove
 The original file is: [`node_modules/front-commerce/src/web/theme/modules/ProductView/ProductItem/ProductItem.js`](https://gitlab.com/front-commerce/front-commerce/blob/master/src/web/theme/modules/ProductView/ProductItem/ProductItem.js)
 
 <blockquote class="info">
-Please refer to the [Folder structure documentation page](#TODO) to get a better
+Please refer to the [Front-Commerce’s folder structure documentation page](/docs/concepts/front-commerce-folder-structure.html) to get a better
 understanding of how components are organized in the base theme.
 </blockquote>
 

--- a/source/docs/essentials/installation.md
+++ b/source/docs/essentials/installation.md
@@ -106,7 +106,7 @@ For instance, to interact with Magento2 you will need to configure a few things:
   to enable cache invalidation from Magento2
 
 We invite you to dig into the other configurations and tweak them if you wish.
-See [our documentation](#TODO) for further information.
+See [our documentation](/docs/reference/environment-variables.html#Remote-services-configuration) for further information.
 
 #### Configure stores
 
@@ -128,7 +128,7 @@ module.exports = {
 };
 ```
 
-<!-- TODO Add a link to the store config documentation -->
+See [Configure multiple stores](/docs/advanced/production-ready/multistore.html) for further information.
 
 <blockquote class="info">
 **Magento:** when using Front-Commerce with Magento, store codes
@@ -140,8 +140,7 @@ must match [Magento store view code](https://docs.magento.com/m2/ee/user_guide/s
 To enable caching locally, you can configure it in `src/config/caching.js`. For now
 only redis is supported, which requires to have a redis instance to connect to.
 
-See [our caching section](#TODO) to know more about caching in the GraphQL
-middleware.
+<!-- TODO See [our caching section](#TODO) to know more about caching in the GraphQL middleware. -->
 
 ### Launch the application
 
@@ -181,5 +180,5 @@ the existing components.
 
 <blockquote class="tip">
 You can configure which stories to display in your styleguide by setting the
-[`styleguidePaths` key in your `.front-commerce.js`](#TODO) file. Its value should be a list of regex (e.g: `[/.*.story.js$/];`) that will be matched against your stories paths.
+[`styleguidePaths` key in your `.front-commerce.js` file](/docs/reference/front-commerce-js.html#styleguidePaths). Its value should be a list of regexes (e.g: `[/.*.story.js$/];`) that will be matched against your stories paths.
 </blockquote>

--- a/source/docs/reference/configurations.md
+++ b/source/docs/reference/configurations.md
@@ -22,7 +22,7 @@ Each file described below exist in [`node_modules/front-commerce/src/config`](ht
 This configuration file should contain any thing that impacts the content of your website. The term website refers to what a [`website` is in Magento's ecosystem](https://devdocs.magento.com/guides/v2.3/config-guide/multi-site/ms_over.html).
 
 * `root_categories_path` (ex: `1/517/`): which category to use for the main navigation menu. It will then be the children of this category that will be displayed.
-* `default_image_url` (ex: an absolute URL of an image): which image to use when no image path has been given to `<ResizedImage>` <!-- TODO link to reference -->
+* `default_image_url` (ex: an absolute URL of an image): which image to use when no image path has been given to [`<ResizedImage>`](/docs/advanced/production-ready/media-middleware.html#lt-ResizedImage-gt-component)
 * `defaultTitle`: the default meta title of your application
 * `defaultDescription`: the default meta description of your application
 * `available_page_sizes`: which page sizes to display in a product list page (or any page with a pagination)

--- a/source/docs/reference/front-commerce-js.md
+++ b/source/docs/reference/front-commerce-js.md
@@ -3,44 +3,134 @@ id: front-commerce-js
 title: .front-commerce.js
 ---
 
-The `.front-commerce.js` configuration file at the root of a Front-Commerce project is the main entrypoint defining the application.
-From
+The `.front-commerce.js` configuration file at the root of a Front-Commerce project is the main entrypoint defining how an application behaves.
+
+From this definition, Front-Commerce will initialize and register the different pieces composing your application.
+
+## `name`
+
+The application name.
+
+```js
+module.exports = {
+  name: "ACME shop",
+  // […]
+};
+```
+
+This name is used for _Developer Experience_ only and is not aimed at appearing in the theme or any website user message.
+
+It is for instance used as title in the [Storybook design system](/docs/essentials/add-component-to-storybook.html).
+
+## `url`
+
+The project URL.
+
+```js
+module.exports = {
+  // […]
+  url: "https://github.com/acme/shop/",
+  // […]
+};
+```
+
+This name is used for _Developer Experience_ only and is not aimed at appearing in the theme or any website user message. You may thus use it to redirect to your staging instance, or project management tool for instance.
+
+It is for instance used as link target for the name in the [Storybook design system](/docs/essentials/add-component-to-storybook.html).
+
+<blockquote class="note">
+  Use [the `FRONT_COMMERCE_URL` environment variable](/docs/reference/environment-variables.html#Host) to configure the URL used to access to your application.
+</blockquote>
 
 ## `modules`
 
-A module is declared using the `module` entry from the [`.front-commerce.js`](#TODO) file. Each module can contain client code (See [Extend the theme](/docs/essentials/extend-the-theme.html)), and server code (current guide).
+A list of path to Front-Commerce modules to register in your application.
 
-Once the module is declared, Front-Commerce will automatically add your custom server entrypoints following your module configuration in `my-module/server/module.config.js`.
+```js
+module.exports = {
+  // […]
+  modules: ["./acme-common", "./src", "./winter", "./christmas"]
+  // […]
+};
+```
+
+Each module can contain client code to [extend the theme](/docs/essentials/extend-the-theme.html), and server code to [add custom server endpoints](/docs/advanced/server/add-http-endpoint.html).
+
+<blockquote class="note">
+Front-Commerce modules are registered in the order they appear in this list.
+**The default Front-Commerce theme will always be registered first and must not appear in this list.**
+</blockquote>
+
+In the above example, a `component/Foo` component would be resolved according to theme overrides in the following order (the first existing one would be used):
+
+1. `./christmas/component/Foo`
+1. `./winter/component/Foo`
+1. `./src/component/Foo`
+1. `./acme-common/component/Foo`
+1. `front-commerce/src/web/theme/component/Foo`
+
+
+## `serverModules`
+
+A list of objects describing GraphQL modules to register in your application.
+GraphQL modules allows you to [extend the GraphQL schema](/docs/essentials/extend-the-graphql-schema.html).
+
+```js
+module.exports = {
+  // […]
+  serverModules: [
+    { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+    { name: "Magento2", path: "server/modules/magento2" }
+  ],
+  // […]
+};
+```
+
+Each object must be composed of the properties below:
+
+* `name`: unique key that must be unique across the `serverModules` list.
+  It is a temporary name that is used during a code generation step and has no other usage in the application.
+  _Do not worry about it, it will be deprecated in a near future: see [#179](https://gitlab.com/front-commerce/front-commerce/issues/179) for further information._
+
+* `path`: must be a path to the [GraphQL module definition file](/docs/reference/graphql-module-definition.html)
+
+<blockquote class="info">
+  GraphQL modules will be loaded according to the [`dependencies` declared in their respective definitions](/docs/reference/graphql-module-definition.html#dependencies-optional).
+  The order in the `serverModules` list should **NOT** be relied on for dependency management.
+</blockquote>
+
+As of the latest release, Front-Commerce’s provides the following GraphQL modules (or [meta-modules](/docs/advanced/graphql/meta-modules.html)):
+
+* `server/modules/front-commerce-core`: core features of Front-Commerce.
+* `server/modules/magento2` _(meta module)_: Magento2 GraphQL modules to [use Front-Commerce with all Magento2 supported features](/docs/magento2/overview.html).
+  Register single sub-modules explicitely if you only need a subset of features.
+* [Front-Commerce’s embedded payment](/docs/advanced/checkout/overview.html) modules:
+  * `server/modules/payment-ogone`: Ogone payment platform.
+  * `server/modules/payment-paypal`: PayPal payment platform.
+  * `server/modules/payment-payzen`: PayZen payment platform.
+
+<!-- TODO Add links to each embedded payment documentation page when available -->
 
 ## `styleguidePaths`
 
--> Display only the relevant stories to your Design System
+_Default value: `[ /.*.story.js$/ ]`_
 
-If you run the styleguide for your own project, you may notice that
-Front-Commerce comes with a lot of stories. This is what serves as
-documentation Front-Commerce base theme's core components.
-
-However, you might not use each one of them in your final theme, and some
-stories might become irrelevant in your design system. To chose which one to
-display, you need to update the `.frontcommerce.js` configuration file, and
-add the key `styleguidePaths`.
-
-## `name`
-## `url`
-## `serverModules`
+A list of regexes that match the Stoybook stories you want to use in your styleguide, so you can [only display relevant stories in your Design System](/docs/essentials/add-component-to-storybook.html#Display-only-the-relevant-stories-to-your-Design-System).
 
 
-Front-Commerce allows you to manage your modules in the `serverModules` key of
-the [`.frontcommerce.js`](#TODO) file located in your project’s root.
+```js
+module.exports = {
+  // […]
+  styleguidePaths: [
+    /.?\/components\/atoms\/Button\/.*.story.js$/,
+    /.?\/components\/atoms\/Typography\/.*.story.js$/,
+    /.?\/components\/molecules\/.*.story.js$/,
+    /.?\/(pages|modules)\/.*.story.js$/,
+  ],
+  // […]
+};
+```
 
-Let’s add a `ClicksCounters` GraphQL module by adding it to the existing list:
-
-
-
-The `name` key must be unique across your server modules. It is a temporary name
-that is used during a code generation step and has no other usage in the
-application. _Do not worry about it, it will be deprecated in a near future: see
-[#179](https://gitlab.com/front-commerce/front-commerce/issues/179) for further
-information._
-
-The `path` must be a path to your module definition file (created above).
+<blockquote class="info">
+Stories matching this pattern will be fetched across the `web/theme` folder of every [Front-Commerce `modules` defined](#modules) in the `.front-commerce.js` file.
+</blockquote>

--- a/source/docs/reference/front-commerce-js.md
+++ b/source/docs/reference/front-commerce-js.md
@@ -1,0 +1,46 @@
+---
+id: front-commerce-js
+title: .front-commerce.js
+---
+
+The `.front-commerce.js` configuration file at the root of a Front-Commerce project is the main entrypoint defining the application.
+From
+
+## `modules`
+
+A module is declared using the `module` entry from the [`.front-commerce.js`](#TODO) file. Each module can contain client code (See [Extend the theme](/docs/essentials/extend-the-theme.html)), and server code (current guide).
+
+Once the module is declared, Front-Commerce will automatically add your custom server entrypoints following your module configuration in `my-module/server/module.config.js`.
+
+## `styleguidePaths`
+
+-> Display only the relevant stories to your Design System
+
+If you run the styleguide for your own project, you may notice that
+Front-Commerce comes with a lot of stories. This is what serves as
+documentation Front-Commerce base theme's core components.
+
+However, you might not use each one of them in your final theme, and some
+stories might become irrelevant in your design system. To chose which one to
+display, you need to update the `.frontcommerce.js` configuration file, and
+add the key `styleguidePaths`.
+
+## `name`
+## `url`
+## `serverModules`
+
+
+Front-Commerce allows you to manage your modules in the `serverModules` key of
+the [`.frontcommerce.js`](#TODO) file located in your project’s root.
+
+Let’s add a `ClicksCounters` GraphQL module by adding it to the existing list:
+
+
+
+The `name` key must be unique across your server modules. It is a temporary name
+that is used during a code generation step and has no other usage in the
+application. _Do not worry about it, it will be deprecated in a near future: see
+[#179](https://gitlab.com/front-commerce/front-commerce/issues/179) for further
+information._
+
+The `path` must be a path to your module definition file (created above).

--- a/source/help.md
+++ b/source/help.md
@@ -24,7 +24,7 @@ questions about this documentation and the project
 No.
 
 As a bootstrapped company with a small team, we do not think we could be able to
-achieve [our vision](TODO) in a sustainable way with an open source
+achieve our vision <!-- TODO Link to « our vision » page -->in a sustainable way with an open source
 business model yet.
 
 That being said, we are open sourcing part of our stack and contributing to open
@@ -51,7 +51,7 @@ endpoints and custom theme.
     features
 5.  Customize your Front-Commerce theme by extending the base theme
 
-More information in our [getting started section](TODO).
+More information in our [getting started section](/docs/essentials/installation.html).
 
 ### What benefits should I expect?
 

--- a/source/index.md
+++ b/source/index.md
@@ -84,7 +84,7 @@ layout: index
         <li>SEO: clean urls, redirections, sitemaps, meta information and rich data</li>
       </ul>
 
-      <a class="link learn-more button" href="mailto:contact@front-commerce.com?subject=I’m interested!">
+      <a class="link learn-more button" href="/docs/magento2/overview.html">
         About our Magento 2 integration <span class="icon-arrow-right-alt"></span>
       </a>
     </div>
@@ -109,7 +109,7 @@ layout: index
         <li><a href="https://www.izberg-marketplace.com/">Izberg</a></li>
       </ul>
 
-      <a class="link learn-more button" href="mailto:contact@front-commerce.com?subject=I’m interested!">
+      <a class="link learn-more button" href="/docs/appendices/roadmap.html">
         Take a look at our Roadmap <span class="icon-arrow-right-alt"></span>
       </a>
     </div>
@@ -165,7 +165,7 @@ layout: index
   <h2>Still interested? Any questions?</h2>
 
   <p>If you are interested with what you’ve read or things are still not clear, do not hesitate to reach us! We could schedule a call or a demo so you could evaluate the product in a more concrete way.</p>
-  
+
   <div class="center">
     <a class="link primary button" href="mailto:contact@front-commerce.com?subject=I’m interested!">Contact the team</a>
   </div>


### PR DESCRIPTION
See https://deploy-preview-41--elastic-austin-cf9d40.netlify.com/docs/reference/front-commerce-js.html for the `.front-commerce.js` page.

The only remaining dead links are the one related to the « vision » page.
We should settle on this…