### PR TITLE
Update demo links on the home page to redirect to the landing page

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -66,25 +66,10 @@ layout: index
 
   <p>Even though we built Front-Commerce by integrating it with Magento 2, we had a clear vision of introducing a clean separation between the frontend and your backend solution. You will be able to use the backend that best fits your needs without rebuilding your frontend from scratch.</p>
 
-  <p>However, we now are focused on supporting Magento 2 and 1, and plan to add new e-commerce backends integrations later this year.</p>
-
-  <div class="card-grid">
-    <div class="card card--large">
-      <img src="/images/magento-logo.svg">
-      <h3><a href="https://magento1.demo.front-commerce.com">Magento 1</a> & <a href="https://magento2.demo.front-commerce.com">Magento 2</a></h3>
-    </div>
-    <div class="card card--large">
-      <img src="/images/wordpress-logo.svg">
-      <h3><a href="https://wordpress.demo.front-commerce.com">WordPress</a></h3>
-    </div>
-    <div class="card card--large">
-      <img src="/images/prismic-logo.svg">
-      <h3><a href="https://prismic.demo.front-commerce.com">Prismic</a></h3>
-    </div>
-  </div>
+  <p>**Magento 2 and 1 storefronts are currently running in production** (with Wordpress and / or Prismic modues). **BigCommerce is the next** one to go-live.</p>
 
   <p class="center">
-    <a class="link primary button" href="https://demo.front-commerce.com">Browse all demos</a>
+    <a class="link primary button" href="https://demo.front-commerce.app">Browse our online demos</a>
   </p>
 </section>
 


### PR DESCRIPTION
From a feedback received, there are incorrect links to legacy demo instances on the home page.

This PR removes explicit links and redirects users to the new landing page designed specifically (and that will be kept up-to-date).

Preview: https://deploy-preview-375--heuristic-almeida-1a1f35.netlify.app/