### PR TITLE
fix(docs): adds the hash to the relative url

### DIFF
--- a/theme/layout/page.ejs
+++ b/theme/layout/page.ejs
@@ -156,7 +156,10 @@
               hitsPerPage: 20
             },
             transformData: function(hits) {
-              return hits.map(hit => ({ ...hit, url: new URL(hit.url).pathname }));
+              return hits.map(hit => {
+                const url = new URL(hit.url)
+                return { ...hit, url: url.pathname + url.hash }
+              });
             }
           }).autocomplete;
 


### PR DESCRIPTION
When searching hashed content, only using the `pathname` does not suffice as we also need to include the `hash` to navigate to the correct sections.


Related to : https://github.com/front-commerce/developers.front-commerce.com/pull/346