### PR TITLE
fix: use ids as unique identifier for determining prev/next pages

### DIFF
--- a/source/docs/advanced/checkout/overview.md
+++ b/source/docs/advanced/checkout/overview.md
@@ -1,5 +1,5 @@
 ---
-id: overview
+id: checkout-overview
 title: Overview
 ---
 

--- a/source/docs/advanced/graphql/overview.md
+++ b/source/docs/advanced/graphql/overview.md
@@ -1,5 +1,5 @@
 ---
-id: overview
+id: graphql-overview
 title: Overview
 ---
 

--- a/source/docs/advanced/payments/overview.md
+++ b/source/docs/advanced/payments/overview.md
@@ -1,6 +1,6 @@
 ---
-id: payments
-title: Payments overview
+id: payments-overview
+title: Overview
 ---
 
 There are many ways to integrate payments in Front-Commerce. We support different payment workflows, payment modules from different platforms (Magento2 …) and Front-Commerce can also process payments itself with Front-Commerce payment modules.

--- a/source/docs/advanced/performance/overview.md
+++ b/source/docs/advanced/performance/overview.md
@@ -1,5 +1,5 @@
 ---
-id: overview
+id: performance-overview
 title: Overview
 ---
 

--- a/source/docs/advanced/production-ready/overview.md
+++ b/source/docs/advanced/production-ready/overview.md
@@ -1,5 +1,5 @@
 ---
-id: overview
+id: production-ready-overview
 title: Overview
 ---
 

--- a/source/docs/advanced/server/overview.md
+++ b/source/docs/advanced/server/overview.md
@@ -1,5 +1,5 @@
 ---
-id: overview
+id: server-overview
 title: Overview
 ---
 

--- a/source/docs/advanced/theme/overview.md
+++ b/source/docs/advanced/theme/overview.md
@@ -1,5 +1,5 @@
 ---
-id: overview
+id: theme-overview
 title: Overview
 ---
 

--- a/source/docs/magento1/installation.md
+++ b/source/docs/magento1/installation.md
@@ -1,5 +1,5 @@
 ---
-id: installation
+id: magento1-installation
 title: Installation
 ---
 

--- a/source/docs/magento1/overview.md
+++ b/source/docs/magento1/overview.md
@@ -1,5 +1,5 @@
 ---
-id: overview
+id: magento1-overview
 title: Overview
 ---
 

--- a/source/docs/magento2/overview.md
+++ b/source/docs/magento2/overview.md
@@ -1,5 +1,5 @@
 ---
-id: overview
+id: magento2-overview
 title: Overview
 ---
 

--- a/theme/layout/page.ejs
+++ b/theme/layout/page.ejs
@@ -53,7 +53,7 @@
               var pages = _.map(pagePaths, function (val) { return site.pages.findOne({path: val + '.html'}); });
               var i = pages.length
               while (i--) {
-                if (pages[i] && pages[i].title === page.title) {
+                if (pages[i] && pages[i].id === page.id) {
                   break
                 }
               }


### PR DESCRIPTION
there was an issue where pages with the same title ("Overview") were
mixed up in the "algorithm", leading to incorrect next/prev pages

Thanks @astik for notifying us about this issue.

@JulienPradet: we'll have to pay attention to ids in the future, a convention could be to prefix them with their path. It seems to be better than using titles, because for consistency it could make sense to have several pages with the same one.

I'll merge right away but feel free to comment to keep the discussion going.