### PR TITLE
Document deactivation of GraphQL Persisted Queries

### DIFF
--- a/source/docs/appendices/migration-guides.md
+++ b/source/docs/appendices/migration-guides.md
@@ -153,6 +153,7 @@ const isCompanyUser = (user) => {
 ### New features in `2.14.0`
 
 - [Custom routable pages now supports dynamic GraphQL variables from URL](/docs/advanced/theme/route-dispatcher.html#Advanced-queries)
+- [New `FRONT_COMMERCE_GRAPHQL_PERSISTED_QUERIES_DISABLE` environment variable for temporarily deactivating the GraphQL Persisted Queries feature](/docs/reference/environment-variables.html#Server)
 - New Prismic module features:
   - Support for [trailing slashes](/docs/prismic/routable-types.html#Trailing-Slash)
   - Support for [path rewrites](/docs/prismic/routable-types.html#Path-Rewrites)

--- a/source/docs/reference/environment-variables.md
+++ b/source/docs/reference/environment-variables.md
@@ -59,6 +59,7 @@ Configure the execution environment of the Front-Commerce's application:
 
 - `FRONT_COMMERCE_EXPRESS_LOG_ACCESS_ENABLED`: in some contexts, the proxy already has access logs and it is not useful to have a duplication. Logs grow unnecessarily and it adds an overhead. You can set `FRONT_COMMERCE_EXPRESS_LOG_ACCESS_ENABLED=false` to disable Front-Commerce access logs (in logs/access.log).
 - `FRONT_COMMERCE_EXPERIMENTAL_NEW_RELIC_INSTRUMENT_GRAPHQL_SERVER`: set it to `true` to turn on an experimental logging of GraphQL resolvers metrics in New Relic. It uses the [New Relic Apollo Server plugin](https://www.npmjs.com/package/@newrelic/apollo-server-plugin)
+- `FRONT_COMMERCE_GRAPHQL_PERSISTED_QUERIES_DISABLE`: in some contexts [GraphQL persisted queries](https://www.apollographql.com/docs/apollo-server/performance/apq/) can be a blocker for a task. For instance, when recording a stress test scenario you might want fully reproducible HTTP traffic: persisted queries may lead to unreproducible recordings. In this case, you can set `FRONT_COMMERCE_GRAPHQL_PERSISTED_QUERIES_DISABLE=true` to disable the GraphQL server persisted queries feature (upon restart). Don't forget to turn it on again afterwards: **it is recommended for production use cases!**
 
 ### Sitemap
 


### PR DESCRIPTION
This PR documents the new feature flag added in https://gitlab.com/front-commerce/front-commerce/-/merge_requests/1152