### PR TITLE
`root_categories_path` is now unused in Front-Commerce

### DIFF
--- a/source/docs/appendices/migration-guides.md
+++ b/source/docs/appendices/migration-guides.md
@@ -17,6 +17,12 @@ As of the 2.7 version, Front-Commerce fetches the attributes on which facets can
 1. if you need to have an attribute configured this way but still want to ignore it in the facets, you can add it to the `search.ignoredAttributeKeys` configuration
 1. you can remove attribute codes that are not "Used in Layered Navigation" from the `search.ignoredAttributeKeys` configuration. They were probably text fields added here to prevent incorrect Elasticsearch queries (`description`, `short_description`,…)
 
+### `root_categories_path` configuration removed
+
+The `root_categories_path` configuration key from `website.js` is not used anymore. **You can remove it from your codebase** after ensuring you didn't use it for application specific code.
+
+It was first introduced for the navigation menu in Magento GraphQL modules (then unused), but used for breadcrumbs. We've reworked how breadcrumbs are generated from the category "path" value returned by magento to make it useless. We now always remove the first two category levels of the path, no matter their values. It prevent userland errors due to a misconfiguration of their app.
+
 ## `2.5.0` -> `2.6.0`
 ### Minimum Node.js version
 

--- a/source/docs/reference/configurations.md
+++ b/source/docs/reference/configurations.md
@@ -29,7 +29,7 @@ _New in version `1.0.0-beta.3`:_ configurations are inherited across themes decl
 
 This configuration file should contain any thing that impacts the content of your website. The term website refers to what a [`website` is in Magento's ecosystem](https://devdocs.magento.com/guides/v2.3/config-guide/multi-site/ms_over.html).
 
-* `root_categories_path` (ex: `1/517/`): which category to use for the main navigation menu. It will then be the children of this category that will be displayed.
+* ~~`root_categories_path` (ex: `1/517/`): which category to use for the main navigation menu.~~ Removed in `2.7.0`.
 * `default_image_url` (ex: an absolute URL of an image): which image to use when no image path has been given to [`<ResizedImage>`](/docs/advanced/production-ready/media-middleware.html#lt-ResizedImage-gt-component)
 * `defaultTitle`: the default meta title of your application
 * `defaultDescription`: the default meta description of your application


### PR DESCRIPTION
This PR documents the change implemented in https://gitlab.com/front-commerce/front-commerce/-/merge_requests/506