### PR TITLE
Document the `--module` option for `front-commerce translate`

### DIFF
--- a/source/docs/reference/cli.md
+++ b/source/docs/reference/cli.md
@@ -95,6 +95,7 @@ If some translations are missing, the script will throw an error. This lets you 
 ### Options
 
 - `--ignore-build`: By default, this command will build your application to make sure that no translation is forgotten. However, if you've just run `front-commerce build`, this step is not necessary. `--ignore-build` option is what makes it possible not to build the application during the translation.
+- `--module` (`-m`): scope translations to a specific module registered in your `.front-commerce.js` configuration file. Translation files will be written in the `/path/to/module/translations` directory instead of your application's one.
 
 ## `front-commerce test`
 


### PR DESCRIPTION
It was documented in https://developers.front-commerce.com/docs/advanced/theme/translations.html#Translate-what%E2%80%99s-in-your-components but is better also in the reference