### PR TITLE
fix: styleguide url

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -14,7 +14,7 @@ layout: index
     <li class="show-mobile"><a class="link button"  href="/license.html">License</a></li>
     <li><a class="link button"  href="/blog">Changelog</a></li>
     <li><a class="link button"  href="https://demo.front-commerce.app/">Demo store</a></li>
-    <li><a class="link button"  href="https://demo.front-commerce.app/styleguide">Styleguide</a></li>
+    <li><a class="link button"  href="https://front-commerce.app/styleguide">Styleguide</a></li>
     <li><a class="link button"  href="https://twitter.com/Front_Commerce?ref_src=twsrc%5Etfw">@Front_Commerce</a></li>
   </ul>
 </section>


### PR DESCRIPTION
The current url `demo.front-commerce.app/styleguide` directs to the demo list page. 

I set the styleguide url to the base `front-commerce.app` so if we update the default demo, in our current case `magento2.front-commerce.app` we will see the latest styleguides.
![image](https://user-images.githubusercontent.com/39598117/146170836-f7f691b7-8d84-4fc0-99c8-9b23dde2facb.png)


