### PR TITLE
fix: adds modules include in click counter example

### DIFF
--- a/source/docs/essentials/extend-the-graphql-schema.md
+++ b/source/docs/essentials/extend-the-graphql-schema.md
@@ -67,7 +67,9 @@ Let’s add a `ClicksCounters` GraphQL module by adding it to the existing list:
 module.exports = {
   name: "Front-Commerce",
   url: "https://www.front-commerce.test",
-  modules: [],
+  modules: [
++   "./my-module"
+  ],
   serverModules: [
     { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
     { name: "Magento2", path: "server/modules/magento2" },
@@ -151,10 +153,10 @@ extend type Query {
   clicksCounterByProductSKU(sku: String!): Int
 }
 ```
-However, we feel it would have been less intuitive for front-end developers. On 
-the other hand, it may seem more natural for developers familiar with designing 
-relational databases or REST APIs. Still, we recommend limiting as much 
-as possible the number of top-level queries in your projects to learn _thinking 
+However, we feel it would have been less intuitive for front-end developers. On
+the other hand, it may seem more natural for developers familiar with designing
+relational databases or REST APIs. Still, we recommend limiting as much
+as possible the number of top-level queries in your projects to learn _thinking
 in GraphQL_.
 
 </blockquote>


### PR DESCRIPTION
### Why?
Following this example without the modules include you would run into an issue with the `.gql` import for the schema

Pre: prepare_modules
```bash
FRONT-COMMERCE  An error occured when running: webpack --silent --config /front-commerce-skeleton/node_modules/front-commerce/config/server/webpack.config.prod.js --entry server=/Projects/front-commerce-skeleton/node_modules/front-commerce/src/server/core/graphql/writeIntrospectionFiles.js -o /Projects/front-commerce-skeleton/build/server/core/graphql/writeIntrospectionFiles.js
```

Post: prepare_modules
```bash
   WEBPACK  ./my-module/server/modules/click-counters/schema.gql 1:0
Module parse failed: Unexpected character '#' (1:0)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
```