### PR TITLE
Country locales

### DIFF
--- a/source/docs/advanced/theme/translations.md
+++ b/source/docs/advanced/theme/translations.md
@@ -73,7 +73,7 @@ Please refer to [react-intl documentation](https://github.com/yahoo/react-intl/w
 
 Now that you have defined what should be translated in your application, you actually need to translate your application. This is a two-step process:
 
-1. Run the following script that will fetch all your translatable strings in your application and gather them in a JSON file located in `translations/[lang].json`
+1. Run the following script that will fetch all your translatable strings in your application and gather them in a JSON file located in `translations/[locale].json`
 ```sh
 npm run translate
 ```
@@ -81,25 +81,27 @@ npm run translate
 
 Note that for some translations you won't need to change anything. This usually happens for the default language and for business phrases such as "SKU", etc.
 
-However, `react-intl` will warn you against those cases because it might be an actual translation that is missing. Luckily, you can opt-out of this warning for specific translations ids by adding it to the `translations/whitelist_[lang].json` file.
+However, `react-intl` will warn you against those cases because it might be an actual translation that is missing. Luckily, you can opt-out of this warning for specific translations ids by adding it to the `translations/whitelist_[locale].json` file.
 
 This task can be daunting at first, but it will make your life easier in the future when you will need to know which string was not translated in a recent update.
 
 ### Translations fallback
 
-With `react-intl` translations are usually grouped into a single file. In our case, we would expect them to be in `translations/whitelist_[lang].json`. But in Front-Commerce's case, we don't want you to be troubled by translations that are handled by the core.
+With `react-intl` translations are usually grouped into a single file. In our case, we would expect them to be in `translations/[locale].json`. But in Front-Commerce's case, we don't want you to be troubled by translations that are handled by the core.
 
 That's why Front-Commerce uses a mechanism called **translations fallbacks**. Instead of relying on a single file for translations, Front-Commerce will look out for translations in the following locations and pick the ones that exist:
 
-* Front-Commerce core: `node_modules/front-commerce/translations/[lang].json`
-* from [your modules declared in `.front-commerce.js`](/docs/reference/front-commerce-js.html#modules): `<my-module>/translations/[lang].json`
-* from your project: `translations/[lang].json`
+* Front-Commerce core: `node_modules/front-commerce/translations/[short-locale].json` or `node_modules/front-commerce/translations/[locale].json`
+* from [your modules declared in `.front-commerce.js`](/docs/reference/front-commerce-js.html#modules): `<my-module>/translations/[short-locale].json` or `<my-module>/translations/[locale].json`
+* from your project: `translations/[short-locale].json` or `translations/[locale].json`
+
+`[short-locale]` here means that we are only taking the first particle of the `locale`. E.g. if the locale was `en-GB`, the short-locale would be `en`.
 
 If a translation key is defined in multiple files, the last one (according to the above list) will be be used. This is especially useful if you want to change the core's translations.
 
 > You can see exactly which translation files are used by opening the files located in `.front-commerce/translations/`.
 
-Please keep in mind that when you run `npm run translate`, new keys will be added to `translations/[lang].json`. However, if you are developing a module it can make sense to manually create the files in `<my-module>/translations/[lang].json` and relocate the translations there.
+Please keep in mind that when you run `npm run translate`, new keys will be added to `translations/[locale].json`. However, if you are developing a module it can make sense to add the translations to `<my-module>/translations/[locale].json`. You can do this by using `npm run translate -- -m <my-module>`.
 
 ## About dynamic content
 

--- a/source/docs/advanced/theme/translations.md
+++ b/source/docs/advanced/theme/translations.md
@@ -95,7 +95,7 @@ That's why Front-Commerce uses a mechanism called **translations fallbacks**. In
 * from [your modules declared in `.front-commerce.js`](/docs/reference/front-commerce-js.html#modules): `<my-module>/translations/[short-locale].json` or `<my-module>/translations/[locale].json`
 * from your project: `translations/[short-locale].json` or `translations/[locale].json`
 
-`[short-locale]` here means that we are only taking the first particle of the `locale`. E.g. if the locale was `en-GB`, the short-locale would be `en`.
+`[short-locale]` here means that we are only taking the first particle of the `locale`. E.g. if the locale was `en-GB`, the short-locale would be `en`. That's how `en-GB` would load translations from both `en.json` and `en-GB.json` files.
 
 If a translation key is defined in multiple files, the last one (according to the above list) will be be used. This is especially useful if you want to change the core's translations.
 

--- a/source/docs/appendices/migration-guides.md
+++ b/source/docs/appendices/migration-guides.md
@@ -19,6 +19,26 @@ While it was possible to fetch configurations from Magento2 by using the GraphQL
 
 Please refer to [Using Magento Configuration](/docs/magento2/using-magento-configuration.html) for further information.
 
+### Magento Admin Detection
+
+It is now possible to detect if the user connected on the shop is an admin that is connected in Magento. Only thing is you must setup the following environment variable: `FRONT_COMMERCE_MAGENTO_ADMIN_TOKEN`.
+
+Please refer to [Detect admin users](/docs/magento2/detect-admin-users.html) for more details.
+
+### Translation locales variants
+
+<blockquote>
+**Important:** Please remove your `.front-commerce/translations` folder after updating to 2.1.0. Otherwise your local build will fail.
+</blockquote>
+
+Previously, the translation mechanism only accepted a main language (`fr`, `en`, ...). It is now possible to set translation files using locales that includes the country (`fr-FR`, `en-US`, `en-GB`, ...).
+
+In new projects, new locales in the `config/stores.js` will automatically create `translations/<new-locale>.json` files so you don't have to worry about it.
+
+In existing projects that already have main language translation files (e.g. `translations/en.json`) new files won't be created automatically. This means that if you have a store using `en-US` and a store using `en-GB` while only having a `translations/en.json` file in your project, both stores will use `translations/en.json`. If you want to add specificities for each locale, please create manually the files with the correct filename (`translations/en-GB.json`, `translations/en-US.json`).
+
+Please note that if some translations are shared across `en-GB` and `en-US`, you can put them in a `translations/en.json`. It will still be used even if you have created `translations/en-GB.json` or `translations/en-US.json`.
+
 ## `2.0.0-rc.2` -> `2.0.0`
 
 Over the years, we've deprecated a lot of code and provided backwards-compatible adapters to cope with API changes in dependencies.


### PR DESCRIPTION
Some tiny changes to explicitly talk about the difference between `fr-FR.json` and `fr.json` in our translations mechanisms.