### PR TITLE
Simplify and fix makeExecutor documentation

### DIFF
--- a/source/docs/reference/graphql-module-definition.md
+++ b/source/docs/reference/graphql-module-definition.md
@@ -280,7 +280,7 @@ The following example demonstrates how to add an `Authorization` header to your 
 ```js
 import makeExecutor from "server/core/graphql/makeExecutor";
 
-const authenticateRequest = () => (fetchOptions, { context }) => {
+const authenticateRequest = (fetchOptions, { context }) => {
   const req = (context && context.req) || {};
   const authService = makeAuthServiceFromRequest(req);
   if (!authService.isAuthenticated()) {
@@ -303,7 +303,7 @@ export default {
     uri: "https://remote-feature.acme.org/graphql",
     // […]
       executor: makeExecutor(uri, {
-        fetchOptionsAdapter: withMagentoAuthorizationHeaders(),
+        fetchOptionsAdapter: authenticateRequest,
       }),
   }
 };

--- a/source/docs/reference/remote-schema-helpers.md
+++ b/source/docs/reference/remote-schema-helpers.md
@@ -17,7 +17,7 @@ It will create an executor that will:
 
 The `makeExecutor` takes two parameters:
 
-* `uri` (`string | (fetchOptions, graphQLExecutionInfo) => string`): The URI where the Remote GraphQL schema lives. It can either be a string or a function if the URI can change based on the user's request (ex: language, store id, etc.) 
+* `uri` (`string | (graphQLExecutionInfo) => string`): The URI where the Remote GraphQL schema lives. It can either be a string or a function if the URI can change based on the user's request (ex: language, store id, etc.)
 * `options` (`object`): An optional object containing the following keys:
     * `fetcher` optional: The fetcher used to execute the request. By default it is `isomorphic-fetch`
     * `fetchOptionsAdapter` optional (`(fetchOptions) => fetchOptions`): transforms the options passed to the `fetcher` when executing the request


### PR DESCRIPTION
* Simplify the `makeExecutor` example (and make it uses a function that exists in the example)
* Fix the argument of `uri` function used by `makeExecutor`