### PR TITLE
Document automatic Prismic version update

### DIFF
--- a/source/docs/appendices/migration-guides.md
+++ b/source/docs/appendices/migration-guides.md
@@ -47,7 +47,7 @@ It is very unlikely that you were using these features but if you did, please re
 These new features may be relevant for your existing application:
 
 - For custom options, the Graph now exposes an `extraCost` field where you can find the rate to apply or the prices including and excluding taxes of each option and value.
-- Prismic API calls are now cached using the `PrismicAPI` dataloader. Ensure your `caching.js` config supports this key if you want to benefit from it. A specific `front-commerce:prismic:cache` debug flag allows you to view usage information.
+- Prismic API calls are now cached using the `PrismicAPI` dataloader. Ensure your `caching.js` config supports this key if you want to benefit from it. A specific `front-commerce:prismic:cache` debug flag allows you to view usage information. The new`FRONT_COMMERCE_PRISMIC_API_CACHE_TTL_IN_SECONDS` environment variable allows to change [the default TTL configuration](/docs/prismic/installation.html#Configure-the-environment-for-Prismic).
 
 ## `2.7.0` -> `2.8.0`
 

--- a/source/docs/prismic/installation.md
+++ b/source/docs/prismic/installation.md
@@ -22,12 +22,14 @@ FRONT_COMMERCE_PRISMIC_URL=https://your-repository.prismic.io
 FRONT_COMMERCE_PRISMIC_LOCALE=en-us
 FRONT_COMMERCE_PRISMIC_ACCESS_TOKEN=the-very-long-access-token-from-prismic
 FRONT_COMMERCE_PRISMIC_WEBHOOK_SECRET=a-secret-defined-in-webhook-configuration
+#FRONT_COMMERCE_PRISMIC_API_CACHE_TTL_IN_SECONDS=60
 ```
 
 * `FRONT_COMMERCE_PRISMIC_URL` is the URL of your Prismic repository
 * `FRONT_COMMERCE_PRISMIC_LOCALE`: your Prismic repository's locale (available at `https://your-repository.prismic.io/settings/multi-languages/`)
 * `FRONT_COMMERCE_PRISMIC_ACCESS_TOKEN` is the access token for the repository, go to _Settings > API & Security_ and create an application and copy the _Permanent access token_ generated for this application
-* `FRONT_COMMERCE_PRISMIC_WEBHOOK_SECRET` is a secret key used to clear caches in Front-Commerce and to secure [Integration Fields API endpoints](/docs/prismic/integration-fields.html). To define it, go to _Settings > Webhook_ and create a webhook pointing to your Front-Commerce URL `https://my-shop.example.com/prismic/webhook`. In the webhook form, you can configure a _Secret_. This is the one you should use in this environment variable. In a development environment, you can skip this step and [simulate the webhook locally when needed](#Simulate-the-webhook-in-a-development-environment).
+* `FRONT_COMMERCE_PRISMIC_WEBHOOK_SECRET` is a secret key used to clear caches in Front-Commerce and to secure [Integration Fields API endpoints](/docs/prismic/integration-fields.html). To define it, go to _Settings > Webhook_ and create a webhook pointing to your Front-Commerce URL `https://my-shop.example.com/prismic/webhook`. In the webhook form, you can configure a _Secret_. This is the one you should use in this environment variable.
+* `FRONT_COMMERCE_PRISMIC_API_CACHE_TTL_IN_SECONDS` is an optional configuration that allows to customize the TTL of Prismic API cache. Shortening it allows to prioritize data freshness in environments not targeted by a Prismic webhook over performance. **It defaults to 23h in production environments and 1min in staging and dev environments.**
 
 <blockquote class="tip">
 In case of trouble, `front-commerce:prismic` (or `front-commerce:prismic*` to include more specific namespaces) can be added to the `DEBUG` environment variable value, this value turns the debug on for Prismic module and make it verbose.
@@ -35,7 +37,9 @@ In case of trouble, `front-commerce:prismic` (or `front-commerce:prismic*` to in
 
 ### Simulate the webhook in a development environment
 
-Configuring a webhook is required so that Front-Commerce fetches the last version of the Prismic content. In a development environment, you might skip this step. To make sure your currently running Front-Commerce instance uses the lastest version of the Prismic content without restarting it, you can simulate the webhook by issuing a `POST` request to `http://dev-fc-url/prismic/webhook` with the HTTP client of your choice. The body of this request must be a JSON object similar to `{"secret": "the value of FRONT_COMMERCE_PRISMIC_WEBHOOK_SECRET", "type": "api-update", "masterRef": true}`.
+Configuring a webhook is required so that Front-Commerce fetches the last version of the Prismic content. In a development environment, you might skip this step. Data will get refreshed regularly depending on your `FRONT_COMMERCE_PRISMIC_API_CACHE_TTL_IN_SECONDS` configuration. In some situations, you may want to simulate Prismic webhooks to ensure your data uses the latest Prismic version without restarting the application.
+
+You can simulate the webhook by issuing a `POST` request to `http://dev-fc-url/prismic/webhook` with the HTTP client of your choice. The body of this request must be a JSON object similar to `{"secret": "the value of FRONT_COMMERCE_PRISMIC_WEBHOOK_SECRET", "type": "api-update", "masterRef": true}`.
 
 For instance, you can use the following curl command:
 


### PR DESCRIPTION
This PR updates the documentation to explain a bit how Prismic version gets refreshed.

Since https://gitlab.com/front-commerce/front-commerce-prismic/-/merge_requests/46 it should be more convenient.

The PR documents the `FRONT_COMMERCE_PRISMIC_API_CACHE_TTL_IN_SECONDS` environment variable so integrators can customize the behavior to their context.