### PR TITLE
Adds styling for kdb html element

### DIFF
--- a/theme/source/style/_common-post.less
+++ b/theme/source/style/_common-post.less
@@ -19,6 +19,7 @@
 @import "./_global/nav.less";
 @import "./_global/panel.less";
 @import "./_global/syntax.less";
+@import "./_global/kbd.less";
 
 // global templates
 @import "./_theme/layout.less";

--- a/theme/source/style/_global/kbd.less
+++ b/theme/source/style/_global/kbd.less
@@ -1,0 +1,18 @@
+kbd {
+  margin: 0px 0.1em;
+  padding: 0.1em 0.6em;
+  border-radius: 3px;
+  border: 1px solid rgb(204, 204, 204);
+  color: rgb(51, 51, 51);
+  line-height: 1.4;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 10px;
+  display: inline-block;
+  box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.2), inset 0px 0px 0px 2px #ffffff;
+  background-color: rgb(247, 247, 247);
+  -moz-box-shadow: 0 1px 0px rgba(0, 0, 0, 0.2), 0 0 0 2px #ffffff inset;
+  -webkit-box-shadow: 0 1px 0px rgba(0, 0, 0, 0.2), 0 0 0 2px #ffffff inset;
+  -moz-border-radius: 3px;
+  -webkit-border-radius: 3px;
+  text-shadow: 0 1px 0 #fff;
+}


### PR DESCRIPTION
### What?
This adds styling to display kbd (keyboard) HTML elements in a more readable way.

| Before | <img width="462" alt="image" src="https://user-images.githubusercontent.com/39598117/161713209-c0f1b439-5c28-4342-8b48-570778ee4539.png"> |
|--------|-------------------------------------------------------------------------------------------------------------------------------------------|
| After  | <img width="481" alt="image" src="https://user-images.githubusercontent.com/39598117/161713096-28207eaf-2cb5-4e10-b3a1-53a7abcb4394.png"> |

