### PR TITLE
fix: missing images on various pages

### DIFF
--- a/docs/advanced/features/quickorder.mdx
+++ b/docs/advanced/features/quickorder.mdx
@@ -22,10 +22,11 @@ import Link from "@docusaurus/Link";
 The `<QuickOrder />` component adds a user interface allowing your customers to
 directly order an item based on its <abbr title="Stock Keeping Unit">SKU</abbr>
 
-<Figure
-  src={require("./assets/Quickorder-sample.png").default}
-  alt="Example with the component added to the default's theme minicart"
-/>
+<Figure>
+
+![Example with the component added to the default's theme minicart](./assets/Quickorder-sample.png)
+
+</Figure>
 
 ## Integrate QuickOrder into your project
 

--- a/docs/advanced/theme/analytics.mdx
+++ b/docs/advanced/theme/analytics.mdx
@@ -639,16 +639,18 @@ First, the `userConsents` configuration option will be pushed to your dataLayer
 as the `userConsents` value. You can reference it from a Variable in GTM. Here
 is an example:
 
-<Figure
-  src={require("./assets/gtm-datalayer-variable.png").default}
-  alt="Screenshot of a GTM Variable configured to expose the user consents"
-/>
+<Figure>
+
+![Screenshot of a GTM Variable configured to expose the user consents](./assets/gtm-datalayer-variable.png)
+
+</Figure>
 
 Then, you can leverage the `UserConsentUpdated` event tracked whenever users
 update their consent preferences. You could create triggers to enable scripts to
 load / remove (depending on the `userConsents` value). Here is an example:
 
-<Figure
-  src={require("./assets/gtm-trigger-example.png").default}
-  alt="Screenshot of a GTM Trigger configured to detect when users gave their consent to a specific integration"
-/>
+<Figure>
+
+![Screenshot of a GTM Trigger configured to detect when users gave their consent to a specific integration](./assets/gtm-trigger-example.png)
+
+</Figure>

--- a/docs/advanced/theme/layouts.mdx
+++ b/docs/advanced/theme/layouts.mdx
@@ -30,10 +30,11 @@ Let's take a Category page.
 
 <!-- TODO - update this figure with theme-chocolatine example? -->
 
-<Figure
-  src={require("./assets/category.png").default}
-  alt="A category page displays the list of the products of the category below the header and the menu."
-/>
+<Figure>
+
+![A category page displays the list of the products of the category below the header and the menu.](./assets/category.png)
+
+</Figure>
 
 The contents that are specific to this Category are the title, the products, the
 facets, etc. The header with the logo and the menu are not specific to the
@@ -48,11 +49,11 @@ the case for the account pages.
 
 <!-- TODO - update this figure with theme-chocolatine example? -->
 
-<Figure
-  src={require("./assets/account.png").default}
-  alt="An account dashboard displays the main layout, but also a navigation common
-  to all the account pages."
-/>
+<Figure>
+
+![An account dashboard displays the main layout, but also a navigation common to all the account pages.](./assets/account.png)
+
+</Figure>
 
 In this case, the sidebar navigation is by definition a layout since it remains
 across the multiple pages available in the account. However, it is contained in

--- a/docs/essentials/adapt-theme-to-your-brand.mdx
+++ b/docs/essentials/adapt-theme-to-your-brand.mdx
@@ -26,11 +26,11 @@ There even exist tools that extract those tokens from existing websites. In this
 example, we will use [CSS Stats](https://cssstats.com/) to extract Design Tokens
 from [Smashing Magazine](https://www.smashingmagazine.com/) and use them later.
 
-<Figure
-  src={require("./assets/smashingmagazine-cssstats.png").default}
-  alt="CSS Stats lists all the 62 colors and 59 unique background colors of Smashing Magazine"
-  caption="Here is an example with the awesome Smashing Magazine website"
-/>
+<Figure caption="Here is an example with the awesome Smashing Magazine website">
+
+![CSS Stats lists all the 62 colors and 59 unique background colors of Smashing Magazine](./assets/smashingmagazine-cssstats.png)
+
+</Figure>
 
 :::info
 

--- a/docs/essentials/add-component-to-storybook.mdx
+++ b/docs/essentials/add-component-to-storybook.mdx
@@ -76,10 +76,11 @@ make it accessible in the Storybook's website under `components` > `molecules`
 navigation, it will display a default story which will show the standard usecase
 of the `IllustratedContent` component.
 
-<Figure
-  src={require("./assets/illustrated-content-story.png").default}
-  alt="Storybook interface with the IllustratedContent's default story selected"
-/>
+<Figure>
+
+![Storybook interface with the IllustratedContent's default story selected](./assets/illustrated-content-story.png)
+
+</Figure>
 
 :::note
 

--- a/docs/essentials/create-a-ui-component.mdx
+++ b/docs/essentials/create-a-ui-component.mdx
@@ -173,11 +173,11 @@ story in `components > molecules > IllustratedContent`.
 Now that you've done that, you can edit the `IllustratedContent` component,
 save, and view changes live in your browser.
 
-<Figure
-  src={require("./assets/demo.gif").default}
-  alt="Demo of Storybook hot reloading"
-  caption="Take a look at this magical development playground!"
-/>
+<Figure caption="Take a look at this magical development playground!">
+
+![Demo of Storybook hot reloading](./assets/demo.gif)
+
+</Figure>
 
 :::info Learn more
 

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "react-slick": "0.29.0",
     "react-twitter-embed": "4.0.4",
     "react-use-intercom": "2.0.0",
-    "tailwindcss": "3.1.8",
-    "type-fest": "2.18.1"
+    "tailwindcss": "3.1.8"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.0.1",

--- a/src/components/Figure.tsx
+++ b/src/components/Figure.tsx
@@ -1,26 +1,17 @@
 import React from "react";
-import type { RequireExactlyOne } from "type-fest";
 
 export type FigureProps = {
-  /** The image URL  */
-  src: string;
-  /** The image Component */
   children: React.ReactNode;
-  /** Defines an alternative text description of the image. */
-  alt?: string;
   /** Represents a caption or legend describing the rest of the contents of its parent */
   caption?: string;
 };
 
 export default function Figure({
-  src,
-  children = null,
-  alt,
+  children,
   caption,
-}: RequireExactlyOne<FigureProps, "src" | "children">) {
+}) {
   return (
     <figure className="text-center py-6">
-      {src && <img src={src} alt={alt} />}
       {children}
       {caption && <figcaption className="text-xs">{caption}</figcaption>}
     </figure>


### PR DESCRIPTION
from support

visible at: https://deploy-preview-457--heuristic-almeida-1a1f35.netlify.app/docs/advanced/theme/analytics#google-tag-manager (bottom of the page) vs. https://developers.front-commerce.com/docs/advanced/theme/analytics#google-tag-manager