### PR TITLE
Search engine doc

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,6 +73,7 @@ sidebar_categories:
   Magento1:
     - docs/magento1/overview
     - docs/magento1/installation
+    - docs/magento1/search-engine
     - docs/magento1/add-custom-endpoint
     - docs/magento1/exposing-additional-attributes
     - docs/magento1/event-list

--- a/source/docs/appendices/migration-guides.md
+++ b/source/docs/appendices/migration-guides.md
@@ -68,7 +68,7 @@ you were using it in 2.4.x you now need to enable the module in your
 `.front-commerce.js`.
 
 <blockquote class="warning">
-Known issue: the Elasticsearch server module needs to be enabled **before** the Magento's module.
+⚠️ Known issue: the Elasticsearch server module needs to be enabled **before** the Magento's module.
 </blockquote>
 
 For a Magento2 based Front-Commerce setup:
@@ -103,10 +103,37 @@ For a Magento1 based Front-Commerce setup:
    ]
 ```
 
+#### Deprecated search related API
+
+Some modules and functions related to search have been deprecated.
+
 If in your custom code, you were importing files from
 `server/core/esDatasource`, Front-Commerce will issue some deprecation warnings.
 To fix those, you have to replace every occurence of `server/core/esDatasource/`
 by `datasource-elasticsearch/server/datasource/` while importing components.
+
+`makeSearchDatasource` available in `server/modules/magento2/core/factories` or
+`server/modules/magento1/core/factories` is deprecated. Instead, you can
+directly retrieve the registered datasource, for instance if you are working in
+a `contextEnhancer`:
+
+```diff
+-import { makeSearchDataSource } from "server/modules/magento2/core/factories";
+-
+-const esDatasource = makeSearchDataSource();
+-
+ export default {
+   namespace: "MyProject/Search",
+-  dependencies: ["Magento2/Catalog/Layers"],
++  dependencies: ["Front-Commerce/Search", "Magento2/Catalog/Layers"],
+   typeDefs,
+   contextEnhancer: ({ req, loaders }) => {
++    const esDatasource = loaders.Search.buildSearchDatasource();
+     // do stuff with esDatasource
+     // ...
+   }
+ };
+```
 
 ## `2.3.x` -> `2.4.0`
 

--- a/source/docs/magento1/search-engine.md
+++ b/source/docs/magento1/search-engine.md
@@ -1,0 +1,159 @@
+---
+id: search-engine
+title: Search engine
+---
+
+As of Front-Commerce 2.5.0, it is possible to use Elasticsearch or Algolia to
+bring a search engine to your website.
+
+## Elasticsearch
+
+### Requirements
+
+On Magento's side, you need to install [the
+`front-commerce-oss/magento1-elasticsuite-indexer`
+module](https://github.com/front-commerce/magento1-elasticsuite-indexer#magento-1-elasticsearch-indexer-).
+You can install it with composer:
+
+```
+composer require front-commerce-oss/magento1-elasticsuite-indexer
+```
+
+After the installation, you need to configure it, at least:
+
+1. in System > Catalog > Catalog in the _Catalog Search_ section, make sure the
+   search engine is set on _Smile Searchandising Suite_
+1. in the same section, set the server host and port
+1. take note of the alias (`magento` by default)
+
+You can then run the indexer so that the products, categories and cms pages are
+indexed in Elasticsearch.
+
+### Front-Commerce configuration
+
+First, you need to make sure the Elasticsearch search client is installed:
+
+```
+npm i @elastic/elasticsearch
+```
+
+On Front-Commerce side, you need to enable the Elasticsearch datasource by
+making the changes in your `.front-commerce.js` file similar to:
+
+```diff
+// .front-commerce.js
+-  modules: [],
++  modules: ["./node_modules/front-commerce/modules/datasource-elasticsearch"],
+   serverModules: [
+     { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
++    {
++      name: "Magento1Elasticsearch",
++      path: "datasource-elasticsearch/server/modules/magento1-elasticsearch",
++    },
+     { name: "Magento1", path: "server/modules/magento1" },
+   ]
+```
+
+<blockquote class="warning">
+⚠️ Known issue: the Elasticsearch server module needs to be enabled **before** the Magento's module.
+</blockquote>
+
+Then, in your `.env` file, you need to define [the `FRONT_COMMERCE_ES_HOST` and
+`FRONT_COMMERCE_ES_ALIAS` variables](/docs/reference/environment-variables.html#Elasticsearch).
+
+After restarting Front-Commerce, you should be able run a GraphQL query to
+search for products, for instance:
+
+```graphql
+query Search {
+  search(query: "whatever you want to search for") {
+    query
+    products(params: { from: 0, size: 5 }) {
+      total
+      products {
+        sku
+        name
+      }
+    }
+  }
+}
+```
+
+If you are using the default theme or the theme Chocolatine, the search bar
+should now be visible.
+
+## Algolia
+
+### Requirements
+
+On Magento's side, you need to install [the `algolia/algoliasearch-magento`
+module](https://github.com/algolia/algoliasearch-magento). You can install it
+with modman:
+
+```
+modman clone https://github.com/algolia/algoliasearch-magento.git
+```
+
+After the installation, you need to configure it, at least:
+
+1. in System > Algolia Search > Configuration in the _Credentials & Setup_
+   section, set the _Enable Indexing_ option
+1. in the same section, fill the credentials you can find on [the Algolia
+   Dashboard](https://www.algolia.com/dashboard/api-keys)
+1. take note of the index name prefix (`magento_` by default)
+
+You can then run the indexer so that the products are indexed in Algolia's
+index.
+
+### Front-Commerce configuration
+
+First, you need to make sure the Algolia's search client is installed:
+
+```
+npm i algoliasearch
+```
+
+On Front-Commerce side, you need to enable the Algolia datasource by
+making the changes in your `.front-commerce.js` file similar to:
+
+```diff
+// .front-commerce.js
+-  modules: [],
++  modules: ["./node_modules/front-commerce/modules/datasource-algolia"],
+   serverModules: [
+     { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
++    {
++      name: "Magento1Elasticsearch",
++      path: "datasource-algolia/server/modules/magento1-algolia",
++    },
+     { name: "Magento1", path: "server/modules/magento1" },
+   ]
+```
+
+<blockquote class="warning">
+⚠️ Known issue: the Algolia server module needs to be enabled **before** the Magento's module.
+</blockquote>
+
+Then, in your `.env` file, you need to define [all the Algolia related
+environment variables](/docs/reference/environment-variables.html#Algolia).
+
+After restarting Front-Commerce, you should be able run a GraphQL query to
+search for products, for instance:
+
+```graphql
+query Search {
+  search(query: "whatever you want to search for") {
+    query
+    products(params: { from: 0, size: 5 }) {
+      total
+      products {
+        sku
+        name
+      }
+    }
+  }
+}
+```
+
+If you are using the default theme or the theme Chocolatine, the search bar
+should now be visible.

--- a/source/docs/magento1/search-engine.md
+++ b/source/docs/magento1/search-engine.md
@@ -31,10 +31,10 @@ indexed in Elasticsearch.
 
 ### Front-Commerce configuration
 
-First, you need to make sure the Elasticsearch search client is installed:
+First, you need to make sure the Elasticsearch search client is installed with a version that matches your ElasticSearch server:
 
 ```
-npm i @elastic/elasticsearch
+npm i @elastic/elasticsearch@6
 ```
 
 On Front-Commerce side, you need to enable the Elasticsearch datasource by


### PR DESCRIPTION
* [Doc to install Elasticsearch or Algolia in Magento1](https://deploy-preview-161--heuristic-almeida-1a1f35.netlify.app/docs/magento1/search-engine.html)
* Improve a bit the 2.5 migration guide to help dealing with deprecated API
    (related to questions we had this morning) : https://deploy-preview-161--heuristic-almeida-1a1f35.netlify.app/docs/appendices/migration-guides.html#Elasticsearch-in-a-dedicated-module