### PR TITLE
Clarify version of dependencies for 2.6

### DIFF
--- a/source/docs/appendices/migration-guides.md
+++ b/source/docs/appendices/migration-guides.md
@@ -10,7 +10,7 @@ Our goal is to make migrations as smooth as possible. This is why we try to make
 ## `2.5.0` -> `2.6.0`
 ### Minimum Node.js version
 
-Node.js 10.x [reaches its end of life at the end of April 2021](https://nodejs.org/en/about/releases/). As a result, the required minimum Node.js version has been updated to the version **12.22.1**.
+Node.js 10.x [reaches its end of life at the end of April 2021](https://nodejs.org/en/about/releases/). As a result, the minimum supported Node.js version in Front-Commerce is **12.22.1**.
 
 We also recommend to use Node.js 14.x as this version is also supported and it is the current active Long Term Support Node.js release.
 

--- a/source/docs/appendices/release-notes.md
+++ b/source/docs/appendices/release-notes.md
@@ -15,6 +15,27 @@ Compatible with:
 - **Magento2**: 2.3.2 -> 2.4.1 (Open Source & Commerce)
 - **Magento1**: CE 1.7+, EE 1.12+, [OpenMageLTS](https://www.openmage.org/supported-versions.html) 19.4+
 
+## 2.6.0
+
+> Front-Commerce 2.6 embraces HTTP Caching to bring your storefront performance to a whole new level.
+>
+> Leverage proxy or CDN caching to get the performance of static websites with the flexibility you’d expect for a dynamic eCommerce storefront. We’re eager to see what you will do with this!
+>
+> We’ve also added new features (Store credits, wishlist improvements, remote configuration), updated our dependencies and fixed several issues.
+
+- [Announcement](https://developers.front-commerce.com/blog/2021/04/29/front-commerce-2.6/)
+- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.6.0)
+
+Requirements:
+- Magento2: 2.3.2+ -> 2.4.1 - requires [magento module version 2.2.0+](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/releases/2.2.0) - (Open Source & Commerce)
+- or Magento1: CE 1.7+, EE 1.12+, [OpenMageLTS](https://www.openmage.org/supported-versions.html) 19.4+
+- Reverse Proxy : Nginx 1.16 or more
+- NodeJS: 12.22+
+- Redis: 3.2+
+- ElasticSearch: 6.7+ and 7.x with the plugins:
+  - analysis-phonetic
+  - analysis-icu
+
 ## 2.5.1
 
 > This release contains a bugfix of guest orders not being tracked.


### PR DESCRIPTION
This PR rewords a sentence about the Node version bump (from user feedback) and adds the related "Release notes" section for 2.6.

BTW, Nginx supports Stale-While-Revalidate [since NGINX 1.11.10](https://www.nginx.com/blog/nginx-caching-guide/) so I've also updated the minimum Nginx documented version.
I used a ~2yo version that matches the Nginx plus LTS.