### PR TITLE
Expose Prismic Content in the Graph

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -87,6 +87,7 @@ sidebar_categories:
   Prismic:
     - docs/prismic/index
     - docs/prismic/installation
+    - docs/prismic/expose-content
     - docs/prismic/routable-types
   Payments:
     - docs/advanced/payments/overview

--- a/source/docs/prismic/expose-content.md
+++ b/source/docs/prismic/expose-content.md
@@ -31,7 +31,7 @@ const homepage = await loaders.Prismic.loadSingle("homepage");
 console.log("Last update of my homepage", homepage.lastUpdate);
 ```
 
-For most Field Types, the field value can directly be used. However for some of them, the field value is not very handy to expose the data in the Graph or even requires a deep transformation. To make that operation easier, the Prismic loader also exposes some Field Transformers to transform field values. In the previous example, if the `lastUpdate` field is [a Date Field](https://prismic.io/docs/core-concepts/date), `homepage.lastUpdate` will be a string. If instead you want to have a JavaScript `Date` instance as the field value, you can configure `loadSingle` to transform it:
+For most Field Types, the field value can directly be used. However for some of them, the field value is not very handy to expose the data in the Graph or even requires a deep transformation. To make that operation easier, the Prismic loader also exposes some Field Transformers to transform field values. Instances of the transformers can be passed to `loadSingle`, `loadByUID` and `loadList` to transform the loaded Prismic Content. In the previous example, if the `lastUpdate` field is [a Date Field](https://prismic.io/docs/core-concepts/date), `homepage.lastUpdate` will be a string. If instead you want to have a JavaScript `Date` instance as the field value, you can configure `loadSingle` to transform it:
 
 ```js
 const { DateTransformer } = loaders.Prismic.transformers;

--- a/source/docs/prismic/expose-content.md
+++ b/source/docs/prismic/expose-content.md
@@ -67,7 +67,7 @@ export default {
 
 #### Define the schema
 
-Let's assume you have created a Single Custom Type _Homepage_ which identifier is `homepage`. This Custom Type has three fields:
+Let's assume you have created a Single Custom Type _Homepage_ whose identifier is `homepage`. This Custom Type has three fields:
 
 * `title` of type Title
 * `image` of type Image

--- a/source/docs/prismic/expose-content.md
+++ b/source/docs/prismic/expose-content.md
@@ -15,9 +15,9 @@ To benefit from this API, you first need to [install the Prismic module](/docs/p
 
 The Prismic loader has the following API to request Content from Prismic:
 
-* `loadSingle(typeIdentifier[, options])` returns [an object of type `Content`](https://gitlab.com/front-commerce/front-commerce-prismic/-/blob/0.5.0/prismic/server/modules/prismic/core/loaders/Content.js) or throws an error if no such Content exists.
+* `loadSingle(typeIdentifier[, options])` returns [an object of type `Content`](https://gitlab.com/front-commerce/front-commerce-prismic/-/blob/main/prismic/server/modules/prismic/core/loaders/Content.js) or throws an error if no such Content exists.
 * `loadByUID(typeIdentifier, uid[, options])` returns a `Content` representing a Prismic Content of [the corresponding type](https://prismic.io/docs/core-concepts/custom-types) and having [an UID field](https://prismic.io/docs/core-concepts/uid) with the given value. If such Content does not exist, it throws an error.
-* `loadList(query[, options])` returns [a `ContentList`](https://gitlab.com/front-commerce/front-commerce-prismic/-/blob/0.5.0/prismic/server/modules/prismic/core/loaders/ContentList.js) matching the query. `query` must be an instance of [`ListQuery`](https://gitlab.com/front-commerce/front-commerce-prismic/-/blob/0.5.0/prismic/server/modules/prismic/core/loaders/ListQuery.js), it provides a way to filter, sort and paginate Prismic Content.
+* `loadList(query[, options])` returns [a `ContentList`](https://gitlab.com/front-commerce/front-commerce-prismic/-/blob/main/prismic/server/modules/prismic/core/loaders/ContentList.js) matching the query. `query` must be an instance of [`ListQuery`](https://gitlab.com/front-commerce/front-commerce-prismic/-/blob/main/prismic/server/modules/prismic/core/loaders/ListQuery.js), it provides a way to filter, sort and paginate Prismic Content.
 
 ### Field Transformers
 
@@ -44,7 +44,7 @@ const homepage = await loaders.Prismic.loadSingle("homepage", {
 console.log("Last update of my homepage", homepage.lastUpdate);
 ```
 
-The complete list of available Transformers can be found under [the `transformers` directory in Prismic module](https://gitlab.com/front-commerce/front-commerce-prismic/-/tree/0.5.0/prismic/server/modules/prismic/core/loaders/transformers). We will use some of them in the following examples.
+The complete list of available Transformers can be found under [the `transformers` directory in Prismic module](https://gitlab.com/front-commerce/front-commerce-prismic/-/tree/main/prismic/server/modules/prismic/core/loaders/transformers). We will use some of them in the following examples.
 
 ## Implementation examples
 

--- a/source/docs/prismic/expose-content.md
+++ b/source/docs/prismic/expose-content.md
@@ -115,6 +115,7 @@ In this example, without a dedicated resolver, the `image` field of the `Homepag
 
 ```diff
 type Homepage {
+  title: String
   image: String
 + thumbnail: String
   text: DefaultWysiwyg
@@ -156,6 +157,7 @@ In addition, each view carries some metadata like the alternative text or the im
 
 ```diff
 type Homepage {
+  title: String
   image: String
 + imageAlt: String
   thumbnail: String

--- a/source/docs/prismic/expose-content.md
+++ b/source/docs/prismic/expose-content.md
@@ -109,6 +109,68 @@ export default {
 };
 ```
 
+#### Title field handling
+
+In this example, the title is exposed as a plain string in the graph. However, the `TitleTransformer` also generates an HTML representation of the field. So if you need to retrieve the HTML code instead, you can define a custom resolver on the `title` field of the `Homepage` type:
+
+```diff
+export default {
+  Query: {
+    homepage: async (root, args, { loaders }) => {
+      const { TitleTransformer, RichtextToWysiwygTransformer, ImageTransformer } = loaders.Prismic.transformers;
+      const homepage = await loaders.Prismic.loadSingle("homepage", {
+        fieldTransformers: {
+          title: new TitleTransformer(),
+          image: new ImageTransformer(),
+          text: new RichtextToWysiwygTransformer(loaders.Wysiwyg),
+        },
+      });
+      return homepage;
+    },
+  },
++ Homepage: {
++   title: (homepageContent) => homepageContent.title.html;
++ }
+};
+```
+
+In addition, Title and Rich Text fields are very similar; a Title field can be seen as a restricted Rich Text field. As a result, the Transformers dedicated to Rich Text fields can also be used on Title fields. So if you want to expose the title as a `DefaultWysiwyg`, you can do the following changes, in the `schema.gql`:
+
+```diff
+type Homepage {
+- title: String
++ title: DefaultWysiwyg
+  image: String
+  text: DefaultWysiwyg
+}
+
+extend type Query {
+  homepage: Homepage
+}
+```
+
+and in the resolver:
+
+```diff
+export default {
+  Query: {
+    homepage: async (root, args, { loaders }) => {
+-     const { TitleTransformer, RichtextToWysiwygTransformer, ImageTransformer } = loaders.Prismic.transformers;
++     const { RichtextToWysiwygTransformer, ImageTransformer } = loaders.Prismic.transformers;
+      const homepage = await loaders.Prismic.loadSingle("homepage", {
+        fieldTransformers: {
+-         title: new TitleTransformer(),
++         title: new RichtextToWysiwygTransformer(loaders.Wysiwyg),
+          image: new ImageTransformer(),
+          text: new RichtextToWysiwygTransformer(loaders.Wysiwyg),
+        },
+      });
+      return homepage;
+    },
+  },
+};
+```
+
 ### Expose a list of FAQs
 
 #### Define the schema

--- a/source/docs/prismic/expose-content.md
+++ b/source/docs/prismic/expose-content.md
@@ -7,7 +7,7 @@ The Prismic Front-Commerce module provides a loader and the infrastructure to ex
 
 ## Prerequisites
 
-To benefit from this API, you first need to [install the Prismic module](/docs/prismic/installation.html). You will also need [a custom GraphQL module](/docs/essentials/extend-the-graphql-schema.html) to define a custom GraphQL schema matching the content you want to expose and implement the corresponding resolver. It also recommended to have read [the Prismic Core Concepts documentation](https://prismic.io/docs/core-concepts).
+To benefit from this API, you first need to [install the Prismic module](/docs/prismic/installation.html). You will also need [a custom GraphQL module](/docs/essentials/extend-the-graphql-schema.html) to define a GraphQL schema matching the content you want to expose and implement the corresponding resolver. It also recommended to have read [the Prismic Core Concepts documentation](https://prismic.io/docs/core-concepts).
 
 ## Prismic loader API
 
@@ -31,7 +31,7 @@ const homepage = await loaders.Prismic.loadSingle("homepage");
 console.log("Last update of my homepage", homepage.lastUpdate);
 ```
 
-For most Field Types, the field value can directly be used. However for some of them, the field value is not very handy to expose those field in the Graph or even requires a deep transformation. To make that operation easier, the Prismic loader also exposes some Field Transformers to transform field values. In the previous example, if the `lastUpdate` field is [a Date Field](https://prismic.io/docs/core-concepts/date), `homepage.lastUpdate` will be a string. If instead you want to have a JavaScript `Date` instance as the field value, you can configure `loadSingle` to transform it:
+For most Field Types, the field value can directly be used. However for some of them, the field value is not very handy to expose the data in the Graph or even requires a deep transformation. To make that operation easier, the Prismic loader also exposes some Field Transformers to transform field values. In the previous example, if the `lastUpdate` field is [a Date Field](https://prismic.io/docs/core-concepts/date), `homepage.lastUpdate` will be a string. If instead you want to have a JavaScript `Date` instance as the field value, you can configure `loadSingle` to transform it:
 
 ```js
 const { DateTransformer } = loaders.Prismic.transformers;
@@ -111,7 +111,7 @@ export default {
 
 #### Image field handling
 
-In this example, without a dedicated resolver, the `image` field of the `Homepage` type is the path to the image of [the `main` view](https://prismic.io/docs/technologies/templating-image-field-javascript#get-an-image-view). In Prismic, while configuring an Image field in the Custom Type editor, it is possible to define several views to get the same image under a different format. Those views can also be exposed in the Graph. For instance, if you have defined a `thumbnail` view, it can be exposed in the graph by applying the following changes, in `schema.gql`:
+In this example, without a dedicated resolver, the `image` field of the `Homepage` type is the path to the image of [the `main` view](https://prismic.io/docs/technologies/templating-image-field-javascript#get-an-image-view). In Prismic, while configuring an Image field in the Custom Type editor, it is possible to define several views to get the same image under a different format. Those views can also be exposed in the Graph. For instance, if you have defined a `thumbnail` view, it can be exposed in the graph by applying the following changes. In `schema.gql`:
 
 ```diff
 type Homepage {
@@ -125,7 +125,7 @@ extend type Query {
 }
 ```
 
-and in the resolver:
+And in the resolver:
 
 ```diff
 export default {
@@ -152,7 +152,7 @@ export default {
 
 > The `ImageTransformer` also rewrites the image path provided by the Prismic API to use a custom image proxy defined by the module. This path rewrite makes those image path directly usable by [Front-Commerce's `<Image />` component](https://developers.front-commerce.com/docs/advanced/production-ready/media-middleware.html#lt-Image-gt-component).
 
-In addition, each view carries some metadata like the alternative text or the image dimensions. The following changes allow to expose the alternative text:
+In addition, each view carries some metadata like the alternative text or the image dimensions. The following changes allow to expose the alternative text of both the `tumbnail` and the `main` views:
 
 ```diff
 type Homepage {
@@ -168,7 +168,7 @@ extend type Query {
 }
 ```
 
-in the resolver:
+In the resolver:
 
 ```diff
 export default {
@@ -224,7 +224,7 @@ export default {
 };
 ```
 
-In addition, Title and Rich Text fields are very similar; a Title field can be seen as a restricted Rich Text field. As a result, the Transformers dedicated to Rich Text fields can also be used on Title fields. So if you want to expose the title as a `DefaultWysiwyg`, you can do the following changes, in the `schema.gql`:
+In addition, Title and Rich Text fields are very similar; a Title field can be seen as a restricted Rich Text field. As a result, the Transformers dedicated to Rich Text fields can also be used on Title fields. So if you want to expose the title as a `DefaultWysiwyg`, you can do the following changes instead. In the `schema.gql`:
 
 ```diff
 type Homepage {
@@ -239,7 +239,7 @@ extend type Query {
 }
 ```
 
-and in the resolver:
+And in the resolver:
 
 ```diff
 export default {
@@ -271,7 +271,7 @@ Let's assume you have created a Custom Type _FAQ_ which identifier is `faq`. Thi
 * `answer` of type Rich Text
 * `link` of type Link
 
-Like in the previous example, we can model the corresponding GraphQL type after the Custom Type and in this case we add a root query to retrieve a list of FAQ with a basic pagination and search capability:
+Like in the previous example, we can model the corresponding GraphQL type after the Custom Type and in this case we add a root query to retrieve a list of FAQ with a basic pagination and search capabilities:
 
 ```graphql
 type Faq {

--- a/source/docs/prismic/expose-content.md
+++ b/source/docs/prismic/expose-content.md
@@ -1,0 +1,170 @@
+---
+id: expose-content
+title: Expose Prismic Content
+---
+
+The Prismic Front-Commerce module provides a loader and the infrastructure to expose Prismic based Content in Front-Commerce's GraphQL API.
+
+## Prerequisites
+
+To benefit from this API, you first need to [install the Prismic module](/docs/prismic/installation.html). You will also need [a custom GraphQL module](/docs/essentials/extend-the-graphql-schema.html) to define a custom GraphQL schema matching the content you want to expose and implement the corresponding resolver. It also recommended to have read [the Prismic Core Concepts documentation](https://prismic.io/docs/core-concepts).
+
+## Prismic loader API
+
+### Methods to query content
+
+The Prismic loader has the following API to request Content from Prismic:
+
+* `loadSingle(typeIdentifier[, options])` returns [an object of type `Content`](https://gitlab.com/front-commerce/front-commerce-prismic/-/blob/0.5.0/prismic/server/modules/prismic/core/loaders/Content.js) or throws an error if no such Content exists.
+* `loadByUID(typeIdentifier, uid[, options])` returns a `Content` representing a Prismic Content of [the corresponding type](https://prismic.io/docs/core-concepts/custom-types) and having [an UID field](https://prismic.io/docs/core-concepts/uid) with the given value. If such Content does not exist, it throws an error.
+* `loadList(query[, options])` returns [a `ContentList`](https://gitlab.com/front-commerce/front-commerce-prismic/-/blob/0.5.0/prismic/server/modules/prismic/core/loaders/ContentList.js) matching the query. `query` must be an instance of [`ListQuery`](https://gitlab.com/front-commerce/front-commerce-prismic/-/blob/0.5.0/prismic/server/modules/prismic/core/loaders/ListQuery.js), it provides a way to filter, sort and paginate Prismic Content.
+
+### Field Transformers
+
+By default, the `Content` objects returned by those methods directly expose the fields defined in the corresponding Prismic Custom Type. For instance if you are retrieving a Content of type `homepage` and [this Custom Type is single](https://prismic.io/docs/core-concepts/custom-types#difference-between-single-and-repeatable) and defines a `lastUpdate` field, you can write something like:
+
+```js
+const homepage = await loaders.Prismic.loadSingle("homepage");
+// homepage is an instance of Content
+// the lastUpdate field can be used directly,
+// it's value is the field value returned by the Prismic API
+console.log("Last update of my homepage", homepage.lastUpdate);
+```
+
+For most Field Types, the field value can directly be used. However for some of them, the field value is not very handy to expose those field in the Graph or even requires a deep transformation. To make that operation easier, the Prismic loader also exposes some Field Transformers to transform field values. In the previous example, if the `lastUpdate` field is [a Date Field](https://prismic.io/docs/core-concepts/date), `homepage.lastUpdate` will be a string. If instead you want to have a JavaScript `Date` instance as the field value, you can configure `loadSingle` to transform it:
+
+```js
+const { DateTransformer } = loaders.Prismic.transformers;
+const homepage = await loaders.Prismic.loadSingle("homepage", {
+  fieldTransformers: {
+    lastUpdate: new DateTransformer(),
+  }
+});
+// homepage.lastUpdate is now a Date object
+console.log("Last update of my homepage", homepage.lastUpdate);
+```
+
+The complete list of available Transformers can be found under [the `transformers` directory in Prismic module](https://gitlab.com/front-commerce/front-commerce-prismic/-/tree/0.5.0/prismic/server/modules/prismic/core/loaders/transformers). We will use some of them in the following examples.
+
+## Implementation examples
+
+Those examples assume that you have created [a GraphQL module](https://developers.front-commerce.com/docs/essentials/extend-the-graphql-schema.html#Create-a-new-GraphQL-module) and that it is already registered. Before being able to use the Prismic module API, you have to make sure `Prismic/Core` is a dependency of your module. In addition, we will use the Wysiwyg feature provided by `Front-Commerce/Wysiwyg`, so this one also needs to be in the dependencies:
+
+```diff
+import typeDefs from "./schema.gql";
+import resolvers from "./resolvers";
+
+export default {
+  namespace: "MyModule",
+-  dependencies: [],
++  dependencies: ["Prismic/Core", "Front-Commerce/Wysiwyg"],
+  typeDefs,
+  resolvers,
+}
+```
+
+### Expose a Homepage in the Graph
+
+#### Define the schema
+
+Let's assume you have created a Single Custom Type _Homepage_ which identifier is `homepage`. This Custom Type has three fields:
+
+* `title` of type Title
+* `image` of type Image
+* `text` of type Rich Text
+
+While not mandatory, the best way to expose the Homepage in the Graph is to model the GraphQL type after the Custom Type. So in `schema.gql`, you can add:
+
+```graphql
+type Homepage {
+  title: String
+  image: String
+  text: DefaultWysiwyg
+}
+
+extend type Query {
+  homepage: Homepage
+}
+```
+
+#### Implement the resolver
+
+Once you have defined the type in the Graph, you need to implement the corresponding resolver in `resolvers.js` to retrieve the homepage Content from Prismic:
+
+```js
+export default {
+  Query: {
+    homepage: async (root, args, { loaders }) => {
+      const { TitleTransformer, RichtextToWysiwygTransformer, ImageTransformer } = loaders.Prismic.transformers;
+      const homepage = await loaders.Prismic.loadSingle("homepage", {
+        fieldTransformers: {
+          title: new TitleTransformer(),
+          image: new ImageTransformer(),
+          text: new RichtextToWysiwygTransformer(loaders.Wysiwyg),
+        },
+      });
+      return homepage;
+    },
+  },
+};
+```
+
+### Expose a list of FAQs
+
+#### Define the schema
+
+Let's assume you have created a Custom Type _FAQ_ which identifier is `faq`. This Custom Type has two fields:
+
+* `question` of type Key Text
+* `answer` of type Rich Text
+
+Like in the previous example, we can model the corresponding GraphQL type after the Custom Type and in this case we add a root query to retrieve a list of FAQ with a basic pagination and search capability:
+
+```graphql
+type Faq {
+  question: String
+  answer: DefaultWysiwyg
+}
+
+input FaqQueryInput {
+  page: Int
+  search: String
+}
+
+extend type Query {
+  faqList(params: FaqQueryInput): [Faq]
+}
+```
+
+#### Implement the resolver
+
+Again, we have to implement the corresponding resolver by using `loadList` and `ListQuery` described above:
+
+```js
+const pageSize = 10;
+
+export default {
+  Query: {
+    faqList: (root, { params }, { loaders }) => {
+      const { search, page } = params;
+      const { DateTransformer, RichtextToWysiwygTransformer } = loaders.Prismic.transformers;
+      const ListQuery = loaders.Prismic.queries.ListQuery;
+      const query = new ListQuery(pageSize, page ? page : 1);
+
+      query.type("faq").sortBy("document.last_publication_date", "asc");
+      if (search) {
+        query.search(search);
+      }
+
+      const faqList loaders.Prismic.loadList(query, {
+        fieldTransformers: {
+          // no transformer needed for `question` field as it's a key text field
+          answer: new RichtextToWysiwygTransformer(loaders.Wysiwyg),
+        },
+      });
+
+      return faqList.list;
+    },
+  },
+};
+```

--- a/source/docs/prismic/index.md
+++ b/source/docs/prismic/index.md
@@ -3,8 +3,10 @@ id: prismic-overview
 title: Overview
 ---
 
-The Front-Commerce Prismic module brings support for the headless CMS [Prismic](https://prismic.io/) to Front-Commerce. For now, it allows to replace Magento2's CMS pages and blocks system with content coming from a Prismic repository.
+The Front-Commerce Prismic module brings support for the headless CMS [Prismic](https://prismic.io/) to Front-Commerce. Out of the box, it replaces Magento's CMS pages and blocks system with content coming from a Prismic repository. In addition, it provides an API and the infrastructure to expose Prismic based Content in Front-Commerce.
 
 - [Installation](/docs/prismic/installation.html)
+- [Expose Prismic content](/docs/prismic/expose-content.html)
+- [Prismic Routable Types](/docs/prismic/routable-types.html)
 
 If you need more detailed information, please [contact us](mailto:contact@front-commerce.com). We will make sure to answer you in a timely manner.

--- a/source/docs/prismic/installation.md
+++ b/source/docs/prismic/installation.md
@@ -29,6 +29,10 @@ FRONT_COMMERCE_PRISMIC_WEBHOOK_SECRET=a-secret-defined-in-webhook-configuration
 * `FRONT_COMMERCE_PRISMIC_ACCESS_TOKEN` is the access token for the repository, go to _Settings > API & Security_ and create an application and copy the _Permanent access token_ generated for this application
 * `FRONT_COMMERCE_PRISMIC_WEBHOOK_SECRET` is a secret key used to clear caches in Front-Commerce. To define it, go to _Settings > Webhook_ and create a webhook pointing to your Front-Commerce URL `https://my-shop.example.com/prismic/webhook`. In the webhook form, you can configure a _Secret_. This is the one you should use in this environment variable.
 
+<blockquote class="tip">
+In case of trouble, `front-commerce:prismic` can be added to the `DEBUG` environment variable value, this value turns the debug on for Prismic module and make it verbose.
+</blockquote>
+
 <blockquote class="note">
 Configuring a webhook is required so that Front-Commerce fetches the last version of the Prismic content. In a development environment, you might skip this step but in that case, you will have to restart Front-Commerce after each publish operation in Prismic.
 </blockquote>

--- a/source/docs/prismic/routable-types.md
+++ b/source/docs/prismic/routable-types.md
@@ -100,7 +100,7 @@ export default {
 };
 ```
 
-Note the `postTransformer` above is optional. It is a function that will be called after the transformation is done using `contentTransformOptions`. It is given the current URL being resolved and the transformed document. It can be used if you have some custom logic to apply to the document or if you want to prevent the document from showing using some custom logic (returning a _falsy_ value).
+Note the `postTransformer` above is optional. It is a function that will be called after [the transformation is done using `contentTransformOptions`](/docs/prismic/expose-content.html#Field-Transformers). It is given the current URL being resolved and the transformed document. It can be used if you have some custom logic to apply to the document or if you want to prevent the document from showing using some custom logic (returning a _falsy_ value).
 
 ## Map GraphQL type to a component
 

--- a/source/docs/reference/environment-variables.md
+++ b/source/docs/reference/environment-variables.md
@@ -223,6 +223,7 @@ Here is a list of available debug namespaces:
 - `front-commerce:remote-schemas`: debugs [remote schema stitching](/docs/advanced/graphql/remote-schemas.html) related internals
 - `front-commerce:httpauth`: debugs how [basic authorization](/docs/reference/configurations.html#config-httpAuth-js) is enabled
 - `front-commerce:webpack`: enables `webpack-bundle-analyzer` on webpack client's bundle
+- `front-commerce:prismic`: turns [the Prismic module](/docs/prismic/) debug on
 
 **Note:** one can run the `rg -iF '"front-commerce:'` to find these values.
 


### PR DESCRIPTION
* [x] Base API documentation
* [x] Title vs. RichText vs. Key text
* [x] Image field features
* [x] Link field
* [x] Link in Wysiwyg
* [x] debug flag

Main page: https://deploy-preview-209--heuristic-almeida-1a1f35.netlify.app/docs/prismic/expose-content.html