### PR TITLE
chore(prismic): add NullContent documentation

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,3 @@
+# see https://docs.netlify.com/routing/redirects/ for documentation
+/blog/:year/:month/:day/:slug/ /changelog/:slug/ 301
+/blog/ /changelog/ 301

--- a/source/docs/prismic/resolver-cache.md
+++ b/source/docs/prismic/resolver-cache.md
@@ -142,7 +142,7 @@ The issue we will have here is that there is no way creating a reference to the 
 
 The `NullContent` takes in a single parameter, `contentOrDcoumentId`, which is either the Content object that should be cached as `null`, or the direct id to the document parent document.
 
-```js
+```diff
 import NullContent from "prismic/server/domain/NullContent";
 
 const allowList = ["tag1", "tag2"];
@@ -151,11 +151,11 @@ export default {
   Query: {
     tag: PrismicCachedResolver((parent, args, { loaders }) => {
       const tag = loaders.TagLoader.loadById(args.id);
-      return allowList.includes(tag.name) ? tag : NullContent(tag);
+-      return allowList.includes(tag.name) ? tag : null;
++      return allowList.includes(tag.name) ? tag : NullContent(tag);
     }),
   },
 };
-```
 
 The direct id of the document is usefull when the caching is based on the parent of the document, for example when you want to cache the `tag` inside a `Faq` document.
 

--- a/source/docs/prismic/resolver-cache.md
+++ b/source/docs/prismic/resolver-cache.md
@@ -162,8 +162,7 @@ export default {
 The direct id of the document is usefull when the caching is based on the parent of the document, for example when you want to cache the `tag` inside a `Faq` document.
 
 ```js
-const allowList = ["tag1", "tag2"];
-
+...
 export default {
   Fax: {
     tag: PrismicCachedResolver((parent, args, { loaders }) => {
@@ -176,7 +175,6 @@ export default {
     }),
   },
 };
-```
 
 ### Advanced Usecase
 

--- a/source/docs/prismic/resolver-cache.md
+++ b/source/docs/prismic/resolver-cache.md
@@ -121,7 +121,9 @@ export default {
 
 ### NullContent
 
-The `NullContent` has been introduced to allow caching of resolvers that return `null`, lets say that you return a tag based on an id, but you only want to return the tags which are in the allow list, in this case, we will return `null` for the tags that are not in the allow list.
+The `NullContent` has been introduced to allow caching of resolvers that return `null`.
+
+Lets say that you return a tag based on an id, but you only want to return the tags which are in the allow list, in this case, we will return `null` for the tags that are not in the allow list.
 
 ```js
 const allowList = ["tag1", "tag2"];

--- a/source/docs/prismic/resolver-cache.md
+++ b/source/docs/prismic/resolver-cache.md
@@ -138,7 +138,9 @@ export default {
 };
 ```
 
-The issue we will have here is that there is no way creating a reference to the Tag document in prismic, so we won't be able to know that `tag3` or `tag4` should cache `null`, so we introduced the NullContent to handle this.
+The issue we have here is that there is no way to create a reference to the Tag document in prismic, so we won't be able to know that `tag3` or `tag4` should cache `null`.
+
+The NullContent handles this.
 
 The `NullContent` takes in a single parameter, `contentOrDcoumentId`, which is either the Content object that should be cached as `null`, or the direct id to the document parent document.
 


### PR DESCRIPTION
https://deploy-preview-428--heuristic-almeida-1a1f35.netlify.app/docs/prismic/resolver-cache.html#NullContent