### PR TITLE
feat(ux): add a direct feedback link on all pages

### DIFF
--- a/theme/layout/page.ejs
+++ b/theme/layout/page.ejs
@@ -86,6 +86,11 @@
       <div class="github">
         <a class="link tertiary " href="<%- githubUrl %>" target="_blank">
           <span class="icon-github"></span>Edit on GitHub</a>
+
+          &nbsp;or&nbsp;
+
+        <a class="link tertiary intercom-launcher" href="mailto:support@front-commerce.com">
+          <span class="icon-request-change"></span>Send us a feedback</a>
       </div>
 
       <% if (page.discourseTopicId) { %>


### PR DESCRIPTION
so that readers are _a click away_ from providing us a feedback on documentation pages

![screenshot-2022-03-01_07-08-16](https://user-images.githubusercontent.com/75968/156114591-0584366a-f07f-453a-a741-3aea1d5844d1.png)

Hypothesis: this CTA will increase the amount of typos notifications and help us iterate on the doc (content or organization)

It opens the Intercom Messenger with a fallback on our support email address.