### PR TITLE
chore(essentials): Fixed out-of-date icon names that weren't exported by FC anymore

### DIFF
--- a/source/docs/essentials/add-component-to-storybook.md
+++ b/source/docs/essentials/add-component-to-storybook.md
@@ -60,7 +60,7 @@ import { H3 } from "theme/ui/atoms/Typography/Heading";
 storiesOf("components.molecules.IllustratedContent", module)
   .add("default", () => {
     return (
-      <IllustratedContent media={<Icon icon="truck" />}>
+      <IllustratedContent media={<Icon icon="calendar-full" />}>
         <H3>Shipping within 48h</H3>
       </IllustratedContent>
     );
@@ -98,14 +98,14 @@ import { H3 } from "theme/ui/atoms/Typography/Heading";
 
 storiesOf("components.molecules.IllustratedContent", module)
   .add("default", () => {
-    <IllustratedContent media={<Icon icon="truck" />}>
+    <IllustratedContent media={<Icon icon="calendar-full" />}>
       <H3>Shipping within 48h</H3>
     </IllustratedContent>
 - });
 +  })
 +  .add("with long content", () => {
 +    return (
-+      <IllustratedContent media={<Icon icon="truck" />}>
++      <IllustratedContent media={<Icon icon="calendar-full" />}>
 +        <H3>Shipping within 48h</H3>
 +        <Paragraph>
 +          We are using many delivery services to let you choose what is best for

--- a/source/docs/essentials/create-a-ui-component.md
+++ b/source/docs/essentials/create-a-ui-component.md
@@ -250,19 +250,20 @@ import { storiesOf } from "@storybook/react";
 import Icon from "theme/components/atoms/Icon";
 import { H3 } from "theme/components/atoms/Typography/Heading";
 import { BodyParagraph } from "theme/components/atoms/Typography/Body";
+import Image from "theme/components/atoms/Image";
 
 
 storiesOf("molecules.IllustratedContent", module)
   .add("default", () => {
     return (
-      <IllustratedContent media={<Icon icon="truck" />}>
+      <IllustratedContent media={<Icon icon="calendar-full" />}>
         <H3>Shipping within 48h</H3>
       </IllustratedContent>
     );
   })
   .add("with a lot of content", () => {
     return (
-      <IllustratedContent media={<Icon icon="truck" />}>
+      <IllustratedContent media={<Icon icon="calendar-full" />}>
         <H3>Shipping within 48h</H3>
         <BodyParagraph>
           We are using many delivery services to let you choose what is best for
@@ -311,7 +312,7 @@ import { H3 } from "theme/components/atoms/Typography/Heading";
 
 const ReinsuranceBanner = () => (
   <InlineCards>
-    <IllustratedContent media={<Icon icon="truck" />}>
+    <IllustratedContent media={<Icon icon="calendar-full" />}>
       <H3>Shipping within 48h</H3>
     </IllustratedContent>
     <IllustratedContent media={<Icon icon="thumbsup" />}>


### PR DESCRIPTION
Also added missing `Image` import in one of the example stories.

I picked `"calendar-full"` as a `"truck"` replacement for "48h shipping", as I have the feeling that was the most fitting icon among the currently exported icon list, but please do correct me if there's a better one.