### PR TITLE
Removed mentions to a legacy Prismic locale config

### DIFF
--- a/source/docs/prismic/installation.md
+++ b/source/docs/prismic/installation.md
@@ -19,14 +19,12 @@ In the `.env` file, you have to define the following environment variables:
 
 ```sh
 FRONT_COMMERCE_PRISMIC_URL=https://your-repository.prismic.io
-FRONT_COMMERCE_PRISMIC_LOCALE=en-us
 FRONT_COMMERCE_PRISMIC_ACCESS_TOKEN=the-very-long-access-token-from-prismic
 FRONT_COMMERCE_PRISMIC_WEBHOOK_SECRET=a-secret-defined-in-webhook-configuration
 #FRONT_COMMERCE_PRISMIC_API_CACHE_TTL_IN_SECONDS=60
 ```
 
 * `FRONT_COMMERCE_PRISMIC_URL` is the URL of your Prismic repository
-* `FRONT_COMMERCE_PRISMIC_LOCALE`: your Prismic repository's locale (available at `https://your-repository.prismic.io/settings/multi-languages/`)
 * `FRONT_COMMERCE_PRISMIC_ACCESS_TOKEN` is the access token for the repository, go to _Settings > API & Security_ and create an application and copy the _Permanent access token_ generated for this application
 * `FRONT_COMMERCE_PRISMIC_WEBHOOK_SECRET` is a secret key used to clear caches in Front-Commerce and to secure [Integration Fields API endpoints](/docs/prismic/integration-fields.html). To define it, go to _Settings > Webhook_ and create a webhook pointing to your Front-Commerce URL `https://my-shop.example.com/prismic/webhook`. In the webhook form, you can configure a _Secret_. This is the one you should use in this environment variable.
 * `FRONT_COMMERCE_PRISMIC_API_CACHE_TTL_IN_SECONDS` is an optional configuration that allows to customize the TTL of Prismic API cache. Shortening it allows to prioritize data freshness in environments not targeted by a Prismic webhook over performance. **It defaults to 23h in production environments and 1min in staging and dev environments.**


### PR DESCRIPTION
that has now been replaced with the shop locale automatically

See https://gitlab.com/front-commerce/front-commerce-prismic/-/merge_requests/47 for the related MR.