### PR TITLE
fix(config): clarify the use of the httpAuth configuration

### DIFF
--- a/source/docs/reference/configurations.md
+++ b/source/docs/reference/configurations.md
@@ -117,6 +117,10 @@ Thus, if you are indeed behind a proxy, you must make sure that:
 
 By default most proxies are setting either `x-real-ip` or `x-forwarded-for`. So that's a sane default. But if you have some issues retrieving the client's IP, please check that those headers are correctly configured within your proxy.
 
+<blockquote class="note">
+**Note** This setting is used even without enabling basic authentication to pass the client IP to the third party servers.
+</blockquote>
+
 ### `config/hardcodedSitemap.js`
 
 Allows to define static routes within your application that aren't already fetched dynamically from your backend. Each object should match the Sitemapable interface of `src/server/model/store/schema.gql`


### PR DESCRIPTION
# Why

Improved the httpAuth documentation to avoid misunderstanding the way this configuration works as it is not obvious

https://deploy-preview-396--heuristic-almeida-1a1f35.netlify.app/docs/reference/configurations.html#config-httpAuth-js