### PR TITLE
Document Prismic API caching new feature

### DIFF
--- a/source/docs/appendices/migration-guides.md
+++ b/source/docs/appendices/migration-guides.md
@@ -47,6 +47,7 @@ It is very unlikely that you were using these features but if you did, please re
 These new features may be relevant for your existing application:
 
 - For custom options, the Graph now exposes an `extraCost` field where you can find the rate to apply or the prices including and excluding taxes of each option and value.
+- Prismic API is now cached using the `PrismicAPI` dataloader. Ensure your `caching.js` config supports this key if you want to benefit from it. A specific `front-commerce:prismic:cache` debug flag allows you to view usage information.
 
 ## `2.7.0` -> `2.8.0`
 

--- a/source/docs/appendices/migration-guides.md
+++ b/source/docs/appendices/migration-guides.md
@@ -47,7 +47,7 @@ It is very unlikely that you were using these features but if you did, please re
 These new features may be relevant for your existing application:
 
 - For custom options, the Graph now exposes an `extraCost` field where you can find the rate to apply or the prices including and excluding taxes of each option and value.
-- Prismic API is now cached using the `PrismicAPI` dataloader. Ensure your `caching.js` config supports this key if you want to benefit from it. A specific `front-commerce:prismic:cache` debug flag allows you to view usage information.
+- Prismic API calls are now cached using the `PrismicAPI` dataloader. Ensure your `caching.js` config supports this key if you want to benefit from it. A specific `front-commerce:prismic:cache` debug flag allows you to view usage information.
 
 ## `2.7.0` -> `2.8.0`
 

--- a/source/docs/prismic/installation.md
+++ b/source/docs/prismic/installation.md
@@ -30,7 +30,7 @@ FRONT_COMMERCE_PRISMIC_WEBHOOK_SECRET=a-secret-defined-in-webhook-configuration
 * `FRONT_COMMERCE_PRISMIC_WEBHOOK_SECRET` is a secret key used to clear caches in Front-Commerce and to secure [Integration Fields API endpoints](/docs/prismic/integration-fields.html). To define it, go to _Settings > Webhook_ and create a webhook pointing to your Front-Commerce URL `https://my-shop.example.com/prismic/webhook`. In the webhook form, you can configure a _Secret_. This is the one you should use in this environment variable.
 
 <blockquote class="tip">
-In case of trouble, `front-commerce:prismic` can be added to the `DEBUG` environment variable value, this value turns the debug on for Prismic module and make it verbose.
+In case of trouble, `front-commerce:prismic` (or `front-commerce:prismic*` to include more specific namespaces) can be added to the `DEBUG` environment variable value, this value turns the debug on for Prismic module and make it verbose.
 </blockquote>
 
 <blockquote class="note">

--- a/source/docs/reference/environment-variables.md
+++ b/source/docs/reference/environment-variables.md
@@ -221,12 +221,13 @@ Here is a list of available debug namespaces:
 - `front-commerce:payment:adyen`: debugs advanced Adyen information (several information are also logged in `server.log` no matter this flag)
 - `front-commerce:payment:buybox`:  debugs HTTP interactions with BuyBox API (several information are also logged in `server.log` no matter this flag)
 - `front-commerce:performance`: allow to debug server performance in production by enabling [server timings](/docs/advanced/performance/server-timings.html)
+- `front-commerce:prismic`: turns [the Prismic module](/docs/prismic/) debug on
+- `front-commerce:prismic:cache`: debugs the Prismic caching layer specifically. Can be targetted directly, or included with the previous namespace using `DEBUG=front-commerce:prismic*`
 - `front-commerce:scripts`: debugs all scripts and tooling related commands (webpack…)
 - `front-commerce:scripts:routes`: debugs routing generation during the `prepare` command
 - `front-commerce:smart-forms:capency`: debugs full requests, responses and errors related to Capency's webservice
 - `front-commerce:remote-schemas`: debugs [remote schema stitching](/docs/advanced/graphql/remote-schemas.html) related internals
 - `front-commerce:webpack`: enables `webpack-bundle-analyzer` on webpack client's bundle
-- `front-commerce:prismic`: turns [the Prismic module](/docs/prismic/) debug on
 
 **Note:** one can run the `rg -iF '"front-commerce:'` to find these values.
 


### PR DESCRIPTION
This PR documents the new data loader and debug namespace added in https://gitlab.com/front-commerce/front-commerce-prismic/-/merge_requests/44