### PR TITLE
Update documentation to stay in sync with removed Prismic features

### DIFF
--- a/source/docs/appendices/migration-guides.md
+++ b/source/docs/appendices/migration-guides.md
@@ -34,6 +34,13 @@ So if you have overridden those files, you have to apply [the same update than t
 
 We highly recommend you to test your product and cart pages for products with custom options of both "fixed price" and "percentage" types if your project makes use of this Magento feature.
 
+### Prismic legacy features removed
+
+In order to make code more maintainable, we've removed two legacy features from the Prismic module:
+- Default CMS module
+- Default GraphQL remote schema stitching
+
+It is very unlikely that you were using these features but if you did, please read [the related Merge Request](https://gitlab.com/front-commerce/front-commerce-prismic/-/merge_requests/43) for replacement options.
 
 ### New features in `2.9.0`
 

--- a/source/docs/prismic/index.md
+++ b/source/docs/prismic/index.md
@@ -3,7 +3,7 @@ id: prismic-overview
 title: Overview
 ---
 
-The Front-Commerce Prismic module brings support for the headless CMS [Prismic](https://prismic.io/) to Front-Commerce. For now, it allows to replace Magento2's CMS pages and blocks system with content coming from a Prismic repository.
+The Front-Commerce Prismic module brings support for the headless CMS [Prismic](https://prismic.io/) to Front-Commerce. It allows to expose content coming from a Prismic repository in your GraphQL API and create relationships with data from other systems.
 
 - [Installation](/docs/prismic/installation.html)
 - [Expose Prismic content](/docs/prismic/expose-content.html)

--- a/source/docs/prismic/installation.md
+++ b/source/docs/prismic/installation.md
@@ -41,10 +41,6 @@ Configuring a webhook is required so that Front-Commerce fetches the last versio
 
 For that, you have to apply some changes to your `.front-commerce.js`.
 
-### Magento2
-
-In a Magento2 based setup:
-
 ```diff
  modules: [
    "./node_modules/front-commerce/modules/datasource-elasticsearch",
@@ -63,130 +59,10 @@ In a Magento2 based setup:
    { name: "FrontCommerce", path: "front-commerce/src/web" },
 ```
 
-### Magento1
+The module is ready!
 
-In a Magento1 based setup:
+**You can now use the `Prismic` loader to [Expose Prismic Content in your project](/docs/prismic/expose-content.html).**
 
-```diff
- modules: [
-   "./node_modules/front-commerce/modules/datasource-elasticsearch",
-   "./node_modules/front-commerce/theme-chocolatine",
-+  "./node_modules/front-commerce-prismic/prismic",
-   "./src",
- ],
- serverModules: [
-@@ -13,6 +14,7 @@ module.exports = {
-     path: "datasource-elasticsearch/server/modules/magento2-elasticsearch",
-   },
-   { name: "Magento2", path: "server/modules/magento2" },
-+  { name: "Prismic", path: "prismic/server/modules/prismic/index.magento1.js" },
- ],
- webModules: [
-   { name: "FrontCommerce", path: "front-commerce/src/web" },
-```
+## Optional: update your CSP
 
-## Configure required types in your Prismic repository
-
-The Front-Commerce Prismic module needs 2 custom types to be created, one for the pages and one the blocks.
-
-### CMS Page
-
-On `http://your-repository.prismic.io/masks/`, click on _Create new_ and create a _Repeatable Type_ named `CMS Page` which _API ID_ is `cms-page`, then in the _JSON editor_ tab in the right pane, paste the following code:
-
-```json
-{
-  "Main" : {
-    "uid" : {
-      "type" : "UID",
-      "config" : {
-        "label" : "UID",
-        "placeholder" : "URL used by FC to access the CMS content"
-      }
-    },
-    "meta_title" : {
-      "type" : "Text",
-      "config" : {
-        "label" : "Meta title",
-        "placeholder" : "Meta title for SEO purposes"
-      }
-    },
-    "meta_description" : {
-      "type" : "Text",
-      "config" : {
-        "label" : "Meta description",
-        "placeholder" : "Meta description for SEO purposes"
-      }
-    },
-    "title" : {
-      "type" : "Text",
-      "config" : {
-        "label" : "Title",
-        "placeholder" : "title"
-      }
-    },
-    "content_heading" : {
-      "type" : "StructuredText",
-      "config" : {
-        "single" : "heading1",
-        "label" : "Content heading",
-        "placeholder" : "Title of the page"
-      }
-    },
-    "content" : {
-      "type" : "StructuredText",
-      "config" : {
-        "multi" : "paragraph, preformatted, heading1, heading2, heading3, heading4, heading5, heading6, strong, em, hyperlink, image, embed, list-item, o-list-item, o-list-item",
-        "label" : "Content",
-        "placeholder" : "Content of the page"
-      }
-    }
-  }
-}
-```
-
-And finally, save the type.
-
-### CMS Block
-
-On `http://your-repository.prismic.io/masks/`, click on _Create new_ and create a _Repeatable Type_ named `CMS Block`which _API ID_ is `cms-block`, then in the _JSON editor_ tab in the right pane, paste the following code:
-
-```json
-{
-  "Main": {
-    "uid": {
-      "type": "UID",
-      "config": {
-        "label": "UID",
-        "placeholder": "URL used by FC to access the CMS content"
-      }
-    },
-    "title": {
-      "type": "Text",
-      "config": {
-        "label": "Title",
-        "placeholder": "Title of the page"
-      }
-    },
-    "content": {
-      "type": "StructuredText",
-      "config": {
-        "multi": "paragraph, preformatted, heading1, heading2, heading3, heading4, heading5, heading6, strong, em, hyperlink, image, embed, list-item, o-list-item, o-list-item",
-        "label": "Content",
-        "placeholder": "Content of the page"
-      }
-    }
-  }
-}
-```
-
-And finally, save the type.
-
-## Test it
-
-You can now (re)start Front-Commerce to take your configuration changes into account.
-
-To test it, on Prismic side, you can now create a new `CMS Page` content. When creating the page, take note of the `UID` you set, it will be used as the page identifier so the page will be accessible in Front-Commerce at the URL `http://your-fc-url/the-uid-you-defined`.
-
-<blockquote class="tip">
-If you include images in your content, don't forget to add the domain `images.prismic.io` to `imgSrc` in [the `contentSecurityPolicy` configuration](/docs/reference/configurations.html#config-website-js).
-</blockquote>
+If you plan to directly include images in your content, don't forget to add the domain `images.prismic.io` to `imgSrc` in [the `contentSecurityPolicy` configuration](/docs/reference/configurations.html#config-website-js).


### PR DESCRIPTION
This PR updates the documentation according to Prismic features removed in https://gitlab.com/front-commerce/front-commerce-prismic/-/merge_requests/43

- installation instruction updated
- entry in the migration guide