### PR TITLE
Include the `enhancedEcommerce` GA option in the default example

### DIFF
--- a/source/docs/advanced/theme/analytics.md
+++ b/source/docs/advanced/theme/analytics.md
@@ -214,6 +214,7 @@ Here is a list of integrations frequently used accross eCommerce shops:
           "Google Analytics": {
             trackingId: "UA-123-1",
             anonymizeIp: !authorization,
+            // enhancedEcommerce: true, // uncomment to enable enhanced ecommerce additional trackings
           },
         };
       },


### PR DESCRIPTION
We've detected during support that the `enhancedEcommerce` option was not mentioned for Google Analytics, making it difficult to discover.

This PR might help with discoverability.