### PR TITLE
Fix link pointing to master branch

### DIFF
--- a/source/docs/advanced/graphql/dataloaders-and-cache-invalidation.md
+++ b/source/docs/advanced/graphql/dataloaders-and-cache-invalidation.md
@@ -239,7 +239,7 @@ return fooLoader.load(id).then(data => data.value)
 
 Writing batching functions and loaders could lead to reusing the same patterns. We have extracted some utility functions to help you in this task.
 
-One can find them in the [`server/core/graphql/dataloaderHelpers`](https://gitlab.com/front-commerce/front-commerce/blob/master/src/server/core/graphql/dataloaderHelpers.js) module.
+One can find them in the [`server/core/graphql/dataloaderHelpers`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/server/core/graphql/dataloaderHelpers.js) module.
 
 ### `reorderForIds`
 

--- a/source/docs/advanced/production-ready/checklist-before-production.md
+++ b/source/docs/advanced/production-ready/checklist-before-production.md
@@ -17,4 +17,4 @@ To ensure that you are good to go, you can go through this checklist :
 * [ ] Ensure your server can serve the application in **HTTPS** mode.
   Front-Commerce is aimed at being exposed in HTTPS when in production mode (`NODE_ENV === "production"`). It will redirect users to an HTTPS url if they try to access a page using HTTP. Cookies are also set with secure mode.
   If you want to overcome this limitation (which we don’t recommend!), you may use the [`FRONT_COMMERCE_UNSAFE_INSECURE_MODE` environment variable](/docs/reference/environment-variables.html#Host).
-* [ ] Ensure that the `robots.txt` has been overriden to allow bots. By default, [it forbids crawling to prevent unexpectedly exposing dev applications](https://gitlab.com/front-commerce/front-commerce/-/blob/master/public/robots.txt).
+* [ ] Ensure that the `robots.txt` has been overriden to allow bots. By default, [it forbids crawling to prevent unexpectedly exposing dev applications](https://gitlab.com/front-commerce/front-commerce/-/blob/main/public/robots.txt).

--- a/source/docs/advanced/theme/form.md
+++ b/source/docs/advanced/theme/form.md
@@ -213,7 +213,7 @@ You can configure these behaviors by passing options to `withFormHandlers(option
 
 With those configurations, this allows you to potentially transform the input's display into anything you seem fit. For instance, a DateInput could be created and transformed into either a datepicker or multiple input fields without impacting the external API.
 
-One could use the [`node_modules/front-commerce/src/web/theme/components/atoms/Form/Input/Checkbox/Checkbox.js`](https://gitlab.com/front-commerce/front-commerce/-/blob/master/src/web/theme/components/atoms/Form/Input/Checkbox/Checkbox.js) to better understand how it works.
+One could use the [`node_modules/front-commerce/src/web/theme/components/atoms/Form/Input/Checkbox/Checkbox.js`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/web/theme/components/atoms/Form/Input/Checkbox/Checkbox.js) to better understand how it works.
 
 ### Use another form library than Formsy
 

--- a/source/docs/advanced/theme/server-side-rendering.md
+++ b/source/docs/advanced/theme/server-side-rendering.md
@@ -109,7 +109,7 @@ This behavior is leveraging [Front-Commerce's configuration system](/docs/advanc
 }
 ```
 
-If you want to tweak this behavior, we invite you to browse the [`deviceConfigProvider`](https://gitlab.com/front-commerce/front-commerce/-/blob/master/src/server/express/ssr/deviceConfigProvider.js) for implementation details and [contact us](mailto:contact@front-commerce.com) if you think of improvements.
+If you want to tweak this behavior, we invite you to browse the [`deviceConfigProvider`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/server/express/ssr/deviceConfigProvider.js) for implementation details and [contact us](mailto:contact@front-commerce.com) if you think of improvements.
 
 ## SSR Fallback when things go wrong
 

--- a/source/docs/appendices/migration-guides.md
+++ b/source/docs/appendices/migration-guides.md
@@ -780,7 +780,7 @@ Here the list of the main updates you need to be concerned about:
   It should be compatible for the use cases in FC. If you use specific features, please check them and fix them.
   FormattedMessage no longer insert spans around your messages. This might lead to some styling issues. Add manually a `span` around your message if this is the case.
 - [react-paginate](https://github.com/AdeleD/react-paginate): `5.0.0` -> `6.3.0`
-  It should be compatible [unless you were using `breakLabel`](https://github.com/AdeleD/react-paginate/blob/master/HISTORY.md#-600).
+  It should be compatible [unless you were using `breakLabel`](https://github.com/AdeleD/react-paginate/blob/master/CHANGELOG.md#-600).
 - [react-responsive](https://github.com/contra/react-responsive): `3.0.0` -> `8.0.1`
   Should be compatible since we are using a facade in FC `theme/components/helpers/MediaQuery`. If you are using something else, please make sure your code still works.
 - [react-router](https://github.com/ReactTraining/react-router/): `4.3.1` -> `5.0.1`

--- a/source/docs/essentials/adapt-theme-to-your-brand.md
+++ b/source/docs/essentials/adapt-theme-to-your-brand.md
@@ -40,7 +40,7 @@ theme.
 
 Since we use the Atomic Design principles, the tokens are within atoms of
 our base theme. From your application, you will find the base theme in the
-[`node_modules/front-commerce/src/web/`](https://gitlab.com/front-commerce/front-commerce/tree/master/src/web) directory and atoms under its `theme/components/atoms` subdirectory.
+[`node_modules/front-commerce/src/web/`](https://gitlab.com/front-commerce/front-commerce/tree/main/src/web) directory and atoms under its `theme/components/atoms` subdirectory.
 
 In this guide,
 we'll focus on the colors and the typography settings. But feel free to go

--- a/source/docs/essentials/add-component-to-storybook.md
+++ b/source/docs/essentials/add-component-to-storybook.md
@@ -132,7 +132,7 @@ add a new type of button: `tertiary`.
 To add this story, you will need to override the `Button.story.js` in the same
 way you overrode the `Button.js`. This means that you should copy the existing
 story from
-[`node_modules/front-commerce/src/web/theme/components/atoms/Button/Button.story.js`](https://gitlab.com/front-commerce/front-commerce/blob/master/src/web/theme/components/atoms/Button/Button.story.js)
+[`node_modules/front-commerce/src/web/theme/components/atoms/Button/Button.story.js`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/theme/components/atoms/Button/Button.story.js)
 to `my-module/web/theme/components/atoms/Button/Button.story.js`.
 
 Once you have copied the file, you need to restart the Storybook with
@@ -162,16 +162,16 @@ issues and have created helpers that should make your life easier when
 documenting those complex components.
 
 These helpers are located in
-[`node_modules/front-commerce/src/web/storybook/addons`](https://gitlab.com/front-commerce/front-commerce/tree/master/src/web/storybook/addons) and you can import them by
+[`node_modules/front-commerce/src/web/storybook/addons`](https://gitlab.com/front-commerce/front-commerce/tree/main/src/web/storybook/addons) and you can import them by
 using the alias `web/storybook/addons/...`. For now, we have four of them:
 
-* [`web/storybook/addons/apollo/ApolloDecorator`](https://gitlab.com/front-commerce/front-commerce/blob/master/src/web/storybook/addons/apollo/ApolloDecorator.js): mocks the data fetched by your
+* [`web/storybook/addons/apollo/ApolloDecorator`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/storybook/addons/apollo/ApolloDecorator.js): mocks the data fetched by your
 components
-* [`web/storybook/addons/form/formDecorator`](https://gitlab.com/front-commerce/front-commerce/blob/master/src/web/storybook/addons/form/formDecorator.js): mocks a Form surounding the input
+* [`web/storybook/addons/form/formDecorator`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/storybook/addons/form/formDecorator.js): mocks a Form surounding the input
 component you are documenting
-* [`web/storybook/addons/intl/IntlDecorator`](https://gitlab.com/front-commerce/front-commerce/blob/master/src/web/storybook/addons/intl/IntlDecorator.js): allows you to switch between the
+* [`web/storybook/addons/intl/IntlDecorator`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/storybook/addons/intl/IntlDecorator.js): allows you to switch between the
 languages of your shop
-* [`web/storybook/addons/router/routerDecorator`](https://gitlab.com/front-commerce/front-commerce/blob/master/src/web/storybook/addons/router/routerDecorator.js): mocks the routing and the URLs of
+* [`web/storybook/addons/router/routerDecorator`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/storybook/addons/router/routerDecorator.js): mocks the routing and the URLs of
 your application
 
 <!-- TODO document usage of each of these helpers -->

--- a/source/docs/essentials/create-a-business-component.md
+++ b/source/docs/essentials/create-a-business-component.md
@@ -82,7 +82,7 @@ npm install react-leaflet leaflet
 Before starting to edit the Home page, you first need to extend the theme.
 If you don't have any module yet, please refer to
 [Extend the theme](./extend-the-theme.html#Configure-your-custom-theme-and-use-it-in-your-application).
-Once you have one, the goal will be to override the Home component from [`node_modules/front-commerce/src/web/theme/pages/Home/Home.js`](https://gitlab.com/front-commerce/front-commerce/blob/master/src/web/theme/pages/Home/Home.js)
+Once you have one, the goal will be to override the Home component from [`node_modules/front-commerce/src/web/theme/pages/Home/Home.js`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/theme/pages/Home/Home.js)
 to `my-module/web/theme/pages/Home/Home.js`.
 
 <blockquote class="warning">

--- a/source/docs/essentials/extend-the-theme.md
+++ b/source/docs/essentials/extend-the-theme.md
@@ -64,7 +64,7 @@ That’s it! You have successfully registered the module in your Front-Commerce 
 
 Let's add the description of a `Product` to a `ProductItem` as an example of overriding the base theme.
 
-The original file is: [`node_modules/front-commerce/src/web/theme/modules/ProductView/ProductItem/ProductItem.js`](https://gitlab.com/front-commerce/front-commerce/blob/master/src/web/theme/modules/ProductView/ProductItem/ProductItem.js)
+The original file is: [`node_modules/front-commerce/src/web/theme/modules/ProductView/ProductItem/ProductItem.js`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/theme/modules/ProductView/ProductItem/ProductItem.js)
 
 <blockquote class="info">
 Please refer to the [Front-Commerce’s folder structure documentation page](/docs/concepts/front-commerce-folder-structure.html) to get a better
@@ -78,7 +78,7 @@ understanding of how components are organized in the base theme.
 The `description` information is not included in the GraphQL fields fetched by the application in the base theme.
 You will thus need to update the fragment related to `ProductItem`.
 
-The original fragment file is collocated with the original component at: [`node_modules/front-commerce/src/web/theme/modules/ProductView/ProductItem/ProductItemFragment.gql`](https://gitlab.com/front-commerce/front-commerce/blob/master/src/web/theme/modules/ProductView/ProductItem/ProductItemFragment.gql)
+The original fragment file is collocated with the original component at: [`node_modules/front-commerce/src/web/theme/modules/ProductView/ProductItem/ProductItemFragment.gql`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/theme/modules/ProductView/ProductItem/ProductItemFragment.gql)
 
 1. copy it to: `my-module/web/theme/modules/ProductView/ProductItem/ProductItemFragment.gql`
 2. add the field `description` to the fragment.

--- a/source/docs/magento2/headless-payments.md
+++ b/source/docs/magento2/headless-payments.md
@@ -32,7 +32,7 @@ Our Magento2 integration currently provides native adapters for the platforms be
 
 We will explain the mechanisms available to implement your own adapter if supported Magento payment modules do not suit your needs.
 
-**Payment Adapters must implement the [`\FrontCommerce\Integration\Api\HeadlessPayment\Adapter`](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/master/app/code/FrontCommerce/Integration/Api/HeadlessPayment/Adapter.php) interface no matter the [workflows](/docs/advanced/payments/payment-workflows.html) they support.**
+**Payment Adapters must implement the [`\FrontCommerce\Integration\Api\HeadlessPayment\Adapter`](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/main/app/code/FrontCommerce/Integration/Api/HeadlessPayment/Adapter.php) interface no matter the [workflows](/docs/advanced/payments/payment-workflows.html) they support.**
 
 Front-Commerce module will simulate a Magento action as if the page was loaded in a frontend context. It will:
 
@@ -51,7 +51,7 @@ Adapters must implement methods that are called at key times in order to:
 **Payment flows:** [Redirect before order](/docs/advanced/payments/payment-workflows.html#Redirect-Before-Order)
 </blockquote>
 
-Converts an internal Magento response to a [`RedirectionInterface`](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/master/app/code/FrontCommerce/Integration/Api/Data/HeadlessPayment/RedirectionInterface.php) value object.
+Converts an internal Magento response to a [`RedirectionInterface`](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/main/app/code/FrontCommerce/Integration/Api/Data/HeadlessPayment/RedirectionInterface.php) value object.
 
 ```php
 public function redirectionFromCheckoutRedirectActionResponse(
@@ -66,7 +66,7 @@ public function redirectionFromCheckoutRedirectActionResponse(
 **Payment flows:** [Redirect after order](/docs/advanced/payments/payment-workflows.html#Redirect-After-Order)
 </blockquote>
 
-Converts an internal Magento response to a [`RedirectionInterface`](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/master/app/code/FrontCommerce/Integration/Api/Data/HeadlessPayment/RedirectionInterface.php) value object.
+Converts an internal Magento response to a [`RedirectionInterface`](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/main/app/code/FrontCommerce/Integration/Api/Data/HeadlessPayment/RedirectionInterface.php) value object.
 
 ```php
 public function redirectionFromCheckoutRedirectAfterActionResponse(
@@ -129,7 +129,7 @@ public function changeAfterCheckoutResponseFromResult(
 **Payment flows:** [Redirect before order](/docs/advanced/payments/payment-workflows.html#Redirect-Before-Order), [Redirect after order](/docs/advanced/payments/payment-workflows.html#Redirect-After-Order)
 </blockquote>
 
-This is a factory to build a [`ProxiedAction`](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/master/app/code/FrontCommerce/Integration/Api/HeadlessPayment/ProxiedAction.php) matching the next step for the Customer depending on information transmitted by the payment system in the return url the user was redirected to when coming back to the store
+This is a factory to build a [`ProxiedAction`](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/main/app/code/FrontCommerce/Integration/Api/HeadlessPayment/ProxiedAction.php) matching the next step for the Customer depending on information transmitted by the payment system in the return url the user was redirected to when coming back to the store
 
 ```php
 public function buildReturnFromPlatformProxiedAction(
@@ -145,7 +145,7 @@ Example: `throw new \RuntimeException('Checkout flow not supported');`
 
 ## Register the Payment Adapter
 
-Wether you've implemented a new Payment Adapter or are reusing an existing one, adapters have to be registered so Front-Commerce's module could instantiate it when relevant. Using the `di.xml`, inject the adapter in the [`FrontCommerce\Integration\Model\HeadlessPayments\AdapterFactory` `$adapters` constructor param](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/master/app/code/FrontCommerce/Integration/Model/HeadlessPayments/AdapterFactory.php#L12).
+Wether you've implemented a new Payment Adapter or are reusing an existing one, adapters have to be registered so Front-Commerce's module could instantiate it when relevant. Using the `di.xml`, inject the adapter in the [`FrontCommerce\Integration\Model\HeadlessPayments\AdapterFactory` `$adapters` constructor param](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/main/app/code/FrontCommerce/Integration/Model/HeadlessPayments/AdapterFactory.php#L12).
 
 Below is an example from Front-Commerce's core:
 
@@ -163,7 +163,7 @@ Below is an example from Front-Commerce's core:
 ```
 
 <blockquote class="note">
-We encourage you to investigate existing Adapters' source code from [Front-Commerce's core](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/tree/master/app/code/FrontCommerce/Integration/Model/HeadlessPayments/Adapter) to learn about advanced patterns.
+We encourage you to investigate existing Adapters' source code from [Front-Commerce's core](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/tree/main/app/code/FrontCommerce/Integration/Model/HeadlessPayments/Adapter) to learn about advanced patterns.
 </blockquote>
 
 ## Allow the Payment's URLs

--- a/source/docs/reference/cli.md
+++ b/source/docs/reference/cli.md
@@ -7,7 +7,7 @@ With Front-Commerce comes a CLI tool (`front-commerce`) that helps you launch th
 
 These commands should be launched from your project's root directory. This can be done by:
 
-- Using npm scripts (just like [front-commerce-skeleton/package.json](https://gitlab.com/front-commerce/front-commerce-skeleton/blob/master/package.json#L7))
+- Using npm scripts (just like [front-commerce-skeleton/package.json](https://gitlab.com/front-commerce/front-commerce-skeleton/blob/main/package.json#L7))
 - Prefixing the commands with `npx` which will call the `front-commerce` bin in your project
 
 ## `front-commerce help`


### PR DESCRIPTION
While checking some details in the documentation, I noticed a link still
referencing `master` while the branch has been renamed to `main`. So I fixed all
links still referencing `master` and while doing that I also found a broken link
to react-paginate history/changelog