### PR TITLE
CI: configure Github actions to add a linting step

### DIFF
--- a/.github/workflows/ensure-consistency.yml
+++ b/.github/workflows/ensure-consistency.yml
@@ -1,0 +1,22 @@
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+name: CI - Ensure consistency
+
+on:
+  push:
+    branches: [main, next]
+  pull_request:
+    branches: [main, next]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          cache: "npm"
+      - run: npm ci
+      - run: npm run lint

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+node_modules/
+public/

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build": "hexo --config config/_config.yml,_config.yml && hexo --config _multiconfig.yml generate && cp -r source/_static/* public",
     "clean": "hexo clean",
     "test": "npm run clean; npm run build",
+    "lint": "prettier --check .",
     "blc:prod": "blc --exclude 4000 --exclude 9001 --filter-level 2 https://developers.front-commerce.com -ro",
     "blc:local": "blc --exclude 4000 --exclude 9001 --filter-level 2 http://localhost:4444 -ro",
     "prepare": "husky install",


### PR DESCRIPTION
To ensure code consistency.

This PR is aimed at making reviews easier. The CI is failing because content has not been reformatted.

Reformatting is done in #342 (CI is passing there)