### PR TITLE
Update doc to use `export default` where relevant

### DIFF
--- a/source/docs/advanced/production-ready/logging.md
+++ b/source/docs/advanced/production-ready/logging.md
@@ -34,7 +34,7 @@ Without configuration, a logger does nothing. You need to configure what to do w
 
 ```js
 // my-module/config/logging.js
-module.exports = {
+export default {
   server: [
     {
       type: "file",
@@ -82,7 +82,7 @@ To do so, you can create new custom loggers that will be configured through the 
 
 ```diff
 // my-module/config/logging.js
-module.exports = {
+export default {
   // ... the rest of your logger configuration
 +  myLoggerName: [
 +    {

--- a/source/docs/advanced/production-ready/sitemap.md
+++ b/source/docs/advanced/production-ready/sitemap.md
@@ -46,7 +46,7 @@ However, if you need to setup your own routes, you will need to register your ow
 If the pages you are adding to your sitemap are static and exist regardless of the state of your shop, you can add them by creating `config/hardcodedSitemap.js` in your module.
 
 ```js
-module.exports = [
+export default [
   {
     path: "/",
     priority: 1,

--- a/source/docs/advanced/theme/analytics.md
+++ b/source/docs/advanced/theme/analytics.md
@@ -136,7 +136,7 @@ Moreover, we didn't talk about a `trackPage` method here. This is because a `Pag
 An integration will listen each `event` and `page` tracking in your application and will send it to your tracking service. To configure which tracking service your application will use, you need to edit the `config/analytics.js` file:
 
 ```js
-module.exports = {
+export default {
   analytics: {
     // Make sure that your analytics is enabled
     enable: true,

--- a/source/docs/reference/configurations.md
+++ b/source/docs/reference/configurations.md
@@ -77,7 +77,7 @@ This file should export an object where the keys are the store's code (see [Conf
 Configure a [Basic Authentication](https://en.wikipedia.org/wiki/Basic_access_authentication) on your server (usually for dev environments).
 
 ```js
-module.exports = {
+export default {
   // enable basic authentication
   enable: true,
   // allow these IPs to bypass the basic authentication
@@ -108,7 +108,7 @@ By default most proxies are setting either `x-real-ip` or `x-forwarded-for`. So 
 Allows to define static routes within your application that aren't already fetched dynamically from your backend. Each object should match the Sitemapable interface of `src/server/model/store/schema.gql`
 
 ```js
-module.exports = [
+export default [
   {
     path: "/",
     priority: 1,
@@ -125,7 +125,7 @@ Allows to define which kind of entities should be returned within the search bar
 Available values are : "products", "categories" and "pages".
 
 ```js
-module.exports = ["products", "categories", "pages"];
+export default ["products", "categories", "pages"];
 ```
 
 ### `config/caching.js`


### PR DESCRIPTION
I may be wrong as I did a search/replace on the whole doc by filtering some files where a `module.exports` is needed.