### PR TITLE
feat(dx): add relative paths for search result

### DIFF
--- a/theme/layout/page.ejs
+++ b/theme/layout/page.ejs
@@ -63,22 +63,22 @@
             }
           %>
           <% if (prev) { %>
-         
+
               <a class="link primary prev" href="<%- relative_url(page.path, prev.path) %>">
                 <span class="icon-arrow-left-alt"></span>
                 <span class="subtitle-pagination">Previous</span>
                 <%- prev.title %>
               </a>
-         
+
           <% } %>
           <% if (next) { %>
-           
+
               <a class="link primary next" href="<%- relative_url(page.path, next.path) %>">
                 <span class="subtitle-pagination">Next</span>
                 <%- next.title %>
                   <span class="icon-arrow-right-alt"></span>
               </a>
-           
+
           <% } %>
         </div>
       </div>
@@ -149,6 +149,9 @@
             },
             algoliaOptions: {
               hitsPerPage: 20
+            },
+            transformData: function(hits) {
+              return hits.map(hit => ({ ...hit, url: new URL(hit.url).pathname }));
             }
           }).autocomplete;
 


### PR DESCRIPTION
### Why?
If you search in any instance other than production, the url's returned are absolute (with production origin), which results in unusable searching in either local development or preview deployments, this addresses that issue by removing the origin from the URL, only exposing the pathname, which results in navigatable links in current deployment/instance.










| Berfore | After    |
| ---------- | --------- |
|  <video src="https://user-images.githubusercontent.com/39598117/156334515-abd1aebf-747e-4550-8603-78b0040a39bb.mp4" />  |   <video src="https://user-images.githubusercontent.com/39598117/156334583-dd6ab3d4-b4cb-4a1d-a0c4-a46142ac8ab5.mp4" />  |