### PR TITLE
fix: fixes broken links detected in crawler

### DIFF
--- a/source/_posts/front-commerce-2.9.md
+++ b/source/_posts/front-commerce-2.9.md
@@ -9,7 +9,7 @@ Front-Commerce 2.9 is out! Over the past few weeks, we focused on delivering inc
 
 ## Bugfixes for all
 
-As promised [in the 2.8 announcement](/blog/2021/09/02/front-commerce-2.8/#Summer-backlog-cleaning), we’ve released patch versions for the 5 minor versions released in 2021.
+As promised [in the 2.8 announcement](/blog/2021/07/22/front-commerce-2.8/#Summer-backlog-cleaning), we’ve released patch versions for the 5 minor versions released in 2021.
 It allows customers to update their project without waiting for a minor version upgrade.
 Each release contains bugfixes fixed in later minor versions.
 

--- a/source/_posts/prototype-ecommerce-applications-with-front-commerce-lite.md
+++ b/source/_posts/prototype-ecommerce-applications-with-front-commerce-lite.md
@@ -71,7 +71,7 @@ In case you want to understand step by step what is happening or if you
 encounter difficulties to install or launch the project, we are here to learn!
 Time has come to discover our official documentation for developers:
 
-[Install Front-Commerce Lite (developers.front-commerce.com)](https://developers.front-commerce.com/docs/getting-started.html)
+[Install Front-Commerce Lite (developers.front-commerce.com)](/docs/essentials/installation.html)
 
 If you still have troubles with this task, feel free to
 [get in touch with us](https://github.com/front-commerce/front-commerce-lite#get-help)

--- a/source/docs/advanced/performance/cache-control-and-cdn.md
+++ b/source/docs/advanced/performance/cache-control-and-cdn.md
@@ -80,7 +80,7 @@ Once you have enabled `GET` for your GraphQL queries the dispatcher will automat
 
 ## CDN or Reverse proxy configuration
 
-Finally after you have set up the appropriate cache controls for your site you now need to configure a CDN (or a reverse proxy such as Nginx) which will take care of caching pages for users. See [Which CDN providers support stale-while-revalidate?](https://www.ctrl.blog/entry/cdn-rfc5861-support.html) for a list of CDN that supports it. As of 2.6, Front-Commerce requires that the CDN ignores the cache for requests containing a cookie named `connect.sid`. Please refer to your CDN's documentation for more details. **If you are using Front-Commerce Cloud, you have nothing to do** unless you changed default values. Please [contact us](support@front-commerce.com) if you need support to enable caching.
+Finally after you have set up the appropriate cache controls for your site you now need to configure a CDN (or a reverse proxy such as Nginx) which will take care of caching pages for users. See [Which CDN providers support stale-while-revalidate?](https://www.ctrl.blog/entry/cdn-rfc5861-support.html) for a list of CDN that supports it. As of 2.6, Front-Commerce requires that the CDN ignores the cache for requests containing a cookie named `connect.sid`. Please refer to your CDN's documentation for more details. **If you are using Front-Commerce Cloud, you have nothing to do** unless you changed default values. Please [contact us](mailto:support@front-commerce.com) if you need support to enable caching.
 
 ## Advanced usage
 

--- a/source/docs/advanced/shipping/add-new-shipping-data-in-graphql.md
+++ b/source/docs/advanced/shipping/add-new-shipping-data-in-graphql.md
@@ -3,9 +3,9 @@ id: add-new-shipping-data-in-graphql
 title: Add a shipping method with pickup points
 ---
 
-In this guide we'll go through the steps needed to retreive pickup points from GraphQL and display them in a Map using Front-Commerce's component. This method can also be useful if you are planning to setup a Store Locator in your shop.
+In this guide we'll go through the steps needed to retrieve pickup points from GraphQL and display them in a Map using Front-Commerce's component. This method can also be useful if you are planning to setup a Store Locator in your shop.
 
-If you are willing to display these pickups in the checkout this guide will help you. However if you are willing to save the needed information in the user's quote, please have a look at [source/docs/advanced/shipping/custom-shipping-information.md](Custom Shipping Information) instead.
+If you are willing to display these pickups in the checkout this guide will help you. However if you are willing to save the needed information in the user's quote, please have a look at [Custom Shipping Information](/docs/advanced/shipping/custom-shipping-information.html) instead.
 
 <blockquote class="feature--new">
 _Since version 2.1.0_

--- a/source/docs/advanced/theme/analytics.md
+++ b/source/docs/advanced/theme/analytics.md
@@ -77,7 +77,7 @@ Additionally, you may wonder what name and properties you should give to your ev
 
 ### Track an event as a React Component
 
-If you don't have an actual callback to put the `trackEvent` (like `onClick`), you can use the `withTrackOnMount` enhancer that will let you call the `trackEvent` using [React lifecycle](<(http://projects.wojtekmaj.pl/react-lifecycle-methods-diagram/)>).
+If you don't have an actual callback to put the `trackEvent` (like `onClick`), you can use the `withTrackOnMount` enhancer that will let you call the `trackEvent` using [React lifecycle](http://projects.wojtekmaj.pl/react-lifecycle-methods-diagram/).
 
 For instance, in Front-Commerce's core, we are using `withTrackOnMount` to track when a user sees their cart.
 
@@ -107,7 +107,7 @@ export default withTrackOnMount({
 <blockquote class="note">
 Please refer to [Analytics React Components](/docs/reference/analytics-components.html#withTrackOnMount) to have a detailed explanation of the API of `withTrackOnMount`.
 
-Note that if you prefer to use render props you can refer to [`TrackOnMount`](docs/reference/analytics-components.html#TrackOnMount).
+Note that if you prefer to use render props you can refer to [`TrackOnMount`](/docs/reference/analytics-components.html#TrackOnMount).
 
 </blockquote>
 
@@ -130,7 +130,7 @@ withTrackPage("Home")(Cart);
 <blockquote class="note">
 Please refer to [Analytics React Components](/docs/reference/analytics-components.html#withTrackPage) to have a detailed explanation of the API of `withTrackPage`.
 
-Note that if you prefer to use render props you can refer to [`TrackPage`](docs/reference/analytics-components.html#TrackPage).
+Note that if you prefer to use render props you can refer to [`TrackPage`](/docs/reference/analytics-components.html#TrackPage).
 
 Moreover, we didn't talk about a `trackPage` method here. This is because a `Page` is tightly coupled to a React Component. This is why you shouldn't need to use `trackPage` directly.
 

--- a/source/docs/appendices/migration-guides.md
+++ b/source/docs/appendices/migration-guides.md
@@ -2426,7 +2426,7 @@ Please note that if in your code, you relied on some int types, there might be c
 
 First things first, if you didn't customize the sitemap, you can skip this section. If you did though, you will need to change the way you customized the Sitemap loader.
 
-Previously, in order to change the sitemap loader, you had to override the default resolver for `Query.sitemap` and add your own nodes to the default ones. From now on, you will instead need to register nodes dynamically. Please follow the [Sitemap guide](/docs/advanced/theme/sitemap.html#Add-your-own-routes-in-the-sitemap) for more details.
+Previously, in order to change the sitemap loader, you had to override the default resolver for `Query.sitemap` and add your own nodes to the default ones. From now on, you will instead need to register nodes dynamically. Please follow the [Sitemap guide](/docs/advanced/production-ready/sitemap.html#Add-your-own-routes-in-the-sitemap) for more details.
 
 ### Caching update
 
@@ -2545,7 +2545,7 @@ We have introduced the mechanism of [Translation Fallback](/docs/advanced/theme/
 
 ### Improved search experience
 
-While working on our compatibility with Magento 2.3, we decided to use [ElasticSuite](https://elasticsuite.io/). Learn more about it in our [announcement](/blog/2019/05/07/release-1.0.0-beta.0/#Improved-search-experience).
+While working on our compatibility with Magento 2.3, we decided to use [ElasticSuite](https://elasticsuite.io/). Learn more about it in our [announcement](/blog/2019/05/13/release-1.0.0-beta.0/#Improved-search-experience).
 
 During this change, we needed to update some parts of the GraphQL schema. If you don't use our implementation, this won't impact you. However, if you do, here is what changed in the schema:
 

--- a/source/docs/appendices/release-notes.md
+++ b/source/docs/appendices/release-notes.md
@@ -443,7 +443,7 @@ Requirements:
 > - Wishlist
 > - Performance
 
-- [Announcement](/blog/2019/05/07/release-1.0.0-beta.0/)
+- [Announcement](/blog/2019/05/13/release-1.0.0-beta.0/)
 - [Migration guide](/docs/appendices/migration-guides.html#1-0-0-alpha-2-gt-1-0-0-beta-0)
 - [Changelog](https://gitlab.com/front-commerce/front-commerce/tags/1.0.0-beta.0)
 

--- a/source/docs/reference/analytics-components.md
+++ b/source/docs/reference/analytics-components.md
@@ -7,7 +7,7 @@ For a tangible example and explanation, please refer to [Analytics](/docs/advanc
 
 ## `withTrackOnMount`
 
-`withTrackPage` is an enhancer that lets you track an event by using [React lifecycle]((http://projects.wojtekmaj.pl/react-lifecycle-methods-diagram/).
+`withTrackPage` is an enhancer that lets you track an event by using [React lifecycle](http://projects.wojtekmaj.pl/react-lifecycle-methods-diagram/).
 
 ```jsx
 import withTrackOnMount from "theme/modules/Analytics/withTrackOnMount";


### PR DESCRIPTION
This fixes a bunch of broken links that were detected while crawling the docs, the only outstanding link is the `https://developers.front-commerce.com/docs/vision.html` which I could not find.

![Google Chrome - Monitoring  Crawler Admin Console 2022-04-20 at 10 22 06](https://user-images.githubusercontent.com/39598117/164184153-5123742b-ec0e-43ae-aba4-470f7129ebdb.png)

