### PR TITLE
Update PaymentMethodLabel location

### DIFF
--- a/source/docs/advanced/payments/hipay.md
+++ b/source/docs/advanced/payments/hipay.md
@@ -156,8 +156,8 @@ const ComponentMap = {
 6. register the HiPay payment methods labels
 
 ```
-mkdir -p my-module/web/theme/modules/User/Order/OrderMethod/
-cp -u node_modules/front-commerce/src/web/theme/modules/User/Order/OrderMethod/PaymentMethodLabel.js my-module/web/theme/modules/User/Order/OrderMethod/PaymentMethodLabel.js
+mkdir -p my-module/web/theme/modules/Checkout/Payment/
+cp -u node_modules/front-commerce/src/web/theme/modules/Checkout/Payment/PaymentMethodLabel.js my-module/web/theme/modules/Checkout/Payment/PaymentMethodLabel.js
 ```
 
 ```diff


### PR DESCRIPTION
### Why?
The [location](https://gitlab.com/front-commerce/front-commerce/blob/dbb8658bd9b6dcd77253b83f91b0b48d4096e56e/src/web/theme/modules/User/Order/OrderMethod/PaymentMethodLabel.js) has changed