### PR TITLE
Configure intercom to monitor the `.intercom-launcher` custom launcher

### DIFF
--- a/source/404.md
+++ b/source/404.md
@@ -8,6 +8,6 @@ title: Page not found
 This page cannot be found.
 If you were looking for something specific, use the search to find its new location.
 
-Please [send us an email](mailto:contact@front-commerce.com) if you do not know where to find an information and we’ll do our best to find a solution in a timely manner!
+Please <span class="intercom-launcher">[get in touch](mailto:support@front-commerce.com)</span> if you do not know where to find an information and we’ll do our best to find a solution in a timely manner!
 
 ![Error 404](/images/undraw_404.svg)

--- a/source/docs/advanced/checkout/add-custom-checkout-step.md
+++ b/source/docs/advanced/checkout/add-custom-checkout-step.md
@@ -35,7 +35,7 @@ Thus, if we want to add our own step, we need to duplicate the `stepsDefinitions
 In order to illustrate this concept, we will add a new step which will enable the user to leave a comment with their command.
 
 <blockquote class="wip">
-**Work In Progress:** we didn't add the example yet. If you need it right away, please [contact us](mailto:contact@front-commerce.com). We will make sure to answer you in a timely manner.
+**Work In Progress:** we didn't add the example yet. If you need it right away, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span>. We will make sure to answer you in a timely manner.
 </blockquote>
 
 ## Changing the whole checkout system

--- a/source/docs/advanced/checkout/overview.md
+++ b/source/docs/advanced/checkout/overview.md
@@ -18,4 +18,4 @@ We are currently writing documentation about:
     * Payzen
     * Magento2 supported payment methods
 
-If you need more detailed information, please [contact us](mailto:contact@front-commerce.com). We will make sure to answer you in a timely manner.
+If you need more detailed information, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span>. We will make sure to answer you in a timely manner.

--- a/source/docs/advanced/features/overview.md
+++ b/source/docs/advanced/features/overview.md
@@ -14,4 +14,4 @@ Front-Commerce has several extension points that allow to override default imple
 * [Quick order](./quickorder.html)
 * [Password fields](./password-fields.html)
 
-If you need more detailed information, please [contact us](mailto:contact@front-commerce.com). We will make sure to answer you in a timely manner.
+If you need more detailed information, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span>. We will make sure to answer you in a timely manner.

--- a/source/docs/advanced/graphql/dataloaders-and-cache-invalidation.md
+++ b/source/docs/advanced/graphql/dataloaders-and-cache-invalidation.md
@@ -339,7 +339,7 @@ const loader = makeDataLoader("CatalogCategory")(ids =>
 
 By default, all dataLoaders are using a **per-request in-memory caching strategy**. It means that during the same GraphQL query, the same data will only be requested once.
 
-Front-Commerce is also shipped with a persistent cache implementation, using a Redis strategy (see [Caching strategies](#Caching-strategies)). You can implement new strategies to support more services (we also can help and support more strategies, please [contact us](mailto:contact@front-commerce.com)).
+Front-Commerce is also shipped with a persistent cache implementation, using a Redis strategy (see [Caching strategies](#Caching-strategies)). You can implement new strategies to support more services (we also can help and support more strategies, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span>).
 
 The DataLoader cache must be configured in the [`config/caching.js` configuration file](/docs/reference/configurations.html#config-caching-js). Please refer to the reference documentation for further details or read the following section to choose the most relevant strategies for your context.
 
@@ -487,7 +487,7 @@ export default {
 
 ### Advanced usage
 
-If you need additional implementations or want to leverage strategies for a specific use case, please [contact us](mailto:contact@front-commerce.com) so we can discuss it and guide you!
+If you need additional implementations or want to leverage strategies for a specific use case, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span> so we can discuss it and guide you!
 
 ## Invalidating the cache
 

--- a/source/docs/advanced/graphql/remote-schemas.md
+++ b/source/docs/advanced/graphql/remote-schemas.md
@@ -218,6 +218,6 @@ See [#196](https://gitlab.com/front-commerce/front-commerce/issues/196) for more
 ---
 
 <blockquote class="wip">
-  This remote schema stitching feature is still being explored, and we are actively looking for feedback to make it better.
-  Please [get in touch](mailto:contact@front-commerce.com) if you want to share your thoughts with us or ask any question!
+  This remote schema stitching feature is still being explored, and we are looking for feedback to make it better.
+  Please <span class="intercom-launcher">[get in touch](mailto:support@front-commerce.com)</span> if you want to share your thoughts with us or ask any question!
 </blockquote>

--- a/source/docs/advanced/graphql/slim-down-resolvers-with-loaders.md
+++ b/source/docs/advanced/graphql/slim-down-resolvers-with-loaders.md
@@ -293,7 +293,7 @@ see how you could combine them to achieve your goals.
 
 <blockquote class="wip">
   The content below is currently being written. If you need more detailed
-  information, please [contact us](mailto:contact@front-commerce.com). We will
+  information, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span>. We will
   make sure to answer you in a timely manner.
 
 <ul>

--- a/source/docs/advanced/payments/adyen.md
+++ b/source/docs/advanced/payments/adyen.md
@@ -12,7 +12,7 @@ This page contains information about the different ways you can accept payments 
 </blockquote>
 
 <blockquote class="note">
-**Note** This integration is aimed at being transparent for administrators and developers. That is why we haven't duplicated documentation from existing Magento resources. Please [contact us](mailto:contact@front-commerce.com) if you need further assistance.
+**Note** This integration is aimed at being transparent for administrators and developers. That is why we haven't duplicated documentation from existing Magento resources. Please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span> if you need further assistance.
 </blockquote>
 
 Front-Commerce is compatible with [Adyen's official Magento headless integration](https://docs.adyen.com/plugins/magento-2/magento-headless-integration) in its native version.

--- a/source/docs/advanced/payments/affirm.md
+++ b/source/docs/advanced/payments/affirm.md
@@ -12,7 +12,7 @@ This page contains information about the different ways you can accept payments 
 </blockquote>
 
 <blockquote class="note">
-**Note** This integration is aimed at being transparent for administrators and developers. That is why we haven't duplicated documentation from existing Magento resources. Please [contact us](mailto:contact@front-commerce.com) if you need further assistance.
+**Note** This integration is aimed at being transparent for administrators and developers. That is why we haven't duplicated documentation from existing Magento resources. Please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span> if you need further assistance.
 </blockquote>
 
 Front-Commerce for Magento2 contains a `FrontCommerce_HeadlessAffirm` module that turns the [Affirm's official Magento extension](https://github.com/Affirm/Magento2_Affirm) into a headless payment method for Front-Commerce. It is aimed at being transparent for Magento administrators and developers while allowing for a better Customer experience in a Front-Commerce application.

--- a/source/docs/advanced/payments/front-commerce-payments.md
+++ b/source/docs/advanced/payments/front-commerce-payments.md
@@ -10,6 +10,7 @@ Payment platforms integrated as a Front-Commerce Payment are compatible with eve
 ## Supported Payment platforms
 
 Front-Commerce Payments are currently available for the platforms below, learn how to install each one of them from the related documentation page:
+
 - [Stripe](/docs/advanced/payments/stripe.html#Front-Commerce-Payment)
 - [Paypal](/docs/advanced/payments/paypal.html#Front-Commerce-Payment)
 - [PayZen](/docs/advanced/payments/payzen.html#Front-Commerce-Payment)
@@ -17,7 +18,7 @@ Front-Commerce Payments are currently available for the platforms below, learn h
 - [BuyBox](/docs/advanced/payments/buybox.html#Front-Commerce-Payment)
 
 <blockquote class="info">
-  If you want to use a Payment platform not yet listed above, please [`contact us`](mailto:contact@front-commerce.com) so we can provide information about a potential upcoming native support for it.
+  If you want to use a Payment platform not yet listed above, please <span class="intercom-launcher">[`contact us`](mailto:hello@front-commerce.com)</span> so we can provide information about a potential upcoming native support for it.
 </blockquote>
 
 ## How is a Front-Commerce Payment method integrated with eCommerce platforms

--- a/source/docs/advanced/payments/ingenico.md
+++ b/source/docs/advanced/payments/ingenico.md
@@ -73,7 +73,7 @@ To allow loading Ogone related remote resources:
 ## Magento2 module
 
 <blockquote class="wip">
-**Work In Progress** This integration is aimed at being transparent for administrators and developers. That is why we haven't duplicated documentation from existing Magento resources. Please [contact us](mailto:contact@front-commerce.com) if you need further assistance.
+  This integration is aimed at being transparent for administrators and developers. That is why we haven't duplicated documentation from existing Magento resources. Please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span> if you need further assistance.
 </blockquote>
 
 Front-Commerce Magento2 module contains [headless payment adapters](/docs/magento2/headless-payments.html) for the [Ingenico ePayments **OpsCCRedirect** method](https://epayments.developer-ingenico.com/documentation/ecommerce-extensions/) (Ingenicos's official Magento module).

--- a/source/docs/advanced/payments/overview.md
+++ b/source/docs/advanced/payments/overview.md
@@ -21,7 +21,8 @@ In this section, you will learn how payments can be added to an application. It 
 - [Payment on account (B2B)](/docs/advanced/payments/payment-on-account.html)
 
 If you are looking for details about a specific eCommerce platform, please visit their dedicated page:
+
 - [Magento2 headless payments](/docs/magento2/headless-payments.html)
 - [Magento1 headless payments](/docs/magento1/headless-payments.html)
 
-Payments are a sensitive part of any eCommerce store. Our team is dedicated to make projects a success and we recommend you to [get in touch with us](mailto:contact@front-commerce.com) so we can provide recommendations about payment integration. **We are always looking to support more payment methods.**
+Payments are a sensitive part of any eCommerce store. Our team is dedicated to make projects a success and we recommend you to <span class="intercom-launcher">[get in touch with us](mailto:hello@front-commerce.com)</span> so we can provide recommendations about payment integration. **We are always looking to support more payment methods.**

--- a/source/docs/advanced/payments/payline.md
+++ b/source/docs/advanced/payments/payline.md
@@ -12,7 +12,7 @@ This page contains information about the different ways you can accept payments 
 </blockquote>
 
 <blockquote class="note">
-**Note** This integration is aimed at being transparent for administrators and developers. That is why we haven't duplicated documentation from existing Magento resources. Please [contact us](mailto:contact@front-commerce.com) if you need further assistance.
+**Note** This integration is aimed at being transparent for administrators and developers. That is why we haven't duplicated documentation from existing Magento resources. Please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span> if you need further assistance.
 </blockquote>
 
 Front-Commerce for Magento 1 requires a [`FrontCommerce_Payline` module](https://github.com/front-commerce/magento1-module-payline-front-commerce) that turns the [Monext Payline official Magento 1 extension](https://docs.monext.fr/display/DT/Plugin+Magento+1) into a headless payment method for Front-Commerce. It is aimed at being transparent for Magento administrators and developers while allowing for a better Customer experience in a Front-Commerce application.

--- a/source/docs/advanced/payments/paypal.md
+++ b/source/docs/advanced/payments/paypal.md
@@ -101,7 +101,7 @@ const ComponentMap = {
 ### Advanced: customize data sent to Paypal
 
 <blockquote class="wip">
-**Work In Progress** This advanced pattern must be documented with further details. While we are working on it, please [contact us](mailto:contact@front-commerce.com) if you need further assistance.
+**Documentation In Progress** This advanced pattern must be documented with further details. While we are working on it, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span> if you need further assistance.
 </blockquote>
 
 The Paypal payment module is extensible. It leverages Front-Commerce's "data transform" pattern to allow developers to customize payloads sent to Paypal for Payer data and Payer units.
@@ -116,7 +116,7 @@ See the tests for an example (while a detailed documentation is being written):
 ## Magento2 module
 
 <blockquote class="wip">
-**Work In Progress** This integration is aimed at being transparent for administrators and developers. That is why we haven't duplicated documentation from [existing Magento resources](https://docs.magento.com/user-guide/configuration/sales/paypal-express-checkout.html). Please [contact us](mailto:contact@front-commerce.com) if you need further assistance.
+**Documentation In Progress** This integration is aimed at being transparent for administrators and developers. That is why we haven't duplicated documentation from [existing Magento resources](https://docs.magento.com/user-guide/configuration/sales/paypal-express-checkout.html). Please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span> if you need further assistance.
 </blockquote>
 
 Front-Commerce Magento2 module contains [headless payment adapters](/docs/magento2/headless-payments.html) for the **Paypal Express** payment method.
@@ -126,7 +126,7 @@ The Paypal module must be configured in a normal way, as for a non-headless Mage
 ## Magento1 module
 
 <blockquote class="wip">
-**Work In Progress** This integration is aimed at being transparent for administrators and developers. That is why we haven't duplicated documentation from existing Magento resources. Please [contact us](mailto:contact@front-commerce.com) if you need further assistance.
+**Documentation In Progress** This integration is aimed at being transparent for administrators and developers. That is why we haven't duplicated documentation from existing Magento resources. Please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span> if you need further assistance.
 </blockquote>
 
 Front-Commerce Magento1 module contains [headless payment adapters](/docs/magento1/headless-payments.html) for the **Paypal Standard** payment method.

--- a/source/docs/advanced/payments/payzen.md
+++ b/source/docs/advanced/payments/payzen.md
@@ -108,7 +108,7 @@ To allow loading PayZen related remote resources:
 ### Advanced: customize data sent to PayZen
 
 <blockquote class="wip">
-**Work In Progress** This advanced pattern must be documented with further details. While we are working on it, please [contact us](mailto:contact@front-commerce.com) if you need further assistance.
+**Documentation In Progress** This advanced pattern must be documented with further details. While we are working on it, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span> if you need further assistance.
 </blockquote>
 
 The PayZen payment module is extensible. It leverages Front-Commerce's "data transform" pattern to allow developers to customize payloads sent to PayZen for a [Payment Request creation](https://payzen.io/en-EN/rest/V4.0/api/playground/?ws=Charge/CreatePayment#vMGdf).
@@ -116,12 +116,13 @@ The PayZen payment module is extensible. It leverages Front-Commerce's "data tra
 The Payment request object can be customized at application level. It allows to add additional metadata depending on your own logic. For this, you can use the `registerPaymentRequestDataTransform` method of the Payzen loader to add your custom transformers.
 
 See the test for an example (while a detailed documentation is being written):
-* https://gitlab.com/front-commerce/front-commerce/-/blob/c1ca1ef8a60ecb545e2758d04a4d11577e764658/src/server/modules/payment-payzen/__pacts__/loader.js#L132
+
+- https://gitlab.com/front-commerce/front-commerce/-/blob/c1ca1ef8a60ecb545e2758d04a4d11577e764658/src/server/modules/payment-payzen/__pacts__/loader.js#L132
 
 ## Magento2 module
 
 <blockquote class="wip">
-**Work In Progress** This integration is aimed at being transparent for administrators and developers. That is why we haven't duplicated documentation from existing Magento resources. Please [contact us](mailto:contact@front-commerce.com) if you need further assistance.
+**Documentation In Progress** This integration is aimed at being transparent for administrators and developers. That is why we haven't duplicated documentation from existing Magento resources. Please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span> if you need further assistance.
 </blockquote>
 
 Front-Commerce Magento2 module contains [headless payment adapters](/docs/magento2/headless-payments.html) for the [**PayZen Standard** method](https://github.com/lyra/plugin-magento) (Lyra's official Magento module).

--- a/source/docs/advanced/payments/stripe.md
+++ b/source/docs/advanced/payments/stripe.md
@@ -90,7 +90,7 @@ To allow loading stripe related remote resources:
 ### Advanced: customize data sent to Stripe
 
 <blockquote class="wip">
-**Work In Progress** This advanced pattern must be documented with further details. While we are working on it, please [contact us](mailto:contact@front-commerce.com) if you need further assistance.
+**Documentation In Progress** This advanced pattern must be documented with further details. While we are working on it, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span> if you need further assistance.
 </blockquote>
 
 The Stripe payment module is extensible. It leverages Front-Commerce's "data transform" pattern to allow developers to customize payloads sent to Stripe for Customer and Cart content.

--- a/source/docs/advanced/performance/overview.md
+++ b/source/docs/advanced/performance/overview.md
@@ -5,11 +5,11 @@ title: Overview
 
 In this section, you will learn advanced information about Performance in Front-Commerce.
 
-* [Preloading Routes' data](./preloading-routes.html)
-* [Faster Server Side Rendering](./faster-server-side-rendering.html)
-* [Server Timings](./server-timings.html)
-* [Improve your Core Web Vitals](./improve-your-core-web-vitals.html)
-* [Serving assets from a CDN/custom domain](./assets-cdn-domain.html)
-* [Deactivating unnecessary features](./deactivating-unnecessary-features.html)
+- [Preloading Routes' data](./preloading-routes.html)
+- [Faster Server Side Rendering](./faster-server-side-rendering.html)
+- [Server Timings](./server-timings.html)
+- [Improve your Core Web Vitals](./improve-your-core-web-vitals.html)
+- [Serving assets from a CDN/custom domain](./assets-cdn-domain.html)
+- [Deactivating unnecessary features](./deactivating-unnecessary-features.html)
 
-If you need more detailed information, please [contact us](mailto:contact@front-commerce.com). We will make sure to answer you in a timely manner.
+If you need more detailed information, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span>. We will make sure to answer you in a timely manner.

--- a/source/docs/advanced/performance/server-timings.md
+++ b/source/docs/advanced/performance/server-timings.md
@@ -9,21 +9,19 @@ You can see a representation in your network panel of your devtools by clicking 
 
 The Server Timings are enabled when one of the following condition is satisfied:
 
-* `FRONT_COMMERCE_ENV !== "production"`
-* `DEBUG=front-commerce:performance`
+- `FRONT_COMMERCE_ENV !== "production"`
+- `DEBUG=front-commerce:performance`
 
 ## List of Server Timings registered in the core
 
 The different timings available for an HTML page are:
 
-* **Compute config for request**: how long it took to compute `req.config`
-* **Resolve initial template**: how long it took to retrieve the `index.html` template needed for SSR
-* **Initialize GraphQL loaders**: how long it took to initialize the GraphQL loaders needed for executing GraphQL queries during SSR
-* **React App initialization**: how long it took to create the base React component that will be rendered during SSR
-* **Resolve Apollo queries**: how long it took to retrieve all the data needed to render the page
-* **Render final HTML**: how long it took to render the final HTML page
-
-We plan to add finer server timings in the future. If you believe that there should be another, please [contact us](mailto:contact@front-commerce.com) and we will look into it.
+- **Compute config for request**: how long it took to compute `req.config`
+- **Resolve initial template**: how long it took to retrieve the `index.html` template needed for SSR
+- **Initialize GraphQL loaders**: how long it took to initialize the GraphQL loaders needed for executing GraphQL queries during SSR
+- **React App initialization**: how long it took to create the base React component that will be rendered during SSR
+- **Resolve Apollo queries**: how long it took to retrieve all the data needed to render the page
+- **Render final HTML**: how long it took to render the final HTML page
 
 For further information about SSR, you can read [the Server Side Rendering documentation page](/docs/advanced/theme/server-side-rendering.html),
 

--- a/source/docs/advanced/production-ready/media-middleware.md
+++ b/source/docs/advanced/production-ready/media-middleware.md
@@ -22,9 +22,10 @@ This method has two advantages:
 </blockquote>
 
 First you need to decide where the proxy can fetch the original images. There are two env variables to set:
-* `FRONT_COMMERCE_MAGENTO_ENDPOINT`: the url of your magento endpoint (`http://magento2.local/`)
-  This will be updated in the future to support media that are uploaded on a different server. Please [contact us](mailto:contact@front-commerce.com) if you need this feature.
-* `FRONT_COMMERCE_BACKEND_IMAGES_PATH`: the base path of your media on the backend (`/media`)
+
+- `FRONT_COMMERCE_MAGENTO_ENDPOINT`: the url of your magento endpoint (`http://magento2.local/`)
+  We don't yet support media that are uploaded on a different server. Please <span class="intercom-launcher">[contact us](mailto:hello@front-commerce.com)</span> if you need this feature.
+- `FRONT_COMMERCE_BACKEND_IMAGES_PATH`: the base path of your media on the backend (`/media`)
   For instance, if you want to retrieve the media `http://magento2.local/upload/toto.jpg` when querying `http://localhost:4000/media/toto.jpg`, you need to use `FRONT_COMMERCE_BACKEND_IMAGES_PATH=/upload`.
     <blockquote class="note">
     Note that you don't need to set `FRONT_COMMERCE_BACKEND_IMAGES_PATH` if you are using Magento as a backend for the API and the images because the default is already `/media`.

--- a/source/docs/advanced/production-ready/multistore.md
+++ b/source/docs/advanced/production-ready/multistore.md
@@ -9,7 +9,7 @@ A store in Front-Commerce has the same meaning as [in Magento](https://devdocs.m
 A same instance of Front-Commerce can handle several stores at the same time. This is configurable in `my-module/config/stores.js`.
 
 <blockquote class="note">
-However, if you need multiple websites, you will need to deploy as many Front-Commerce instances as there are websites. Feel free to [contact us](mailto:contact@front-commerce.com) if you need more informations about this.
+However, if you need multiple websites, you will need to deploy as many Front-Commerce instances as there are websites. Feel free to <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span> if you need more information about this.
 </blockquote>
 
 # How to define the different stores

--- a/source/docs/advanced/production-ready/overview.md
+++ b/source/docs/advanced/production-ready/overview.md
@@ -5,14 +5,14 @@ title: Overview
 
 In this section, you will learn advanced information about the different things to check before deploying your Front-Commerce application.
 
-* [Optimize your media](./media-middleware.html)
-* [Configure multiple stores](./multistore.html)
-* [Setup and use logging](./logging.html)
-* [Before going to production](./checklist-before-production.html)
-* [Sitemap generation](./sitemap.html)
+- [Optimize your media](./media-middleware.html)
+- [Configure multiple stores](./multistore.html)
+- [Setup and use logging](./logging.html)
+- [Before going to production](./checklist-before-production.html)
+- [Sitemap generation](./sitemap.html)
 
 We are currently writing documentation about:
 
-* Deployment
+- Deployment
 
-If you need more detailed information, please [contact us](mailto:contact@front-commerce.com). We will make sure to answer you in a timely manner.
+If you need more detailed information, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span>. We will make sure to answer you in a timely manner.

--- a/source/docs/advanced/server/configurations.md
+++ b/source/docs/advanced/server/configurations.md
@@ -252,15 +252,15 @@ const serviceOverrideProvider = {
   name: "serviceOverride",
   values: Promise.resolve({
     service: {
-      key: "new value"
-    }
-  })
-}
+      key: "new value",
+    },
+  }),
+};
 
-configService.insertAfter("serviceProvider", serviceOverrideProvider)
+configService.insertAfter("serviceProvider", serviceOverrideProvider);
 ```
 
 ## Core configuration providers
 
 Our goal is to use these configuration providers for any configuration that could exist in Front-Commerce. However, this is still a work in progress and there are still some configurations that are not associated with a schema yet. Most configurations are still based on files in the [`config` folder of your project's module](/docs/reference/configurations.html).
-If you have specific needs, please [contact us](mailto:contact@front-commerce.com).
+If you have specific needs, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span>.

--- a/source/docs/advanced/server/overview.md
+++ b/source/docs/advanced/server/overview.md
@@ -5,12 +5,12 @@ title: Overview
 
 In this section, you will learn advanced information about the Node.js server in Front-Commerce.
 
-* [Add custom endpoints to your server](./add-http-endpoint.html)
-* [Configurations](./configurations.html)
-* [Customize response HTTP headers](./customize-response-http-headers.html)
+- [Add custom endpoints to your server](./add-http-endpoint.html)
+- [Configurations](./configurations.html)
+- [Customize response HTTP headers](./customize-response-http-headers.html)
 
 We are currently writing documentation about:
 
-* Maintenance mode
+- Maintenance mode
 
-If you need more detailed information, please [contact us](mailto:contact@front-commerce.com). We will make sure to answer you in a timely manner.
+If you need more detailed information, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span>. We will make sure to answer you in a timely manner.

--- a/source/docs/advanced/shipping/overview.md
+++ b/source/docs/advanced/shipping/overview.md
@@ -13,4 +13,4 @@ Moreover, the following guides should help you implement custom integrations by 
 - [Custom Shipping Information](/docs/advanced/shipping/custom-shipping-information.html)
 - [Add a shipping method with pickup points](/docs/advanced/shipping/add-new-shipping-data-in-graphql.html)
 
-If you are looking for detailed information about an existing shipping method or if you're curious about a new integration, please [contact us](mailto:contact@front-commerce.com). **We are always looking to support more shipping methods.**
+If you are looking for detailed information about an existing shipping method or if you're curious about a new integration, please <span class="intercom-launcher">[contact us](mailto:hello@front-commerce.com)</span>. **We are always looking to support more shipping methods.**

--- a/source/docs/advanced/theme/analytics.md
+++ b/source/docs/advanced/theme/analytics.md
@@ -469,4 +469,4 @@ Indeed, if we're doing this, it's likely to be because the tracking service want
 - Look inside the script itself. The script you've been given may be a shortcut and the solution might live in the script itself. If this is the case, this means that you can try to duplicate the scripts content and adapt it to your integration.
 - If none of the solutions above work, you can always try to load the script several times by adding a `?random=${new Date().getTime()}` at the end of the URL. This will trick the browser into thinking they are different scripts and allow you to load it multiple times.
 
-Implementing a great tagging plan for an e-commerce application is a tough journey. If you have any further questions about how to implement them in Front-Commerce, please [contact us](mailto:contact@front-commerce.com). We'll be happy to answer them.
+Implementing a great tagging plan for an e-commerce application is a tough journey. If you have any further questions about how to implement them in Front-Commerce, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span>. We'll be happy to answer them.

--- a/source/docs/advanced/theme/overview.md
+++ b/source/docs/advanced/theme/overview.md
@@ -7,21 +7,21 @@ In this section, you will learn advanced information about theming in Front-Comm
 
 You can already find documentation for:
 
-* [Handle dynamic URLs with the Dispatcher](./route-dispatcher.html)
-* [Layouts](./layouts.html)
-* [Display WYSIWYG content](./wysiwyg.html)
-* [Managing forms](./form.html)
-* [Analytics](./analytics.html)
-* [Translate your application](./translations.html)
-* [Server Side Rendering (SSR)](./server-side-rendering.html)
+- [Handle dynamic URLs with the Dispatcher](./route-dispatcher.html)
+- [Layouts](./layouts.html)
+- [Display WYSIWYG content](./wysiwyg.html)
+- [Managing forms](./form.html)
+- [Analytics](./analytics.html)
+- [Translate your application](./translations.html)
+- [Server Side Rendering (SSR)](./server-side-rendering.html)
 
 And we are currently writing documentation about:
 
-* How does the BEM convention work in a React environment?
-* SEO
-    * Micro-datas/JSON-LD: how to use them?
-    * How to make sure that your SEO is correct?
-* ErrorBoundaries
-    Improve the User Experience by handling error cases
+- How does the BEM convention work in a React environment?
+- SEO
+  - Micro-datas/JSON-LD: how to use them?
+  - How to make sure that your SEO is correct?
+- ErrorBoundaries
+  Improve the User Experience by handling error cases
 
-If you need more detailed information, please [contact us](mailto:contact@front-commerce.com). We will make sure to answer you in a timely manner.
+If you need more detailed information, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span>. We will make sure to answer you in a timely manner.

--- a/source/docs/advanced/theme/server-side-rendering.md
+++ b/source/docs/advanced/theme/server-side-rendering.md
@@ -109,7 +109,7 @@ This behavior is leveraging [Front-Commerce's configuration system](/docs/advanc
 }
 ```
 
-If you want to tweak this behavior, we invite you to browse the [`deviceConfigProvider`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/server/express/ssr/deviceConfigProvider.js) for implementation details and [contact us](mailto:contact@front-commerce.com) if you think of any improvements.
+If you want to tweak this behavior, we invite you to browse the [`deviceConfigProvider`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/server/express/ssr/deviceConfigProvider.js) for implementation details and <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span> if you think of any improvements.
 
 ## SSR Fallback when things go wrong
 
@@ -132,10 +132,11 @@ If you still want to display the `theme/pages/SsrFallback` page in dev mode, [ad
 Front-Commerce avoids to unnecessary render a full 404 page server-side for URLs that don't need it. When bots access random URLs (e.g: `dump.sql.gz`, `password.txt` etc…) or outdated static assets, Front-Commerce will return a simpler 404 error.
 
 Pages are server-rendered when accessed with the following URL patterns:
+
 - without extension (e.g: `/contact`, `/faq/our-return-policy`…)
 - with an `.html` extension (e.g: `/contact.html`, `/wooden-table-with-chairs.html`…)
 
-**If your application contains pages whose URL have extensions other than `.html`, please [contact us](mailto:contact@front-commerce.com).**
+**If your application contains pages whose URL have extensions other than `.html`, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span>.**
 
 ## Learn more
 

--- a/source/docs/advanced/theme/wysiwyg-legacy.md
+++ b/source/docs/advanced/theme/wysiwyg-legacy.md
@@ -111,9 +111,3 @@ Widget.propTypes = {
 
 export default Widget;
 ```
-
-## Customize your Wysiwyg component
-
-<blockquote class="wip">
-We are still working on writing this guide. However, if you need help customizing your Wysiwyg components, please feel free to [contact us](mailto:contact@front-commerce.com).
-</blockquote>

--- a/source/docs/appendices/migration-guides.md
+++ b/source/docs/appendices/migration-guides.md
@@ -2391,7 +2391,7 @@ During this change, we needed to update some parts of the GraphQL schema. If you
   `DynamicFacet.buckets` (plural).
 - `SearchResult.layer` was renamed to `SearchResult.products`
 
-Please check your front-end queries to ensure to update them accordingly. If you need any help about these, feel free to [contact us](mailto:contact@front-commerce.com).
+Please check your front-end queries to ensure to update them accordingly. If you need any help about these, feel free to <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span>.
 
 ### Wishlist
 

--- a/source/docs/appendices/release-process.md
+++ b/source/docs/appendices/release-process.md
@@ -5,7 +5,7 @@ title: Release process
 
 Front-Commerce is built around the motto "Make it work, then make it better". This means that it is possible **today** to develop and deploy your website to production.
 
-Our mission of making your life easier, and your customers happier is an ongoing process. Front-Commerce will thus regularly evolve. Our main strength is our flexibility. We do take into account our clients needs and adapt our Roadmap to match theirs. If you have any particular needs, feel free to <span class="intercom-launcher">[contact us](mailto:contact@front-commerce.com)</span> and we will see what we can do to help you :)
+Our mission of making your life easier, and your customers happier is an ongoing process. Front-Commerce will thus regularly evolve. Our main strength is our flexibility. We do take into account our clients needs and adapt our Roadmap to match theirs. If you have any particular needs, feel free to <span class="intercom-launcher">[contact us](mailto:hello@front-commerce.com)</span> and we will see what we can do to help you :)
 
 This page explains our release philosophy.
 
@@ -16,6 +16,7 @@ We aim at releasing often and follow [Semantic Versioning](https://semver.org) t
 **TL;DR:** (from the [Semantic Versioning](https://semver.org) documentation)
 
 > Given a version number MAJOR.MINOR.PATCH, increment the:
+>
 > 1. MAJOR version when you make incompatible API changes,
 > 2. MINOR version when you add functionality in a backwards compatible manner, and
 > 3. PATCH version when you make backwards compatible bug fixes.

--- a/source/docs/essentials/installation.md
+++ b/source/docs/essentials/installation.md
@@ -10,7 +10,7 @@ supposes that you have access to our private repositories.
 
 Access is granted to teams that have signed the relevant legal contracts, either
 as a **Partner** or a **Customer**. Please
-[contact us](mailto:contact@front-commerce.com) if you need help or further
+<span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span> if you need help or further
 information.
 
 Front-Commerce is a Node.js server that will serve a GraphQL endpoint and a

--- a/source/docs/magento1/headless-payments.md
+++ b/source/docs/magento1/headless-payments.md
@@ -14,13 +14,13 @@ Our Magento1 integration currently provides native adapters for the platforms be
 - [Paypal](/docs/advanced/payments/paypal.html#Magento1-module)
 
 <blockquote class="info">
-  If you want to use a Payment module not yet listed above, please [contact us](mailto:contact@front-commerce.com) so we can provide information about a potential upcoming native support for it.
+  If you want to use a Payment module not yet listed above, please <span class="intercom-launcher">[contact us](mailto:hello@front-commerce.com)</span> so we can provide information about a potential upcoming native support for it.
 </blockquote>
 
 ## Implement a new Magento1 Payment method
 
 <blockquote class="wip">
-**Work In Progress** This section will be documented in the future. In the meantime, please [contact us](mailto:contact@front-commerce.com) so we can show you the steps to create your own headless payment in Magento1.
+**Documentation In Progress** This section will be documented in the future. In the meantime, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span> so we can show you the steps to create your own headless payment in Magento1.
 </blockquote>
 
 ### Using the "redirect after order" flow
@@ -31,24 +31,25 @@ Our Magento1 integration currently provides native adapters for the platforms be
 
 1. Add your own payment instance on `config.xml` file
 
-  First, you need to create your own model implementing the `FrontCommerce_Integration_Model_Headlesspayment_Interface` interface and register it using the `<config><frontcommerce><payment_instances><{payment_method_code}>{class_name}</{payment_method_code}></payment_instances></frontcommerce></config>` XML node in your `config.xml` file.
+First, you need to create your own model implementing the `FrontCommerce_Integration_Model_Headlesspayment_Interface` interface and register it using the `<config><frontcommerce><payment_instances><{payment_method_code}>{class_name}</{payment_method_code}></payment_instances></frontcommerce></config>` XML node in your `config.xml` file.
 
-  **Note:** don't forget to replace `{payment_method_code}` by your method payment code and `{class_name}` by the class names you've just created
+**Note:** don't forget to replace `{payment_method_code}` by your method payment code and `{class_name}` by the class names you've just created
 
 2. Implement the interface methods in your own model:
-  - `isHtml(): Boolean` if your payment return type is HTML content or not
-  - `isUrl(): Boolean` if your payment return type is URL or not
-  - `getValue(Mage_Sales_Model_Order $order): String` return URL or HTML when this payment method is call on front
-  - `getResponseSuccess(String $action, [String] $additionalData): Boolean` Failed or success payment action
-  - `getResponseMessage(String $action, [String] $additionalData): [String]` Failed action message
-    - in success case, return an array of `quote_id` and `order_id`:
-    ```
-    return [
-      (int) $additionalData['quote_id'], (int)  $additionalData['order_id']
-    ];
-    ```
-    - in case of errors, return an array of error messages:
-    ```
-    return [{error message}]
-    ```
-  - `returnAction(String $action, [String] $additionalData): Boolean` Callback after payment, for example, you can add your custom code here for retrieve customer cart after cancel payment
+
+- `isHtml(): Boolean` if your payment return type is HTML content or not
+- `isUrl(): Boolean` if your payment return type is URL or not
+- `getValue(Mage_Sales_Model_Order $order): String` return URL or HTML when this payment method is call on front
+- `getResponseSuccess(String $action, [String] $additionalData): Boolean` Failed or success payment action
+- `getResponseMessage(String $action, [String] $additionalData): [String]` Failed action message
+  - in success case, return an array of `quote_id` and `order_id`:
+  ```
+  return [
+    (int) $additionalData['quote_id'], (int)  $additionalData['order_id']
+  ];
+  ```
+  - in case of errors, return an array of error messages:
+  ```
+  return [{error message}]
+  ```
+- `returnAction(String $action, [String] $additionalData): Boolean` Callback after payment, for example, you can add your custom code here for retrieve customer cart after cancel payment

--- a/source/docs/magento2/graphql.md
+++ b/source/docs/magento2/graphql.md
@@ -63,4 +63,4 @@ As detailed earlier, Front-Commerce already supports a wide range of Magento fea
 We believe that — to date — **most of the features from Front-Commerce schema are more stable, performant and complete than Magento’s GraphQL counterpart** (even if the schema is slightly different).
 
 However, our goal is to reduce this gap (and our codebase!) and your feedback is welcome.
-If you think something is missing in Front-Commerce, or stable enough in Magento to be used in production [send us an email](mailto:contact@front-commerce.com) and we could add it to our roadmap!
+If you think something is missing in Front-Commerce, or stable enough in Magento to be used in production <span class="intercom-launcher">[send us an email](mailto:hello@front-commerce.com)</span> and we could add it to our roadmap!

--- a/source/docs/magento2/headless-payments.md
+++ b/source/docs/magento2/headless-payments.md
@@ -22,7 +22,7 @@ Our Magento2 integration currently provides native adapters for the platforms be
 - [Payment on account](/docs/advanced/payments/payment-on-account.html)
 
 <blockquote class="info">
-  If you want to use a Payment module not yet listed above, please [`contact us`](mailto:contact@front-commerce.com) so we can provide information about a potential upcoming native support for it.
+  If you want to use a Payment module not yet listed above, please [`contact us`](mailto:hello@front-commerce.com) so we can provide information about a potential upcoming native support for it.
 </blockquote>
 
 ## Implement a new Magento2 Payment method Adapter

--- a/source/docs/magento2/overview.md
+++ b/source/docs/magento2/overview.md
@@ -36,4 +36,4 @@ We are still in the process of writing the documentation. But we will cover the 
 - Interact with Magento 2's REST API
 - Disable Magento 2's storefront
 
-If you need more detailed information, please [contact us](mailto:contact@front-commerce.com). We will make sure to answer you in a timely manner.
+If you need more detailed information, please [contact us](mailto:support@front-commerce.com). We will make sure to answer you in a timely manner.

--- a/source/docs/magento2/page-builder.md
+++ b/source/docs/magento2/page-builder.md
@@ -5,7 +5,7 @@ title: Page Builder
 
 Adobe Commerce and Magento 2.4.3+ allow merchants to author pages using [Page Builder](https://magento.com/products/magento-commerce/page-builder). Front-Commerce supports Page Builder managed content out-of-the-box.
 
-In this section, you will learn how to use this feature and extend it. Create new *content types* and refine UI components so that merchants can create the rich shopping experiences that was designed for *their* customers.
+In this section, you will learn how to use this feature and extend it. Create new _content types_ and refine UI components so that merchants can create the rich shopping experiences that was designed for _their_ customers.
 
 <blockquote class="feature--new">
 _Since version 2.11.0 (early preview)_
@@ -18,6 +18,7 @@ _Since version 2.11.0 (early preview)_
 ## Prerequisites
 
 Page Builder is only available for content that:
+
 - are displayed using [the `<WysiwygV2>` component and its related `WysiwygFragment` GraphQL fragment](/docs/advanced/theme/wysiwyg.html#lt-WysiwygV2-gt-usage)
 - get data from GraphQL fields resolved using [the `MagentoWysiwyg` type](/docs/advanced/theme/wysiwyg-platform.html#MagentoWysiwyg) **(which is the case of all default Magento rich content fields)**
 
@@ -26,12 +27,9 @@ Please check these prerequisites first if your content does not appear properly.
 ## Concepts
 
 Page Builder content types have 2 integration points:
+
 - **server side data conversion** will parse Magento HTML response to extract rich structured data exposed in GraphQL
 - **client side React components** will display the content using existing components, from data fetched from GraphQL
-
-<blockquote class="wip">
-**Work In Progress:** if you need details right now, please [contact us](mailto:contact@front-commerce.com). We will make sure to answer you in a timely manner.
-</blockquote>
 
 ## Supported content types
 
@@ -114,7 +112,7 @@ You can extend existing Page Builder content types, or register new ones specifi
 ### Customize UI components
 
 <blockquote class="wip">
-**Work In Progress:** if you need details right now, please [contact us](mailto:contact@front-commerce.com). We will make sure to answer you in a timely manner.
+**Work In Progress:** if you need details right now, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span>. We will make sure to answer you in a timely manner.
 </blockquote>
 
 - override `theme/modules/WysiwygV2/MagentoWysiwyg/PageBuilder/_appComponents.scss` to register your custom styles
@@ -125,7 +123,7 @@ You can extend existing Page Builder content types, or register new ones specifi
 ### Expose content types data in GraphQL
 
 <blockquote class="wip">
-**Work In Progress:** if you need details right now, please [contact us](mailto:contact@front-commerce.com). We will make sure to answer you in a timely manner.
+**Documentation In Progress:** if you need details right now, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span>. We will make sure to answer you in a timely manner.
 </blockquote>
 
 The `PageBuilder` loader allows you to register new content types.

--- a/source/docs/prismic/index.md
+++ b/source/docs/prismic/index.md
@@ -12,4 +12,4 @@ The Front-Commerce Prismic module brings support for the headless CMS [Prismic](
 - [Integration Fields](/docs/prismic/integration-fields.html)
 - [Prismic Preview](/docs/prismic/preview.html)
 
-If you need more detailed information, please [contact us](mailto:contact@front-commerce.com). We will make sure to answer you in a timely manner.
+If you need more detailed information, please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span>. We will make sure to answer you in a timely manner.

--- a/source/docs/reference/environment-variables.md
+++ b/source/docs/reference/environment-variables.md
@@ -6,25 +6,22 @@ title: Environment variables
 The environment variables available in Front-Commerce are the configurations that are likely to change depending on the current environment of your application. For instance, you could have three different environments: production, staging and local.
 
 These environment variables can be defined in two different ways:
-* on your server (See [How To Read and Set Environmental and Shell Variables on a Linux VPS](https://www.digitalocean.com/community/tutorials/how-to-read-and-set-environmental-and-shell-variables-on-a-linux-vps))
-* in the `.env` file in your root folder
+
+- on your server (See [How To Read and Set Environmental and Shell Variables on a Linux VPS](https://www.digitalocean.com/community/tutorials/how-to-read-and-set-environmental-and-shell-variables-on-a-linux-vps))
+- in the `.env` file in your root folder
 
 You can then access them by using the `process.env` object in your javascript files no matter if it is a server-side or client-side file.
 However, not all variables are exposed in your client code. Client code only have access to variables such as `FRONT_COMMERCE_WEB_*` which were defined during `front-commerce build`. See [Add your own environment variables](/docs/reference/environment-variables.html#Add-your-own-environment-variables) for more details.
 
 ## How to update environment variables
 
-<blockquote class="wip">
-    **Work In Progress:** we plan to add a more exhaustive flowchart to cover all edge cases. By then, if you have any issues to understand why/when a build or restart is necessary, please [contact us](mailto:contact@front-commerce.com). We will make sure to answer you in a timely manner.
-</blockquote>
-
 You can't update these variables only by updating your server's variable. This comes from how node works. But there are also some specificities due to Front-Commerce.
 
-* If `FRONT_COMMERCE_USE_SERVER_DYNAMIC_ENV=true` during build time:
-    * 🚫 if the variable is used on the client side (`FRONT_COMMERCE_WEB_*`) you need to do a new `front-commerce build`
-    * ✅ if the variable is only used on the server side (`FRONT_COMMERCE_*` but not `FRONT_COMMERCE_WEB_*`) you only need to restart your server
-* If `FRONT_COMMERCE_USE_SERVER_DYNAMIC_ENV=false` during build time (default behavior until 1.0.0):
-    * 🚫 You need to do a new `front-commerce build` and restart your server
+- If `FRONT_COMMERCE_USE_SERVER_DYNAMIC_ENV=true` during build time:
+  - 🚫 if the variable is used on the client side (`FRONT_COMMERCE_WEB_*`) you need to do a new `front-commerce build`
+  - ✅ if the variable is only used on the server side (`FRONT_COMMERCE_*` but not `FRONT_COMMERCE_WEB_*`) you only need to restart your server
+- If `FRONT_COMMERCE_USE_SERVER_DYNAMIC_ENV=false` during build time (default behavior until 1.0.0):
+  - 🚫 You need to do a new `front-commerce build` and restart your server
 
 The reason behind these rules is because some variables are defined and bundled within your code during the `build` of your application. For this reason, if you are are in a case where you can't update the variable, you will need to trigger a new build with the new environment variables defined and restart your server.
 
@@ -124,21 +121,22 @@ Front-Commerce 2.5 with Magento1.
 - `FRONT_COMMERCE_ALGOLIA_INDEX_NAME_PREFIX`: a prefix to use to build index names
 
 You can find these credentials on the [Algolia Dashboard](https://www.algolia.com/dashboard/api-keys), on the **API keys** page from the menu.
+
 ### Paypal
 
 <blockquote class="wip">
-More documentation about this module will be available soon. Please [contact us](mailto:contact@front-commerce.com) directly if you need this information quickly.
+More documentation about this module will be available soon. Please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span> directly if you need this information quickly.
 </blockquote>
 
 - `FRONT_COMMERCE_WEB_PAYPAL_ENV`: `production` or `sandbox`
 - Paypal credentials (See [How do I request API Signature or Certificate credentials for my PayPal account?](https://www.paypal.com/uk/smarthelp/article/how-do-i-request-api-signature-or-certificate-credentials-for-my-paypal-account-faq3196))
-    - `FRONT_COMMERCE_PAYPAL_USERNAME`
-    - `FRONT_COMMERCE_PAYPAL_PASSWORD`
+  - `FRONT_COMMERCE_PAYPAL_USERNAME`
+  - `FRONT_COMMERCE_PAYPAL_PASSWORD`
 
 ### Ogone
 
 <blockquote class="wip">
-More documentation about this module will be available soon. Please [contact us](mailto:contact@front-commerce.com) directly if you need this information quickly.
+More documentation about this module will be available soon. Please <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span> directly if you need this information quickly.
 </blockquote>
 
 - `FRONT_COMMERCE_OGONE_ENV`

--- a/source/docs/reference/scripts.md
+++ b/source/docs/reference/scripts.md
@@ -9,7 +9,7 @@ Front-Commerce contains scripts aimed at being used on your server when your app
 <blockquote class="warning">
 We plan to improve the way scripts are created and used in the future, and allow developers to register custom scripts from their applications.
 If interested for more context, please see [#169](https://gitlab.com/front-commerce/front-commerce/issues/169) for further details and do note hesitate to send us feedback about this feature.
-You can also [contact us](mailto:contact@front-commerce.com) directly if you have any question.
+You can also <span class="intercom-launcher">[contact us](mailto:support@front-commerce.com)</span> directly if you have any question.
 </blockquote>
 
 ## `imageWarmUp.js`

--- a/source/index.md
+++ b/source/index.md
@@ -56,10 +56,6 @@ layout: index
       <p>Our goal is not to provide tools for the sake of tooling. However we strongly believe that a good set of tools will make your life easier and will enable you to do what is best for your users.</p>
 
       <p>Because each brand communicates differently with its customers, our goal is to let you adapt quickly and efficiently, by avoiding technical considerations that will slow you down. We stay up to date and you stay in touch with your users.</p>
-
-      <a class="link learn-more button" href="mailto:contact@front-commerce.com?subject=I’m interested!">
-        Learn more about our vision <span class="icon-arrow-right-alt"></span>
-      </a>
     </div>
 
   </div>
@@ -98,7 +94,7 @@ layout: index
   <p>We're driving our next integrations depending on our future clients needs. So feel free to contact us if you have any specific needs. We're willing to take advantage of our flexibility to adapt to our client's roadmaps.</p>
 
   <p>
-    <a class="link learn-more button" href="mailto:contact@front-commerce.com?subject=Hi!%20I'd%20like%20to%20know%20more%20about%20your%20roadmap&body=Hi%2C%0D%0A%0D%0AI%20am%20interested%20in%20your%20product%2C%20and%20would%20love%20to%20know%20if%20you%20considered%20...">
+    <a class="link learn-more button intercom-launcher" href="mailto:hello@front-commerce.com?subject=Hi!%20I'd%20like%20to%20know%20more%20about%20your%20roadmap&body=Hi%2C%0D%0A%0D%0AI%20am%20interested%20in%20your%20product%2C%20and%20would%20love%20to%20know%20if%20you%20considered%20...">
       Ask us about our roadmap <span class="icon-arrow-right-alt"></span>
     </a>
   </p>
@@ -156,6 +152,6 @@ layout: index
   <p>If you are interested with what you’ve read or things are still not clear, do not hesitate to reach us! We could schedule a call or a demo so you could evaluate the product in a more concrete way.</p>
 
   <div class="center">
-    <a class="link primary button" href="mailto:contact@front-commerce.com?subject=I’m interested!">Contact the team</a>
+    <a class="link primary button intercom-launcher" href="mailto:contact@front-commerce.com?subject=I’m interested!">Contact the team</a>
   </div>
 </section>

--- a/theme/layout/layout.ejs
+++ b/theme/layout/layout.ejs
@@ -170,7 +170,8 @@
 
     <script>
       window.intercomSettings = {
-        app_id: "ehgzoeah"
+        app_id: "ehgzoeah",
+        custom_launcher_selector: '.intercom-launcher',
       };
     </script>
 

--- a/theme/layout/page.ejs
+++ b/theme/layout/page.ejs
@@ -28,9 +28,9 @@
             <% } %>
             <% if (page.wip) { %>
               <blockquote class="wip">
-                <strong>Work In Progress:</strong> This documentation is still a work in progress.
+                <strong>Documentation In Progress:</strong> This documentation is still a work in progress.
                 We apologies for the inconvenience. If you want to learn more this subject, please
-                feel free to <a href="mailto:contact@front-commerce.com">contact us</a> or to upvote
+                feel free to <a href="mailto:support@front-commerce.com" class="intercom-launcher">contact us</a> or to upvote
                 the issue within the <a href="<%- page.wip %>">related issue</a>.
               </blockquote>
             <% } %>


### PR DESCRIPTION
This PR configures the `intercom-launcher` class as a trigger to open the Intercom messenger and goes over every email contact occurrence to update it.

Can be tested on: https://deploy-preview-330--heuristic-almeida-1a1f35.netlify.app/

https://user-images.githubusercontent.com/75968/154533061-8f20b2ec-f99d-4379-ad92-4e737385090f.mp4


It updates every relevant contact call to action to open the messenger by default (and falls back to the `mailto:` link for users without JS or if intercom isn't loaded).

I've updated the fallback email address to target support@ (support) or hello@ (product) depending on the use case.

## Formatting

I noticed that some code was reformatted during git and/or editor hooks. I've reverted as many changes as possible, but some were a bit more tedious.

I'll try to followup with a PR allowing to have shared configs and tooling to get rid of such imtempestive changes and have a consistent formatting once and for all.