### PR TITLE
fix: anchor so that the browser properly scroll to the expected section

### DIFF
--- a/docs/advanced/features/flash-messages.mdx
+++ b/docs/advanced/features/flash-messages.mdx
@@ -24,7 +24,7 @@ Messages can be either a string or an object with the following attributes:
 
 - `message` text
 - `type` key: allows to display a specific component
-  ([see below](#Create-custom-flash-message-components))
+  ([see below](#create-custom-flash-message-components))
 - `data` object: additional data to be passed to the component displayed
 
 :::info Advanced
@@ -75,7 +75,7 @@ Out of the box, Front-Commerce supports the following types:
 
 To override this mechanism and add your own types, you must override the
 `getFlashMessageComponent.js` module. Here is an snippet (from the
-[Adyen payment module documentation](/docs/advanced/payments/adyen#Register-your-Adyen-payment-components)):
+[Adyen payment module documentation](/docs/advanced/payments/adyen#register-your-adyen-payment-components)):
 
 ```shell
 mkdir -p my-module/web/theme/modules/FlashMessages

--- a/docs/advanced/graphql/change-resolver-behavior.mdx
+++ b/docs/advanced/graphql/change-resolver-behavior.mdx
@@ -14,9 +14,9 @@ is generated.
 
 First, you have to create a GraphQL module. For that, you can follow the process
 detailed in the
-[Create a new GraphQL module](/docs/essentials/extend-the-graphql-schema#Create-a-new-GraphQL-module).
+[Create a new GraphQL module](/docs/essentials/extend-the-graphql-schema#create-a-new-graphql-module).
 Don't forget to also to
-[register the module in Front-Commerce](/docs/essentials/extend-the-graphql-schema#Register-the-module-in-the-application).
+[register the module in Front-Commerce](/docs/essentials/extend-the-graphql-schema#register-the-module-in-the-application).
 
 For this example, the `ProductMetaDescription` module containing:
 

--- a/docs/advanced/graphql/dataloaders-and-cache-invalidation.mdx
+++ b/docs/advanced/graphql/dataloaders-and-cache-invalidation.mdx
@@ -122,8 +122,8 @@ resolve data.
 Clearing the cache manually is possible on some of the supported platforms. Read
 dedicated pages for details:
 
-- [Magento 1](/docs/magento1/advanced#Clearing-Front-Commerce-cache)
-- [Magento 2](/docs/magento2/advanced#Clearing-Front-Commerce-cache)
+- [Magento 1](/docs/magento1/advanced#clearing-front-commerce-cache)
+- [Magento 2](/docs/magento2/advanced#clearing-front-commerce-cache)
 <!-- TODO - add BigCommerce and Prismic manual cache clearing backlinks -->
 
 ## What are DataLoaders?
@@ -134,9 +134,9 @@ it is the name of the reference implementation in Javascript:
 [graphql/dataloader](https://github.com/graphql/dataloader).
 
 A DataLoader is instantiated with a **batching function**, that will allow to
-fetch data in a grouped way (see [Batching](#Batching) above). It also has a
+fetch data in a grouped way (see [Batching](#batching) above). It also has a
 caching strategy that prevents fetching the same data twice in the same request
-or across requests (see [Caching](#Caching) above).
+or across requests (see [Caching](#caching) above).
 
 By default every DataLoader provides request-level caching. But this can be
 configured to switch to a persistent caching strategy instead. For instance,
@@ -276,7 +276,7 @@ const fooLoader = makeDataLoader("AcmeFoo")((ids) =>
 
 In some contexts, cache invalidation could be impossible or difficult to
 implement in remote systems. You may still want to leverage Front-Commerce's
-caching features, such as [the Redis persistent cache](#Redis), to improve
+caching features, such as [the Redis persistent cache](#redis), to improve
 performance of your application.
 
 The Redis strategy supports an additional option (to be provided during
@@ -389,7 +389,7 @@ When using 3rd party APIs or legacy systems, such APIs might not always be
 available. Using dataLoaders in this case will not allow you to reduce the
 number of requests in the absolute, however it could still allow you to prevent
 most of these requests (or reduce its number in practice) thanks to
-[caching](#Caching). It is thus very convenient when dealing with a slow
+[caching](#caching). It is thus very convenient when dealing with a slow
 service.
 
 The `makeBatchLoaderFromSingleFetch` allows you to create a batching function
@@ -435,7 +435,7 @@ strategy**. It means that during the same GraphQL query, the same data will only
 be requested once.
 
 Front-Commerce is also shipped with a persistent cache implementation, using a
-Redis strategy (see [Caching strategies](#Caching-strategies)). You can
+Redis strategy (see [Caching strategies](#caching-strategies)). You can
 implement new strategies to support more services (we also can help and support
 more strategies, please <ContactLink />).
 
@@ -579,7 +579,7 @@ The `PerCurrency` implementation is a decorator that is specific to Magento 1
 integrations. It will decorate the existing caching strategies so that
 DataLoader keys are different depending on the store's currency selected by the
 user. This is only useful if a store has multiple currencies
-([`config/stores.js::availableCurrencies`](/docs/advanced/production-ready/multistore#Multiple-currencies)).
+([`config/stores.js::availableCurrencies`](/docs/advanced/production-ready/multistore#multiple-currencies)).
 It should be used on any DataLoader that returns a price value based on the
 user's session.
 
@@ -654,7 +654,7 @@ relevant.
 Front-Commerce provides several endpoints for it. They respond to `GET` or
 `POST` queries and are secured with a token to be passed in a `auth-token`
 header. The expected token must be configured with the
-[`FRONT_COMMERCE_CACHE_API_TOKEN` environment variable](/docs/reference/environment-variables#Cache).
+[`FRONT_COMMERCE_CACHE_API_TOKEN` environment variable](/docs/reference/environment-variables#cache).
 
 ### `POST` for batched invalidations
 
@@ -687,7 +687,7 @@ below.
 The payload is
 [limited to 1Mb by default](https://gitlab.com/front-commerce/front-commerce/-/blob/2af896b935b2ead5d1ea5b76bc6109b1a3f56ecd/src/server/express/config/expressConfigProvider.js#L10)
 to prevent abuses. You can extend this limit using configurations. See
-["I cannot `POST` a big payload to the server "](/docs/appendices/troubleshooting#I-cannot-POST-a-big-payload-to-the-server)
+["I cannot `POST` a big payload to the server "](/docs/appendices/troubleshooting#i-cannot-post-a-big-payload-to-the-server)
 for a way to define a greater value.
 
 :::
@@ -718,6 +718,6 @@ invalidation logic (for custom Magento entities).
 
 Front-Commerce provides a way to debug several aspects of the caching layer. You
 can use the
-[`DEBUG="front-commerce:cache"` environment variable](/docs/reference/environment-variables#Debugging)
+[`DEBUG="front-commerce:cache"` environment variable](/docs/reference/environment-variables#debugging)
 to view information about caching strategies used for a GraphQL query, along
 with cache invalidation requests received by your Front-Commerce server.

--- a/docs/advanced/graphql/rate-limiting.mdx
+++ b/docs/advanced/graphql/rate-limiting.mdx
@@ -98,7 +98,7 @@ instance).
 
 Front-Commerce allows you to inject a custom store implementation, that will be
 used for all the rate limiting strategies. To do so, you will have to override
-the [`config/rateLimit.js`](/docs/reference/configurations#config-rateLimit-js)
+the [`config/rateLimit.js`](/docs/reference/configurations#config-ratelimit-js)
 configuration file and expose a `store` factory.
 
 Here is how you would replace the default in-memory store with a redis one:

--- a/docs/advanced/graphql/remote-schemas.mdx
+++ b/docs/advanced/graphql/remote-schemas.mdx
@@ -69,7 +69,7 @@ documentation page.
 
 In its current state, this GraphQL module does nothing at all! Let’s update it
 to expose the remote GraphQL schema, by adding a
-[`remoteSchema`](/docs/reference/graphql-module-definition#remoteSchema-optional)
+[`remoteSchema`](/docs/reference/graphql-module-definition#remoteschema-optional)
 key to the module definition.
 
 ```js title="my-module/server/modules/pokemon/index.js"
@@ -192,7 +192,7 @@ headers or content. For instance, you may have to provide an API key in all
 calls or an `Authorization` header to act as the currently logged in Customer.
 
 Front-Commerce allows you to configure the underlying implementation using the
-[`remoteSchema.executor` GraphQL module definition key](/docs/reference/graphql-module-definition#linkContextBuilders-optional).
+[`remoteSchema.executor` GraphQL module definition key](/docs/reference/graphql-module-definition#linkcontextbuilders-optional).
 
 ## Mix local and remote schemas
 

--- a/docs/advanced/graphql/slim-down-resolvers-with-loaders.mdx
+++ b/docs/advanced/graphql/slim-down-resolvers-with-loaders.mdx
@@ -102,7 +102,7 @@ this.
 ### Initial resolvers
 
 For this example, we will reuse loaders from the example used in the
-[Extend the GraphQL schema](/docs/essentials/extend-the-graphql-schema#Implement-resolvers)
+[Extend the GraphQL schema](/docs/essentials/extend-the-graphql-schema#implement-resolvers)
 guide.
 
 Here is the initial code we will refactor:

--- a/docs/advanced/payments/adyen.mdx
+++ b/docs/advanced/payments/adyen.mdx
@@ -19,7 +19,7 @@ There are different ways for you to accept payments with
 
 P.S. No Magento modules are needed if you use this method. If you however want
 to integrate with the Adyen Magento module please refer to
-[Magento2 Integration section](#As-a-Magento2-Integration).
+[Magento2 Integration section](#as-a-magento2-integration).
 
 ### Add the required environment variables
 
@@ -38,18 +38,18 @@ to integrate with the Adyen Magento module please refer to
   Should be configured to contain
   [the Adyen live URL prefix](https://docs.adyen.com/development-resources/live-endpoints#live-url-prefix)
 - `FRONT_COMMERCE_ADYEN_NOTIFICATION_USERNAME` (more on
-  [webhooks below](#Add-webhook)) you create it. You then have to copy it to the
+  [webhooks below](#add-webhook)) you create it. You then have to copy it to the
   webhook section in your Adyen Customer Area under
   `Developers > Webhooks > [your_prefered_webhook] > Authentication > User Name`
 - `FRONT_COMMERCE_ADYEN_NOTIFICATION_PASSWORD` (more on
-  [webhooks below)](#Add-webhook) you create it. You then have to copy it to the
+  [webhooks below)](#add-webhook) you create it. You then have to copy it to the
   webhook section in your Adyen Customer Area under
   `Developers > Webhooks > [your_prefered_webhook] > Authentication > Password`
-- `FRONT_COMMERCE_ADYEN_HMAC_KEY` (more on [webhooks below](#Add-webhook))
+- `FRONT_COMMERCE_ADYEN_HMAC_KEY` (more on [webhooks below](#add-webhook))
   create it from the webhook section in your Adyen Customer Area under
   `Developers > Webhooks > [your_prefered_webhook] > Additional Settings > HMAC key`
 - `FRONT_COMMERCE_ADYEN_PREVIOUS_HMAC_KEY` (more on
-  [webhooks below](#Add-webhook)) when you regenerate your HMAC key configure
+  [webhooks below](#add-webhook)) when you regenerate your HMAC key configure
   this to be the old one
 - `FRONT_COMMERCE_ADYEN_STORE_PAYMENT_DETAILS` Boolean (more on
   [Adyen's Stored Payment Methods](#enable-adyens-stored-payment-methods-optional-1)).
@@ -186,7 +186,7 @@ support new extension points for Payments.
    ```
 
 5. register
-   [custom Flash message components](/docs/advanced/features/flash-messages#Create-custom-flash-message-components)
+   [custom Flash message components](/docs/advanced/features/flash-messages#create-custom-flash-message-components)
    to display payment messages in an optimized way (**recommended**)
 
    ```shell

--- a/docs/advanced/payments/custom-payment-information.mdx
+++ b/docs/advanced/payments/custom-payment-information.mdx
@@ -96,7 +96,7 @@ has an `AdditionalDataComponent` registered.
 - [x] If `AdditionalDataComponent` has been registered, you should then override
       the `AdditionalDataComponent` and add your custom modifications.
 - [ ] If no `AdditionalDataComponent` is registered, you can then follow the
-      [Display a custom input for a payment method](#Display-a-custom-input-for-a-payment-method)
+      [Display a custom input for a payment method](#display-a-custom-input-for-a-payment-method)
       docs.
 
 ## Adding a field to all payment methods

--- a/docs/advanced/payments/front-commerce-payments.mdx
+++ b/docs/advanced/payments/front-commerce-payments.mdx
@@ -24,18 +24,18 @@ These payment methods are also aimed at being as frictionless as possible for
 Customers, so payment inputs are usually embedded in the checkout page to
 prevent redirecting Customers to third-party providers. Per their nature follow
 the
-[Direct Order payment workflow](/docs/advanced/payments/payment-workflows#Direct-Order).
+[Direct Order payment workflow](/docs/advanced/payments/payment-workflows#direct-order).
 
 ## Supported Payment platforms
 
 Front-Commerce Payments are currently available for the platforms below, learn
 how to install each one of them from the related documentation page:
 
-- [Stripe](/docs/advanced/payments/stripe#Front-Commerce-Payment)
-- [Paypal](/docs/advanced/payments/paypal#Front-Commerce-Payment)
-- [PayZen](/docs/advanced/payments/payzen#Front-Commerce-Payment)
-- [Ingenico](/docs/advanced/payments/ingenico#Front-Commerce-Payment)
-- [BuyBox](/docs/advanced/payments/buybox#Front-Commerce-Payment)
+- [Stripe](/docs/advanced/payments/stripe#front-commerce-payment)
+- [Paypal](/docs/advanced/payments/paypal#front-commerce-payment)
+- [PayZen](/docs/advanced/payments/payzen#front-commerce-payment)
+- [Ingenico](/docs/advanced/payments/ingenico#front-commerce-payment)
+- [BuyBox](/docs/advanced/payments/buybox#front-commerce-payment)
 - [Adyen](/docs/advanced/payments/adyen)
 
 :::info
@@ -73,7 +73,7 @@ Front-Commerce allows you to implement your own payment method. New embedded
 payment methods have to be registered from a GraphQL module. Let’s create a new
 "PWAy" payment module for a fictive payment provider.
 
-1. [create a new GraphQL module](/docs/essentials/extend-the-graphql-schema#Create-a-new-GraphQL-module)
+1. [create a new GraphQL module](/docs/essentials/extend-the-graphql-schema#create-a-new-graphql-module)
 2. add a depency upon `"Magento2/Checkout"`
 
    ```js

--- a/docs/advanced/payments/hipay.mdx
+++ b/docs/advanced/payments/hipay.mdx
@@ -146,7 +146,7 @@ support new extension points for Payments.
    ```
 
 5. register
-   [custom Flash message components](/docs/advanced/features/flash-messages#Create-custom-flash-message-components)
+   [custom Flash message components](/docs/advanced/features/flash-messages#create-custom-flash-message-components)
    to display payment messages in an optimized way (**recommended**)
 
    ```shell

--- a/docs/advanced/payments/ingenico.mdx
+++ b/docs/advanced/payments/ingenico.mdx
@@ -42,7 +42,7 @@ to create payments.
 :::caution WIP
 
 See
-[Ogone related environment variables](/docs/reference/environment-variables#Ogone)
+[Ogone related environment variables](/docs/reference/environment-variables#ogone)
 for information.
 
 :::

--- a/docs/advanced/payments/payment-on-account.mdx
+++ b/docs/advanced/payments/payment-on-account.mdx
@@ -29,7 +29,7 @@ This feature is directly provided by Adobe Commerce. Please refer to
 #### Enable the B2B module
 
 First, you need to
-[enable and integrate the Front-Commerce B2B module for Magento2](/docs/magento2/b2b#Enable-B2B-support).
+[enable and integrate the Front-Commerce B2B module for Magento2](/docs/magento2/b2b#enable-b2b-support).
 
 #### Register the Payment on account payment component
 

--- a/docs/advanced/payments/payzen.mdx
+++ b/docs/advanced/payments/payzen.mdx
@@ -50,7 +50,7 @@ only differences are:
 
 - the `FRONT_COMMERCE_PAYZEN_PRODUCT` environment variable (to be set to
   `lyra_collect`)
-- the URLs to use when [updating your CSPs](#Update-your-CSPs) should be
+- the URLs to use when [updating your CSPs](#update-your-csps) should be
   `api.lyra.com` instead of `static.payzen.eu`
 
 ### Configure your environment

--- a/docs/advanced/performance/cache-control-and-cdn.mdx
+++ b/docs/advanced/performance/cache-control-and-cdn.mdx
@@ -147,7 +147,7 @@ values. Please <ContactLink /> if you need support to enable caching.
 ### Customize cache headers per category/product/CMS page
 
 You can have a more fine grained control on your cache headers' configurations
-than the one presented [in the Dynamic Pages above](#Dynamic-Pages). This can be
+than the one presented [in the Dynamic Pages above](#dynamic-pages). This can be
 done in the resolver/loader of the module itself.
 
 For example let us have a look at the resolver of the Magento 2 Categories found

--- a/docs/advanced/performance/preloading-routes.mdx
+++ b/docs/advanced/performance/preloading-routes.mdx
@@ -177,7 +177,7 @@ using the `preload` static property of the component.
 This is why if you have trouble preloading data on one of your custom routes,
 you first need to make sure that the `preload` property is available. If it is
 not, please refer to
-[the first part of this documentation](#How-to-preload-data).
+[the first part of this documentation](#how-to-preload-data).
 
 Additionally, it will also preload the data needed for the layouts around the
 matched route. This means that you can also set a `preload` static property on

--- a/docs/advanced/production-ready/checklist-before-production.mdx
+++ b/docs/advanced/production-ready/checklist-before-production.mdx
@@ -54,7 +54,7 @@ Front-Commerce is aimed at being exposed in HTTPS when in production mode
 (`NODE_ENV === "production"`). It will redirect users to an HTTPS url if they
 try to access a page using HTTP. Cookies are also set with secure mode. If you
 want to overcome this limitation (which we don’t recommend!), you may use the
-[`FRONT_COMMERCE_UNSAFE_INSECURE_MODE` environment variable](/docs/reference/environment-variables#Host).
+[`FRONT_COMMERCE_UNSAFE_INSECURE_MODE` environment variable](/docs/reference/environment-variables#host).
 
 :::
 

--- a/docs/advanced/production-ready/media-middleware.mdx
+++ b/docs/advanced/production-ready/media-middleware.mdx
@@ -39,7 +39,7 @@ This method has two advantages:
 
 This section explains how to use Magento's default proxy. To create your own
 one, refer to the
-[Add your own media proxy endpoint](#Add-your-own-media-proxy-endpoint) section
+[Add your own media proxy endpoint](#add-your-own-media-proxy-endpoint) section
 below.
 
 :::
@@ -350,7 +350,7 @@ user. In the example below, it is the `transformImageBuffer` function that does
 all the heavy lifting.
 
 Here is an example of how an
-[additional route to register in your application](/docs/advanced/server/add-http-endpoint#Register-additional-routes)
+[additional route to register in your application](/docs/advanced/server/add-http-endpoint#register-additional-routes)
 could be implemented:
 
 ```js
@@ -436,7 +436,7 @@ your catalog and put them in cache. It launches a warmup of your image caches
 that you could use before a deployment or with a cron every night.
 
 Documentation about this script is available in the
-[`scripts/imageWarmUp.js` reference page](/docs/reference/scripts#imageWarmUp-js).
+[`scripts/imageWarmUp.js` reference page](/docs/reference/scripts#imagewarmup-js).
 
 ## Ignore caching through a regular expression
 

--- a/docs/advanced/production-ready/sitemap.mdx
+++ b/docs/advanced/production-ready/sitemap.mdx
@@ -49,7 +49,7 @@ query Sitemap {
 This query will be run for each store available in your `config/stores.js` file.
 
 If the request does not work, please make sure that the environment variable
-[`FRONT_COMMERCE_SITEMAP_TOKEN`](/docs/reference/environment-variables#Sitemap)
+[`FRONT_COMMERCE_SITEMAP_TOKEN`](/docs/reference/environment-variables#sitemap)
 is available when running your script.
 
 The result of this query will then be transformed in xml files that are
@@ -71,7 +71,7 @@ through a cron to ensure that the sitemap is up to date.
 By default the sitemap will contain nodes that have been registered by modules
 declared in your Front-Commerce application. For instance, if you have
 registered a `server/modules/magento2` module in your
-[`.front-commerce.js`'s `serverModules` key](/docs/reference/front-commerce-js#serverModules),
+[`.front-commerce.js`'s `serverModules` key](/docs/reference/front-commerce-js#servermodules),
 you should have categories, products and CMS pages available in your sitemap.
 
 However, if you need to setup your own routes, you will need to register your

--- a/docs/advanced/server/configurations.mdx
+++ b/docs/advanced/server/configurations.mdx
@@ -112,7 +112,7 @@ See the sections below to understand what each key stands for.
 
 The identifier of the configuration provider. This is needed for configuration
 providers' registration. See
-[Register a configuration provider](#Register-a-configuration-provider) for more
+[Register a configuration provider](#register-a-configuration-provider) for more
 details.
 
 ```js
@@ -143,7 +143,7 @@ these keys:
   used as the value. If none is given, the configuration won't be configurable
   by environment. Please keep in mind that environment variables should still
   match
-  [Front-Commerce's naming convention](/docs/reference/environment-variables#Add-your-own-environment-variables).
+  [Front-Commerce's naming convention](/docs/reference/environment-variables#add-your-own-environment-variables).
 
 Thus, if we want to define a configuration named `serviceKey` available in
 `req.config.serviceKey` that would take its value from the environment variable
@@ -335,7 +335,7 @@ export default {
 ```
 
 It is also common to register a configuration provider from
-[an express middleware](/docs/advanced/server/add-http-endpoint#Add-a-global-server-middleware)
+[an express middleware](/docs/advanced/server/add-http-endpoint#add-a-global-server-middleware)
 for cases where the corresponding configuration is used in several places in the
 application.
 

--- a/docs/advanced/server/customize-response-http-headers.mdx
+++ b/docs/advanced/server/customize-response-http-headers.mdx
@@ -40,7 +40,7 @@ For instance, here is how you can to set
 [the `Referer-Policy` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy)
 to `origin-when-cross-origin`:
 
-1. [create module and add a `server/module.config.js` to declare a global server middleware](/docs/advanced/server/add-http-endpoint#Add-a-global-server-middleware).
+1. [create module and add a `server/module.config.js` to declare a global server middleware](/docs/advanced/server/add-http-endpoint#add-a-global-server-middleware).
    This file would look like:
 
    ```js title="server/module.config.js"

--- a/docs/advanced/shipping/add-new-shipping-data-in-graphql.mdx
+++ b/docs/advanced/shipping/add-new-shipping-data-in-graphql.mdx
@@ -26,7 +26,7 @@ instead.
 To go through this guide, you'll need to have a created a
 [new GraphQL module](/docs/essentials/extend-the-graphql-schema) and to know how
 to
-[fetch data in a component](/docs/essentials/create-a-business-component#Fetching-our-data).
+[fetch data in a component](/docs/essentials/create-a-business-component#fetching-our-data).
 
 :::
 

--- a/docs/advanced/theme/analytics.mdx
+++ b/docs/advanced/theme/analytics.mdx
@@ -154,11 +154,11 @@ export default withTrackOnMount({
 :::note
 
 Please refer to
-[Analytics React Components](/docs/reference/analytics-components#withTrackOnMount)
+[Analytics React Components](/docs/reference/analytics-components#withtrackonmount)
 to have a detailed explanation of the API of `withTrackOnMount`.
 
 Note that if you prefer to use render props you can refer to
-[`TrackOnMount`](/docs/reference/analytics-components#TrackOnMount).
+[`TrackOnMount`](/docs/reference/analytics-components#trackonmount).
 
 :::
 
@@ -184,11 +184,11 @@ withTrackPage("Home")(Cart);
 :::note
 
 Please refer to
-[Analytics React Components](/docs/reference/analytics-components#withTrackPage)
+[Analytics React Components](/docs/reference/analytics-components#withtrackpage)
 to have a detailed explanation of the API of `withTrackPage`.
 
 Note that if you prefer to use render props you can refer to
-[`TrackPage`](/docs/reference/analytics-components#TrackPage).
+[`TrackPage`](/docs/reference/analytics-components#trackpage).
 
 Moreover, we didn't talk about a `trackPage` method here. This is because a
 `Page` is tightly coupled to a React Component. This is why you shouldn't need

--- a/docs/advanced/theme/form.mdx
+++ b/docs/advanced/theme/form.mdx
@@ -137,7 +137,7 @@ the email field like this:
 Please note that if the value changes during the rendering of the component,
 this will reset the value displayed in the input. However it won't reset the
 input state. Please refer to
-[Reset a form after its submission](#Reset-a-form-after-its-submission) for a
+[Reset a form after its submission](#reset-a-form-after-its-submission) for a
 detailed explanation.
 
 ### Nested inputs

--- a/docs/advanced/theme/layouts.mdx
+++ b/docs/advanced/theme/layouts.mdx
@@ -20,7 +20,7 @@ it, please first refer to the guide
 [Add a new page](/docs/essentials/add-a-page-client-side). Moreover, to complete
 this guide about layouts, you will need to have a module correctly setup in your
 project with a
-[web module preconfigured](/docs/essentials/add-a-page-client-side#Declare-your-module-as-a-web-module).
+[web module preconfigured](/docs/essentials/add-a-page-client-side#declare-your-module-as-a-web-module).
 
 ## What is a layout?
 
@@ -182,7 +182,7 @@ Remember to restart your application to see the changes (`npm run start`).
 You can't create an `_inner-layout.js` if a `_layout.js` file already exists at
 the same level. This is the case for the files in _your_ modules but also for
 files in other's modules. However you can use
-[`front-commerce-prepare.js:onCreateRoute`](/docs/reference/front-commerce-prepare#onCreateRoute)
+[`front-commerce-prepare.js:onCreateRoute`](/docs/reference/front-commerce-prepare#oncreateroute)
 to filter the file you don't need in your project.
 
 :::

--- a/docs/advanced/theme/route-dispatcher.mdx
+++ b/docs/advanced/theme/route-dispatcher.mdx
@@ -237,7 +237,7 @@ your GraphQL datatype to a custom component.
 To do so, you need to create the `my-module/web/moduleRoutes.js` file in your
 module that will contain the mapping. You might have already created it if you
 followed the
-[Add a new page](/docs/essentials/add-a-page-client-side#Map-the-URL-to-the-page-component)
+[Add a new page](/docs/essentials/add-a-page-client-side#map-the-url-to-the-page-component)
 guide. But instead of using the default export, you will need to export a named
 object `dispatchedRoutes`.
 

--- a/docs/advanced/theme/server-side-rendering.mdx
+++ b/docs/advanced/theme/server-side-rendering.mdx
@@ -18,7 +18,7 @@ Front-Commerce uses <abbr title="Server Side Rendering">SSR</abbr> (opposed to
 <abbr title="User experience">UX</abbr> by serving
 <abbr title="Hypertext Markup Language">HTML</abbr> pages to users on their
 first hit to the server. You can read [A typical request in
-Front-Commerce](/docs/concepts/architecture-overview#A-typical-request-in-Front-Commerce)
+Front-Commerce](/docs/concepts/architecture-overview#a-typical-request-in-front-commerce)
 to get a better understanding of this process.
 
 To generate this HTML page, Front-Commerce will render the React application as
@@ -137,7 +137,7 @@ export default withIsServer()(MyIsomorphicComponent);
 In order to reduce the amount of Javascript sent to users, we've found that code
 using `branchServerClient()` are often good candidates to code splitting. You
 may consider using a `loadable()` component here. You can use
-[`DEBUG="front-commerce:webpack"`](/docs/reference/environment-variables#Debugging)
+[`DEBUG="front-commerce:webpack"`](/docs/reference/environment-variables#debugging)
 to analyze your bundles and decide wether it would improve your application or
 not.
 
@@ -185,7 +185,7 @@ for implementation details and <ContactLink /> if you think of any improvements.
 
 During <abbr title="Server Side Rendering">SSR</abbr> you might face some errors
 (syntax errors,
-[browser API usage](/docs/advanced/theme/server-side-rendering#There-is-no-window-on-the-server),
+[browser API usage](/docs/advanced/theme/server-side-rendering#there-is-no-window-on-the-server),
 render errors, etc.). By default in dev mode, Front-Commerce provides an error
 page that makes the mistake obvious to allow you to fix it as early as possible.
 
@@ -197,7 +197,7 @@ another visual waiting page to users while the application is being rendered
 client side.**
 
 If you still want to display the `theme/pages/SsrFallback` page in dev mode,
-[add `FRONT_COMMERCE_DEV_SSR_FALLBACK_DISABLE=true` to your environment variables](/docs/reference/environment-variables#DX).
+[add `FRONT_COMMERCE_DEV_SSR_FALLBACK_DISABLE=true` to your environment variables](/docs/reference/environment-variables#dx).
 
 ## Restrictions on pages that will be server-rendered
 

--- a/docs/advanced/theme/wysiwyg-platform.mdx
+++ b/docs/advanced/theme/wysiwyg-platform.mdx
@@ -66,7 +66,7 @@ we'll look into implementing it.
 - `<style>` tags are transformed to support
   [Magento's Page Builder](/docs/magento2/page-builder) format. The `#html-body`
   selector is replaced with the `<WysiwygV2>` root selector. See
-  [WYSIWYG dynamic styles](/docs/advanced/theme/wysiwyg#Dynamic-styles) for
+  [WYSIWYG dynamic styles](/docs/advanced/theme/wysiwyg#dynamic-styles) for
   details.
 
 ### Add a custom Magento Widget
@@ -200,5 +200,5 @@ The PrismicWysiwyg allows you to display
 [Rich Text](https://prismic.io/docs/core-concepts/edit-rich-text) content from
 Prismic in your front-end, it handles addition fields like Embed fields and
 media links. To learn more of the PrismicWysiwyg usage, please refer to the
-[Configure the PrismicWysiwyg](/docs/prismic/installation#Optional-Configure-the-PrismicWysiwyg)
+[Configure the PrismicWysiwyg](/docs/prismic/installation#optional-configure-the-prismicwysiwyg)
 installation guide.

--- a/docs/advanced/theme/wysiwyg/README.mdx
+++ b/docs/advanced/theme/wysiwyg/README.mdx
@@ -148,7 +148,7 @@ previous section, we've mentioned the type `MagentoWysiwyg`. It uses the exact
 same mechanisms as the one we will describe below.
 
 If you want to customize `MagentoWysiwyg` instead, please refer to
-[the next section](/docs/advanced/theme/wysiwyg-platform#MagentoWysiwyg).
+[the next section](/docs/advanced/theme/wysiwyg-platform#magentowysiwyg).
 
 #### Register your widget type at the GraphQL level
 

--- a/docs/appendices/migration-guides/archives.mdx
+++ b/docs/appendices/migration-guides/archives.mdx
@@ -136,7 +136,7 @@ These new features may be relevant for your existing application:
   specific `front-commerce:prismic:cache` debug flag allows you to view usage
   information. The new`FRONT_COMMERCE_PRISMIC_API_CACHE_TTL_IN_SECONDS`
   environment variable allows to change
-  [the default TTL configuration](/docs/prismic/installation#Configure-the-environment-for-Prismic).
+  [the default TTL configuration](/docs/prismic/installation#configure-the-environment-for-prismic).
 - New logger dedicated to payments. If you maintain a custom Front-Commerce
   payment implementation you might want to use the new
   `loaders.Payment.getLogger()` method to inject this logger instead of using
@@ -147,7 +147,7 @@ These new features may be relevant for your existing application:
 ### Ensure your pages will be rendered server side
 
 We've added a guard to ensure that Server Side Rendering
-[is only tried for relevant pages](/docs/advanced/theme/server-side-rendering#Restrictions-on-pages-that-will-be-server-rendered).
+[is only tried for relevant pages](/docs/advanced/theme/server-side-rendering#restrictions-on-pages-that-will-be-server-rendered).
 Front-Commerce will now only render pages on the server for URLs that have **no
 extension** or the `.html` extension.
 
@@ -159,7 +159,7 @@ please <ContactLink />.
 These new features may be relevant for your existing application:
 
 - reduce CPU usage by
-  [deactivating response compression](/docs/advanced/performance/deactivating-unnecessary-features#Deactivate-response-compression)
+  [deactivating response compression](/docs/advanced/performance/deactivating-unnecessary-features#deactivate-response-compression)
 
 ## `2.6.0` -> `2.7.0`
 
@@ -317,7 +317,7 @@ payment form assets. **Please do a test payment to ensure that everything is
 working as expected**.
 
 If you are using Lyra Collect, use the `api.lyra.com` value as per
-[our documentation](/docs/advanced/payments/payzen#Lyra-Collect-supportq)
+[our documentation](/docs/advanced/payments/payzen#lyra-collect-support)
 
 #### `PayzenEmbeddedQuery` query update
 
@@ -544,7 +544,7 @@ recommended to use the `<WishlistProvider>` to handle wishlist related tasks
 behaviour of Front-Commerce since 2.6.0. So if you started with Front-Commerce
 at or after 2.6.0 you have nothing to worry about. However if you upgraded from
 versions lower than 2.6.0 please refer to the
-[WishlistProvider migration guide](#Wishlist-Provider)
+[WishlistProvider migration guide](#wishlist-provider)
 
 ### Automatic Algolia configuration
 
@@ -565,7 +565,7 @@ Please ensure that you include it in your theme if you customized the bar.
 
 New options were also added in the analytics initialization, which allows you to
 use the user consents in external integrations. We've updated our
-[<abbr title="Google Tag Manager">GTM</abbr> example documentation section](/docs/advanced/theme/analytics#Google-Tag-Manager)
+[<abbr title="Google Tag Manager">GTM</abbr> example documentation section](/docs/advanced/theme/analytics#google-tag-manager)
 to illustrate this.
 
 ### Updated dependencies
@@ -620,7 +620,7 @@ Front-Commerce Cloud customers must update the FCC submodule to version
 ### Default Redis TTL change
 
 We've reduced the default TTL for the
-[Redis application caching strategy](/docs/advanced/graphql/dataloaders-and-cache-invalidation#Redis).
+[Redis application caching strategy](/docs/advanced/graphql/dataloaders-and-cache-invalidation#redis).
 It used to be 10 days, and we reduced it to 23h to ensure cache invalidation
 misses don't impact the store for too long.
 
@@ -864,9 +864,9 @@ these improvements:
 - if your theme contains a list of images but you don't actually know the ratio
   of the final image, you might be interested by the newly introduced
   `placeholderHeight` attribute of images presets (see
-  [the updated `config/images.js` example](/docs/advanced/production-ready/media-middleware#How-to-configure-it))
+  [the updated `config/images.js` example](/docs/advanced/production-ready/media-middleware#how-to-configure-it))
 - ensure you no longer use our 0.x `<ResizedImage>` component
-  ([introduced in 2.0.0-rc.0](#Responsive-images)). The `<Image>` component has
+  ([introduced in 2.0.0-rc.0](#responsive-images)). The `<Image>` component has
   the same API and should work seamlessly.
 
 ### Street lines
@@ -1153,7 +1153,7 @@ configurations are made available through the API.
 If that's not possible, for Magento2 you can manually expose configurations from
 the version `2.0.0` of the module. If you can't upgrade to `2.2.0` then add the
 configuration below
-([as documented in "Using Magento Configuration"](/docs/magento2/using-magento-configuration#Fetch-configurations-from-frontcommerce-storeConfigs-Magento-endpoint)):
+([as documented in "Using Magento Configuration"](/docs/magento2/using-magento-configuration#fetch-configurations-from-frontcommerce-storeconfigs-magento-endpoint)):
 
 ```xml
 <item name="general/region/state_required" xsi:type="string">general/region/state_required</item>
@@ -1355,7 +1355,7 @@ The deprecations introduced in `2.0.0-rc.2` have been removed. Ensure that your
 > to `FRONT_COMMERCE_ES_ALIAS=magento2` in your `.env` file (the `_default` will
 > be appended from your `stores.js` configuration). It is important to
 > acknowledge
-> [Elasticsearch related changes from our previous release](#Elasticsearch-related-changes)
+> [Elasticsearch related changes from our previous release](#elasticsearch-related-changes)
 > if you are upgrading from an earlier version.
 
 ### GraphQL Dataloaders: `loadMany()` change
@@ -1489,7 +1489,7 @@ been renamed and subtle low-level behavior changes were introduced (required
 errors by default in errors etc…).
 
 **If you were using
-[Front-Commerce's wrappers introduced in 2.0.0-rc.0](/docs/appendices/migration-guides#Abstract-Formsy)
+[Front-Commerce's wrappers introduced in 2.0.0-rc.0](/docs/appendices/migration-guides#abstract-formsy)
 you might not encounter any issues**. Otherwise, we recommend to refactor your
 code to use them!
 
@@ -1793,7 +1793,7 @@ Here the list of the main updates you need to be concerned about:
 - [formsy-react](https://github.com/formsy/formsy-react): `0.20.1` -> `1.1.5` It
   should be compatible. However you will have warnings if you use
   `formsy-react-2`. Simply rename it to `formsy-react`. Please have a look at
-  the [Abstract Formsy section](#Abstract-Formsy) below to learn about broader
+  the [Abstract Formsy section](#abstract-formsy) below to learn about broader
   changes regarding the form inputs.
 - [react-helmet](https://github.com/nfl/react-helmet) ->
   [react-helmet-async](https://github.com/staylor/react-helmet-async) It should
@@ -1883,7 +1883,7 @@ endpoint. However, in your production environment you will still see the image.
 :::note
 
 This release also contain a utility library that makes
-[adding your own media proxy](/docs/advanced/production-ready/media-middleware#Add-your-own-media-proxy-endpoint)
+[adding your own media proxy](/docs/advanced/production-ready/media-middleware#add-your-own-media-proxy-endpoint)
 a breeze. Please read the related documentation to know more.
 
 :::
@@ -1903,7 +1903,7 @@ users. The second change is that you can decide to opt-out of `Formsy` any time
 by passing an `onChange` property directly.
 
 For more information, please have a look at
-[how to create new input types](/docs/advanced/theme/form#New-input-types).
+[how to create new input types](/docs/advanced/theme/form#new-input-types).
 
 For existing projects, the goal would be to replace `formsy-react`'s HOC by
 `withFormHandlers`. The best way to migrate components you have overriden in
@@ -2078,7 +2078,7 @@ Previously, in order to change the sitemap loader, you had to override the
 default resolver for `Query.sitemap` and add your own nodes to the default ones.
 From now on, you will instead need to register nodes dynamically. Please follow
 the
-[Sitemap guide](/docs/advanced/production-ready/sitemap#Add-your-own-routes-in-the-sitemap)
+[Sitemap guide](/docs/advanced/production-ready/sitemap#add-your-own-routes-in-the-sitemap)
 for more details.
 
 ### Caching update
@@ -2092,10 +2092,10 @@ use the previous format but is backward-compatible.
 
 This refactoring allowed us to leverage strategies decorators to implement
 something that Magento store owners will appreciate: a
-[`PerMagentoCustomerGroup` caching implementation](/docs/advanced/graphql/dataloaders-and-cache-invalidation#PerMagentoCustomerGroup).
+[`PerMagentoCustomerGroup` caching implementation](/docs/advanced/graphql/dataloaders-and-cache-invalidation#permagentocustomergroup).
 We now recommend Magento 1 and Magento 2 users to cache all dataLoaders in a
 persistent cache (such as
-[Redis](/docs/advanced/graphql/dataloaders-and-cache-invalidation#Redis)), with
+[Redis](/docs/advanced/graphql/dataloaders-and-cache-invalidation#redis)), with
 the `PerMagentoCustomerGroup` strategy for the `CatalogPrice` dataLoader.
 
 Here is how it would look:
@@ -2142,7 +2142,7 @@ mode using the `http` protocol will automatically redirect to `https`.
 If you experience issues after the upgrade, here are the things to ensure:
 
 - start the application with the
-  [`FRONT_COMMERCE_UNSAFE_INSECURE_MODE`](/docs/reference/environment-variables#Front-Commerce-related-variables)
+  [`FRONT_COMMERCE_UNSAFE_INSECURE_MODE`](/docs/reference/environment-variables#front-commerce-related-variables)
   set to `true` to see if that solves your issue
 - if the above manipulation worked, ensure that your proxy (if any) forwards the
   protocol using the `X-Forwarded-Proto` HTTP header
@@ -2177,7 +2177,7 @@ methods.
 If you had a custom remote schema stitching module with Magento 2, you could
 reuse the authentication middleware from Front-Commerce to access resources
 under the currently logged in user by leveraging the
-[new HTTP headers customization feature](/docs/advanced/graphql/remote-schemas#Customize-remote-HTTP-requests).
+[new HTTP headers customization feature](/docs/advanced/graphql/remote-schemas#customize-remote-http-requests).
 
 Here is how it might look:
 
@@ -2221,7 +2221,7 @@ the latest beta in your Magento project.
 :::info Important
 
 **IMPORTANT:** please ensure to keep your
-[`FRONT_COMMERCE_MAGENTO_MODULE_VERSION`](/docs/reference/environment-variables#Magento-2)
+[`FRONT_COMMERCE_MAGENTO_MODULE_VERSION`](/docs/reference/environment-variables#magento-2)
 up-to-date in the `.env` file of your Front-commerce application. It should now
 be `1.0.0-beta`.
 
@@ -2230,14 +2230,14 @@ be `1.0.0-beta`.
 ### Translations
 
 We have introduced the mechanism of
-[Translation Fallback](/docs/advanced/theme/translations#Translations-fallback).
+[Translation Fallback](/docs/advanced/theme/translations#translations-fallback).
 This is means that you will have fewer conflicts during next upgrades.
 
 ### Improved search experience
 
 While working on our compatibility with Magento 2.3, we decided to use
 [ElasticSuite](https://elasticsuite.io/). Learn more about it in our
-[announcement](/changelog/release-1.0.0-beta.0/#Improved-search-experience).
+[announcement](/changelog/release-1.0.0-beta.0/#improved-search-experience).
 
 During this change, we needed to update some parts of the GraphQL schema. If you
 don't use our implementation, this won't impact you. However, if you do, here is
@@ -2312,7 +2312,7 @@ at the moment.
   environment variables. To ensure that you have the newest behavior, please set
   `FRONT_COMMERCE_USE_SERVER_DYNAMIC_ENV=true`. To keep the deprecated one,
   please use `FRONT_COMMERCE_USE_SERVER_DYNAMIC_ENV=false`. See
-  [How to update environment variables](/docs/reference/environment-variables#How-to-update-environment-variables).
+  [How to update environment variables](/docs/reference/environment-variables#how-to-update-environment-variables).
 - While upgrading the search behavior, we have also changed deprecated the
   `search.blacklistKeys` configuration in `config/website.js`. This now should
   be `search.ignoredAttributeKeys` which is less offensive and more explicit.

--- a/docs/appendices/migration-guides/index.mdx
+++ b/docs/appendices/migration-guides/index.mdx
@@ -546,7 +546,7 @@ Support for shareable downloadable products was added. There is now a new page
 under the user account `/user/downloadable-products` that lists all the
 downloadable products of the current user.
 
-P.S. The [withFlashMessage](#withFlashMessages-now-exports-hooks) update is
+P.S. The [withFlashMessage](#withflashmessages-now-exports-hooks) update is
 required for the downloadable product page.
 
 To add a link to the downloadable products in the account navigation please
@@ -604,11 +604,11 @@ following modules, please do update your CSPs accordingly in your
 `config/website.js` configuration:
 
 - `Google Analytics` or `Google Tag Manager` (see
-  [analytics configuration](/docs/advanced/theme/analytics#Universal-Analytics-Google-Analytics))
+  [analytics configuration](/docs/advanced/theme/analytics#universal-analytics-google-analytics))
 - `Paypal` (see
-  [Paypal configuration](/docs/advanced/payments/paypal#Update-your-CSPs))
+  [Paypal configuration](/docs/advanced/payments/paypal#update-your-csps))
 - `Payzen` (see
-  [Payzen configuration](/docs/advanced/payments/payzen#Update-your-CSPs))
+  [Payzen configuration](/docs/advanced/payments/payzen#update-your-csps))
 
 ### Removed deprecations in `Button` component
 
@@ -697,20 +697,20 @@ const isCompanyUser = (user) => {
 
 ### New features in `2.14.0`
 
-- [Custom routable pages now supports dynamic GraphQL variables from URL](/docs/advanced/theme/route-dispatcher#Advanced-queries)
-- [New `FRONT_COMMERCE_GRAPHQL_PERSISTED_QUERIES_DISABLE` environment variable for temporarily deactivating the GraphQL Persisted Queries feature](/docs/reference/environment-variables#Server)
+- [Custom routable pages now supports dynamic GraphQL variables from URL](/docs/advanced/theme/route-dispatcher#advanced-queries)
+- [New `FRONT_COMMERCE_GRAPHQL_PERSISTED_QUERIES_DISABLE` environment variable for temporarily deactivating the GraphQL Persisted Queries feature](/docs/reference/environment-variables#server)
 - New Prismic module features:
-  - Support for [trailing slashes](/docs/prismic/routable-types#Trailing-Slash)
-  - Support for [path rewrites](/docs/prismic/routable-types#Path-Rewrites)
+  - Support for [trailing slashes](/docs/prismic/routable-types#trailing-slash)
+  - Support for [path rewrites](/docs/prismic/routable-types#path-rewrites)
   - Exposed the `url` to the
     [Content type](https://gitlab.com/front-commerce/front-commerce-prismic/-/blob/main/prismic/server/modules/prismic/core/loaders/Content.js)
 
 :::note
 
 When a Prismic document has been registered using the
-[`registerRoutableType`](/docs/prismic/routable-types#registerRoutableType-options)
+[`registerRoutableType`](/docs/prismic/routable-types#registerroutabletype-options)
 method or the
-[`registerPrismicRoute`](/docs/prismic/routable-types#registerPrismicRoute-options)
+[`registerPrismicRoute`](/docs/prismic/routable-types#registerprismicroute-options)
 method, A `url` property is exposed in the
 [Content type object](https://gitlab.com/front-commerce/front-commerce-prismic/-/blob/main/prismic/server/modules/prismic/core/loaders/Content.js).
 This property contains the resolved url of the document.
@@ -913,8 +913,8 @@ const keyToComponent = {
 
 These new features may be relevant for your existing application:
 
-- [Search for products, categories and pages with Algolia in Magento2 based project](/docs/magento2/search-engine#Algolia)
-- [Search for categories and pages with Algolia in Magento1 based project](/docs/magento1/search-engine#Algolia)
+- [Search for products, categories and pages with Algolia in Magento2 based project](/docs/magento2/search-engine#algolia)
+- [Search for categories and pages with Algolia in Magento1 based project](/docs/magento1/search-engine#algolia)
 - [Prismic Preview](/docs/prismic/preview)
 - [HiPay payment method](/docs/advanced/payments/hipay)
 - [Facebook and Google external logins](/docs/advanced/features/external-logins)
@@ -1554,8 +1554,8 @@ This feature is enabled by default in both in theme Chocolatine and in the base
 theme. **You MUST decide whether you want it or not and follow the related
 instructions below:**
 
-- [Integrating the zoom in feature](#Integrating-the-zoom-in-feature)
-- or [Disabling the zoom in feature](#Disabling-the-zoom-in-feature)
+- [Integrating the zoom in feature](#integrating-the-zoom-in-feature)
+- or [Disabling the zoom in feature](#disabling-the-zoom-in-feature)
 
 #### Disabling the zoom in feature
 
@@ -1606,7 +1606,7 @@ In this version, we have improved the MondialRelay shipping support with
 Magento2 so that a customer can only choose a pickup point suitable for the
 products being ordered. This improvement requires an update of Magentix's module
 to
-[install at least the version 100.10.7](/docs/advanced/shipping/mondial-relay#Integrate-with-Magento2).
+[install at least the version 100.10.7](/docs/advanced/shipping/mondial-relay#integrate-with-magento2).
 
 ### New icons required
 
@@ -1682,7 +1682,7 @@ in them:
 
 In order to support Magento Page Builder's default content types, we have added
 new components to the
-[default `MagentoWysiwyg` transforms](/docs/advanced/theme/wysiwyg-platform#MagentoWysiwyg).
+[default `MagentoWysiwyg` transforms](/docs/advanced/theme/wysiwyg-platform#magentowysiwyg).
 
 See
 [the Page Builder ones](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/WysiwygV2/MagentoWysiwyg/PageBuilder/index.js)
@@ -1724,7 +1724,7 @@ In a nutshell, the Front-Commerce module
 that has been renamed from `mondialrelay` to `magento1-mondialrelay`. So, if you
 are upgrading a Magento1 based project using the MondialRelay module, you have
 to update your `.front-commerce.js` as documented in
-[the MondialRelay guide page](/docs/advanced/shipping/mondial-relay#Integrate-with-Magento1).
+[the MondialRelay guide page](/docs/advanced/shipping/mondial-relay#integrate-with-magento1).
 In addition, if you have custom code importing files from
 `modules/shipping-mondialrelay-magento1`, you will also have to update those
 imports to match the new file layout.
@@ -1737,10 +1737,10 @@ are needed to upgrade your project if you are using this payment platform:
 
 1. the Magento2 Adyen Front-Commerce module has been moved. As a result, you
    have to
-   [update your `.front-commerce.js` as documented in the Adyen integration page](/docs/advanced/payments/adyen#Register-the-Adyen-for-Magento2-payment-module-in-Front-Commerce).
+   [update your `.front-commerce.js` as documented in the Adyen integration page](/docs/advanced/payments/adyen#register-the-adyen-for-magento2-payment-module-in-front-commerce).
 1. the `FRONT_COMMERCE_ADYEN_CLIENT_KEY` environment variable is now required so
    you have
-   [to configure the environment so that it is defined](/docs/advanced/payments/adyen#Add-the-Adyen-client-key-in-the-environment)
+   [to configure the environment so that it is defined](/docs/advanced/payments/adyen#add-the-adyen-client-key-in-the-environment)
 1. we have made some changes and fixes to
    [the Adyen related frontend components](https://gitlab.com/front-commerce/front-commerce/-/tree/2.10.0/modules/payment-adyen/web/theme/modules/Adyen).
    If you have overridden some of those, you have to backport the changes.
@@ -1832,5 +1832,5 @@ and
 These new features may be relevant for your existing application:
 
 - [Front-Commerce is now compatible with the latest Magento2 Adyen plugin](/docs/advanced/payments/adyen)
-- [MondialRelay shipping method support in Magento2](/docs/advanced/shipping/mondial-relay#Integrate-with-Magento2)
+- [MondialRelay shipping method support in Magento2](/docs/advanced/shipping/mondial-relay#integrate-with-magento2)
 - [A new hook to homogenize configurable options handling](/docs/reference/use-selected-product-with-configurable-options)

--- a/docs/appendices/troubleshooting.mdx
+++ b/docs/appendices/troubleshooting.mdx
@@ -82,13 +82,13 @@ project.
 ## SSR is broken
 
 > In Dev mode, I see
-> [the SSR Fallback page](/docs/advanced/theme/server-side-rendering#SSR-Fallback-when-things-go-wrong)
+> [the SSR Fallback page](/docs/advanced/theme/server-side-rendering#ssr-fallback-when-things-go-wrong)
 
 1. check the stdout/stderr of your server and the `/logs` folder, there may be
    useful information
 2. are all pages broken or only some of them?
 3. ensure that there is
-   [no code using browser APIs loaded server side](/docs/advanced/theme/server-side-rendering#There-is-no-window-on-the-server)(e.g:
+   [no code using browser APIs loaded server side](/docs/advanced/theme/server-side-rendering#there-is-no-window-on-the-server)(e.g:
    Google Maps)
 
 ## My JS bundle too big
@@ -169,7 +169,7 @@ export default {
 ```
 
 The provider must then be
-[registered in your application](/docs/advanced/server/configurations#Register-a-configuration-provider)
+[registered in your application](/docs/advanced/server/configurations#register-a-configuration-provider)
 as any other one.
 
 ## The signature is invalid. Verify and try again.
@@ -238,7 +238,7 @@ ElasticSuite version. Front-Commerce will detect it and run queries that match
 the way data are indexed.
 
 _Note: this setting was
-[introduced in Front-Commerce 2.3](/docs/appendices/migration-guides#ElasticSearch-7-x-and-ElasticSuite-2-9)_
+[introduced in Front-Commerce 2.3](/docs/appendices/migration-guides#elasticsearch-7-x-and-elasticsuite-2-9)_
 
 ## I have an error when using Magento 2's GraphQL
 

--- a/docs/bigcommerce/webhooks.mdx
+++ b/docs/bigcommerce/webhooks.mdx
@@ -78,7 +78,7 @@ You are now ready to get started with your webhooks, we have created a
 [BigCommerce Webhook API](https://documenter.getpostman.com/view/16678499/UzQys4QZ)
 in postman to simplify this process, you can hit the `Run in Postman` button and
 simply replace all the relevant variables to get started
-[creating your webhooks](#Creating-a-webhook).
+[creating your webhooks](#creating-a-webhook).
 
 ### Creating a webhook
 

--- a/docs/essentials/add-a-page-client-side.mdx
+++ b/docs/essentials/add-a-page-client-side.mdx
@@ -33,7 +33,7 @@ This system is inspired by JavaScript frameworks like
 [Sapper](https://sapper.svelte.dev/), [Nuxt](https://nuxtjs.org/), etc.
 Implementing routing within Front-Commerce will be easier if you understand how
 these work. See
-[Routing reference](/docs/reference/routing#How-routes-are-loaded) for more
+[Routing reference](/docs/reference/routing#how-routes-are-loaded) for more
 advanced information.
 
 :::

--- a/docs/essentials/add-component-to-storybook.mdx
+++ b/docs/essentials/add-component-to-storybook.mdx
@@ -198,7 +198,7 @@ Front-Commerce base theme's core components.
 However, you might not use each one of them in your final theme, and some
 stories might become irrelevant in your design system. To chose which one to
 display, you need to update the `.front-commerce.js` configuration file, and add
-the key [`styleguidePaths`](/docs/reference/front-commerce-js#styleguidePaths).
+the key [`styleguidePaths`](/docs/reference/front-commerce-js#styleguidepaths).
 
 ```js title=".front-commerce.js"
 module.exports = {
@@ -227,7 +227,7 @@ stories within all the `web/theme` folder from
 
 Hence, if you don't want to have an atom that is defined within Front-Commerce
 core, but still want the other atoms, you will need to be more specific within
-your [`styleguidePaths`](/docs/reference/front-commerce-js#styleguidePaths)
+your [`styleguidePaths`](/docs/reference/front-commerce-js#styleguidepaths)
 array. For instance, if you only want the `Typography` related stories, and the
 `Button` related stories, you will need to write like this:
 
@@ -243,7 +243,7 @@ array. For instance, if you only want the `Typography` related stories, and the
 :::info
 
 If you don't define the
-[`styleguidePaths`](/docs/reference/front-commerce-js#styleguidePaths) key in
+[`styleguidePaths`](/docs/reference/front-commerce-js#styleguidepaths) key in
 your `.front-commerce.js` file, each story found in the `web/theme` folder will
 be used.
 

--- a/docs/essentials/create-a-business-component.mdx
+++ b/docs/essentials/create-a-business-component.mdx
@@ -79,7 +79,7 @@ This is one of the biggest advantages of using React to build our front-end, we
 have access to this huge ecosystem.
 
 Let's install the required packages
-([versions are important](/docs/advanced/features/display-a-map#Open-Street-Map-OSM-with-Leaflet)):
+([versions are important](/docs/advanced/features/display-a-map#open-street-map-osm-with-leaflet)):
 
 ```shell
 npm install leaflet@^1.7 react-leaflet@3.1.0 @react-leaflet/core@1.0.2
@@ -101,7 +101,7 @@ replace your components with the `<Map>` one.
 
 Before starting to edit the Home page, you first need to extend the theme. If
 you don't have a module yet, please refer to
-[Extend the theme](./extend-the-theme#Configure-your-custom-theme-and-use-it-in-your-application).
+[Extend the theme](./extend-the-theme#configure-your-custom-theme-and-use-it-in-your-application).
 Once you have one, the goal will be to override the Home component from
 [`node_modules/front-commerce/src/web/theme/pages/Home/Home.js`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/theme/pages/Home/Home.js)
 to `my-module/web/theme/pages/Home/Home.js`.

--- a/docs/essentials/create-a-ui-component.mdx
+++ b/docs/essentials/create-a-ui-component.mdx
@@ -110,7 +110,7 @@ Front-Commerce will look similar to what we are going to build here.
 
 Before doing the actual work let's bootstrap our dev environment. To do so, once
 you've
-[registered your module](./extend-the-theme#Configure-your-custom-theme-and-use-it-in-your-application)
+[registered your module](./extend-the-theme#configure-your-custom-theme-and-use-it-in-your-application)
 you will need to create three files:
 
 - **`IllustratedContent.js` :** will bootstrap the actual component.

--- a/docs/essentials/extend-the-graphql-schema.mdx
+++ b/docs/essentials/extend-the-graphql-schema.mdx
@@ -55,7 +55,7 @@ your application yet. You need to register it.
 ## Register the module in the application
 
 Front-Commerce allows you to manage your modules in the
-[`serverModules` key of the `.front-commerce.js` file](/docs/reference/front-commerce-js#serverModules)
+[`serverModules` key of the `.front-commerce.js` file](/docs/reference/front-commerce-js#servermodules)
 located in your project’s root.
 
 Let’s add a `ClicksCounters` GraphQL module by adding it to the existing list:

--- a/docs/essentials/installation.mdx
+++ b/docs/essentials/installation.mdx
@@ -109,7 +109,7 @@ file, with links to relevant documentation pages.
 
 We invite you to dig into the remote services configurations and tweak them if
 you wish. See
-[our documentation](/docs/reference/environment-variables#Remote-services-configuration)
+[our documentation](/docs/reference/environment-variables#remote-services-configuration)
 for further information.
 
 #### Configure stores
@@ -231,7 +231,7 @@ the existing components.
 :::tip
 
 You can configure which stories to display in your styleguide by setting the
-[`styleguidePaths` key in your `.front-commerce.js` file](/docs/reference/front-commerce-js#styleguidePaths).
+[`styleguidePaths` key in your `.front-commerce.js` file](/docs/reference/front-commerce-js#styleguidepaths).
 Its value should be a list of regexes (e.g: `[/.*.story.js$/];`) that will be
 matched against your stories paths.
 

--- a/docs/magento1/advanced.mdx
+++ b/docs/magento1/advanced.mdx
@@ -17,7 +17,7 @@ import BrowserWindow from "@site/src/components/BrowserWindow";
 Front-Commerce allows you to send additional headers in all API calls. To do so,
 you must define the `magento.api.extraHeaders` (for storefront API) and/or
 `magento.api.extraAdminHeaders` (for admin API) configuration values from a
-[configuration provider](/docs/advanced/server/configurations#What-is-a-configuration-provider).
+[configuration provider](/docs/advanced/server/configurations#what-is-a-configuration-provider).
 
 These additional headers could be useful if you want to add additional context
 to your queries, depending on the request or to detect Front-Commerce requests

--- a/docs/magento1/headless-payments.mdx
+++ b/docs/magento1/headless-payments.mdx
@@ -23,7 +23,7 @@ Our Magento1 integration currently provides native adapters for the platforms
 below, learn how to install each one of them from the related documentation
 page:
 
-- [Paypal](/docs/advanced/payments/paypal#Magento1-module)
+- [Paypal](/docs/advanced/payments/paypal#magento1-module)
 
 :::info
 
@@ -47,7 +47,7 @@ so we can provide information about a potential upcoming native support for it.
 ### Using the "redirect after order" flow
 
 **Payment flows:**
-[Redirect after order](/docs/advanced/payments/payment-workflows#Redirect-After-Order)
+[Redirect after order](/docs/advanced/payments/payment-workflows#redirect-after-order)
 
 1. Add your own payment instance on `config.xml` file
 

--- a/docs/magento1/search-engine.mdx
+++ b/docs/magento1/search-engine.mdx
@@ -14,9 +14,9 @@ import ContactLink from "@site/src/components/ContactLink";
 You can configure search and product lists with filters using the following
 platforms:
 
-- [Native Magento feature](#Native-search)
-- [ElasticSearch - direct access](#Elasticsearch) (using our ElasticSuite fork)
-- [Algolia](#Algolia)
+- [Native Magento feature](#native-search)
+- [ElasticSearch - direct access](#elasticsearch) (using our ElasticSuite fork)
+- [Algolia](#algolia)
 
 ## Native search
 
@@ -79,7 +79,7 @@ module.
 :::
 
 Then, in your `.env` file, you need to define
-[the `FRONT_COMMERCE_ES_HOST` and `FRONT_COMMERCE_ES_ALIAS` variables](/docs/reference/environment-variables#Elasticsearch).
+[the `FRONT_COMMERCE_ES_HOST` and `FRONT_COMMERCE_ES_ALIAS` variables](/docs/reference/environment-variables#elasticsearch).
 
 After restarting Front-Commerce, you should be able run a GraphQL query to
 search for products, for instance:
@@ -160,7 +160,7 @@ The Algolia server module needs to be enabled **before** the Magento's module.
 
 As of Front-Commerce 2.6, Algolia's module is automatically configured. If you
 are using Front-Commerce 2.5, you need to define
-[all the Algolia related environment variables](/docs/reference/environment-variables#Algolia)
+[all the Algolia related environment variables](/docs/reference/environment-variables#algolia)
 in your `.env` file.
 
 Front-Commerce 2.6 takes the following parameters from Magento:

--- a/docs/magento2/add-question-on-registration.mdx
+++ b/docs/magento2/add-question-on-registration.mdx
@@ -26,7 +26,7 @@ add an attribute and create a Front-Commerce module.
 The source code for the `Account creation` page is located at
 `node_modules/front-commerce/src/web/theme/modules/User/RegisterForm/`. Copy it
 into your module. (If you don't know how to locate the source code for a page,
-click [here](/docs/magento2/add-new-attribute#How-to-find-which-files-to-edit).)
+click [here](/docs/magento2/add-new-attribute#how-to-find-which-files-to-edit).)
 
 ```shell
 mkdir -p my-module/web/theme/modules/User/

--- a/docs/magento2/advanced.mdx
+++ b/docs/magento2/advanced.mdx
@@ -20,7 +20,7 @@ integration.
 Front-Commerce allows you to send additional headers in all API calls. To do so,
 you must define the `magento.api.extraHeaders` (for storefront API) and/or
 `magento.api.extraAdminHeaders` (for admin API) configuration values from a
-[configuration provider](/docs/advanced/server/configurations#What-is-a-configuration-provider).
+[configuration provider](/docs/advanced/server/configurations#what-is-a-configuration-provider).
 
 These additional headers could be useful if you want to add additional context
 to your queries, depending on the request or to detect Front-Commerce requests

--- a/docs/magento2/b2b.mdx
+++ b/docs/magento2/b2b.mdx
@@ -32,7 +32,7 @@ and requires at least Adobe Commerce 2.4.3.
 ### Requirements
 
 On Magento2 side, you need to
-[install the Front-Commerce Magento2 Commerce module](/docs/magento2/commerce#Magento2-Commerce-module-installation).
+[install the Front-Commerce Magento2 Commerce module](/docs/magento2/commerce#magento2-commerce-module-installation).
 
 ### Front-Commerce configuration
 

--- a/docs/magento2/detect-admin-users.mdx
+++ b/docs/magento2/detect-admin-users.mdx
@@ -172,7 +172,7 @@ In case you rely on
 you will need to make sure that data fetched by admins are not cached in the
 same namespace as your normal users. For this reason, please make sure to update
 your
-[Caching strategies](/docs/advanced/graphql/dataloaders-and-cache-invalidation#PerMagentoAdminRole)
+[Caching strategies](/docs/advanced/graphql/dataloaders-and-cache-invalidation#permagentoadminrole)
 with the relevant `PerMagentoAdminRole` configuration.
 
 :::
@@ -242,5 +242,5 @@ curl -v 'http://localhost:4000/__front-commerce/UNSAFE_injectRole?data={"foo":"b
 ```
 
 Please note that this featured is only enabled if
-[the environment is configured](#Configuring-your-environment) and `NODE_ENV` is
+[the environment is configured](#configuring-your-environment) and `NODE_ENV` is
 `development`.

--- a/docs/magento2/headless-payments.mdx
+++ b/docs/magento2/headless-payments.mdx
@@ -24,7 +24,7 @@ modules headlessly and supports
 the implementation uses very low-level Magento mechanisms. One must be very
 careful about the implementation and **must rigorously test the payment
 integration** because some extensions could have nasty side effects. Read more
-about it in the [Warnings & Known issues](#Warnings-amp-Known-issues) section if
+about it in the [Warnings & Known issues](#warnings-amp-known-issues) section if
 you plan to use such payment methods.
 
 :::
@@ -35,10 +35,10 @@ Our Magento2 integration currently provides native adapters for the platforms
 below, learn how to install each one of them from the related documentation
 page:
 
-- [Affirm](/docs/advanced/payments/affirm#Magento2-module)
-- [Ingenico](/docs/advanced/payments/ingenico#Magento2-module)
-- [Paypal](/docs/advanced/payments/paypal#Magento2-module)
-- [PayZen](/docs/advanced/payments/payzen#Magento2-module)
+- [Affirm](/docs/advanced/payments/affirm#magento2-module)
+- [Ingenico](/docs/advanced/payments/ingenico#magento2-module)
+- [Paypal](/docs/advanced/payments/paypal#magento2-module)
+- [PayZen](/docs/advanced/payments/payzen#magento2-module)
 - [Payment on account](/docs/advanced/payments/payment-on-account)
 
 :::info
@@ -80,7 +80,7 @@ Adapters must implement methods that are called at key times in order to:
 ### `redirectionFromCheckoutRedirectActionResponse`
 
 **Payment flows:**
-[Redirect before order](/docs/advanced/payments/payment-workflows#Redirect-Before-Order)
+[Redirect before order](/docs/advanced/payments/payment-workflows#redirect-before-order)
 
 Converts an internal Magento response to a
 [`RedirectionInterface`](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/main/app/code/FrontCommerce/Integration/Api/Data/HeadlessPayment/RedirectionInterface.php)
@@ -96,7 +96,7 @@ public function redirectionFromCheckoutRedirectActionResponse(
 ### `redirectionFromCheckoutRedirectAfterActionResponse`
 
 **Payment flows:**
-[Redirect after order](/docs/advanced/payments/payment-workflows#Redirect-After-Order)
+[Redirect after order](/docs/advanced/payments/payment-workflows#redirect-after-order)
 
 Converts an internal Magento response to a
 [`RedirectionInterface`](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/main/app/code/FrontCommerce/Integration/Api/Data/HeadlessPayment/RedirectionInterface.php)
@@ -112,7 +112,7 @@ public function redirectionFromCheckoutRedirectAfterActionResponse(
 ### `prepareAfterCheckoutContext`
 
 **Payment flows:**
-[Redirect after order](/docs/advanced/payments/payment-workflows#Redirect-After-Order)
+[Redirect after order](/docs/advanced/payments/payment-workflows#redirect-after-order)
 
 Populates session objects with information required by the payment action.
 
@@ -127,8 +127,8 @@ public function prepareAfterCheckoutContext(
 ### `checkoutRedirectUrl`
 
 **Payment flows:**
-[Redirect before order](/docs/advanced/payments/payment-workflows#Redirect-Before-Order),
-[Redirect after order](/docs/advanced/payments/payment-workflows#Redirect-After-Order)
+[Redirect before order](/docs/advanced/payments/payment-workflows#redirect-before-order),
+[Redirect after order](/docs/advanced/payments/payment-workflows#redirect-after-order)
 
 Should return the url that will be dispatched internally to trigger the
 redirection to the payment provider in the payment module.
@@ -143,7 +143,7 @@ public function checkoutRedirectUrl(
 ### `changeAfterCheckoutResponseFromResult`
 
 **Payment flows:**
-[Redirect after order](/docs/advanced/payments/payment-workflows#Redirect-After-Order)
+[Redirect after order](/docs/advanced/payments/payment-workflows#redirect-after-order)
 
 May populate or change the Magento response object while still in the correct
 store context. It can for instance render blocks or things like that…
@@ -160,8 +160,8 @@ public function changeAfterCheckoutResponseFromResult(
 ### `buildReturnFromPlatformProxiedAction`
 
 **Payment flows:**
-[Redirect before order](/docs/advanced/payments/payment-workflows#Redirect-Before-Order),
-[Redirect after order](/docs/advanced/payments/payment-workflows#Redirect-After-Order)
+[Redirect before order](/docs/advanced/payments/payment-workflows#redirect-before-order),
+[Redirect after order](/docs/advanced/payments/payment-workflows#redirect-after-order)
 
 This is a factory to build a
 [`ProxiedAction`](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/main/app/code/FrontCommerce/Integration/Api/HeadlessPayment/ProxiedAction.php)

--- a/docs/magento2/i18n.mdx
+++ b/docs/magento2/i18n.mdx
@@ -10,7 +10,7 @@ description:
 <p>{frontMatter.description}</p>
 
 Each Front-Commerce store has one language (see
-[Configure stores](/docs/essentials/installation#Configure-stores) and
+[Configure stores](/docs/essentials/installation#configure-stores) and
 [Configure multiple stores](/docs/advanced/production-ready/multistore)). Each
 one of these languages use translations as detailed in the
 [Translate your application](/docs/advanced/theme/translations) page.
@@ -93,7 +93,7 @@ project.
 ## Store configuration
 
 You will then have to ensure that the store code in
-[your `src/config/stores.js` configuration](/docs/essentials/installation#Configure-stores)
+[your `src/config/stores.js` configuration](/docs/essentials/installation#configure-stores)
 matches the
 [Magento store view code](https://docs.magento.com/m2/ee/user_guide/stores/stores-all-create-view.html)
 configured for the targeted language.

--- a/docs/magento2/log-as-customer.mdx
+++ b/docs/magento2/log-as-customer.mdx
@@ -32,7 +32,7 @@ needed.
 
 **Prerequisites:** the 2.2.x version of the Front-Commerce Magento module is
 installed and
-[the admin user detection is properly configured](/docs/magento2/detect-admin-users#Configuring-your-environment).
+[the admin user detection is properly configured](/docs/magento2/detect-admin-users#configuring-your-environment).
 
 Then, you must configure the related ACL for Administrators who must be allowed
 to log as Customers:

--- a/docs/magento2/page-builder.mdx
+++ b/docs/magento2/page-builder.mdx
@@ -23,9 +23,9 @@ experiences that were designed for _their_ customers.
 Page Builder is only available for content that:
 
 - are displayed using
-  [the `<WysiwygV2>` component and its related `WysiwygFragment` GraphQL fragment](/docs/advanced/theme/wysiwyg#lt-WysiwygV2-gt-usage)
+  [the `<WysiwygV2>` component and its related `WysiwygFragment` GraphQL fragment](/docs/advanced/theme/wysiwyg#lt-wysiwygv2-gt-usage)
 - get data from GraphQL fields resolved using
-  [the `MagentoWysiwyg` type](/docs/advanced/theme/wysiwyg-platform#MagentoWysiwyg)
+  [the `MagentoWysiwyg` type](/docs/advanced/theme/wysiwyg-platform#magentowysiwyg)
   **(which is the case of all default Magento rich content fields)**
 
 Please check these prerequisites first if your content does not appear properly.
@@ -46,7 +46,7 @@ We currently support these content types in a basic way.
 :::info
 
 Additional data is exposed via the GraphQL for more more advanced
-[Customized UI components](#Customize-UI-components) implementations.
+[Customized UI components](#customize-ui-components) implementations.
 
 :::
 

--- a/docs/magento2/search-engine.mdx
+++ b/docs/magento2/search-engine.mdx
@@ -14,9 +14,9 @@ import ContactLink from "@site/src/components/ContactLink";
 You can configure search and product lists with filters using the following
 platforms:
 
-- [Native Magento feature](#Native-search) (using its GraphQL API)
-- [ElasticSearch - direct access](#Elasticsearch) (using ElasticSuite)
-- [Algolia](#Algolia)
+- [Native Magento feature](#native-search) (using its GraphQL API)
+- [ElasticSearch - direct access](#elasticsearch) (using ElasticSuite)
+- [Algolia](#algolia)
 
 ## Native search
 
@@ -84,7 +84,7 @@ module.
 :::
 
 Then, in your `.env` file, you need to define
-[the variables](/docs/reference/environment-variables#Elasticsearch).
+[the variables](/docs/reference/environment-variables#elasticsearch).
 
 ```shell title=".env"
 FRONT_COMMERCE_ES_HOST=<es_host>

--- a/docs/prismic/content-slices.mdx
+++ b/docs/prismic/content-slices.mdx
@@ -73,12 +73,12 @@ type Homepage {
 ```
 
 In your resolvers, load your content as usual
-[with the Prismic loader](/docs/prismic/expose-content#Methods-to-query-content).
+[with the Prismic loader](/docs/prismic/expose-content#methods-to-query-content).
 
 In addition to
-[the `fieldTransformers` parameter](/docs/prismic/expose-content#Field-Transformers)
+[the `fieldTransformers` parameter](/docs/prismic/expose-content#field-transformers)
 in the
-[defineContentTransformers](/docs/prismic/expose-content#defineContentTransformers-typeIdentifier-options),
+[defineContentTransformers](/docs/prismic/expose-content#definecontenttransformers-typeidentifier-options),
 the definition accepts a `supportedSlices` key. It allows to define to a data
 structure for the Slices available in the Custom Type.
 

--- a/docs/prismic/embed-fields.mdx
+++ b/docs/prismic/embed-fields.mdx
@@ -16,8 +16,8 @@ In Front-Commerce we expose the embed fields in two ways;
 
 - Standalone Embed fields with an EmbedTransformer
 - Embed Fields in
-  [`WysiwygV2`](/docs/advanced/theme/wysiwyg#lt-WysiwygV2-gt-usage) with
-  [`PrismicWysiwyg`](/docs/advanced/theme/wysiwyg-platform#PrismicWysiwyg)
+  [`WysiwygV2`](/docs/advanced/theme/wysiwyg#lt-wysiwygv2-gt-usage) with
+  [`PrismicWysiwyg`](/docs/advanced/theme/wysiwyg-platform#prismicwysiwyg)
 
 In this section we will cover how to implement both of these methods, and how to
 implement your own custom embed fields.
@@ -126,14 +126,14 @@ type.
 ### Prerequisites
 
 To benefit from this API, you first need to
-[Configure the PrismicWysiwyg](/docs/prismic/installation#Optional-Configure-the-PrismicWysiwyg).
+[Configure the PrismicWysiwyg](/docs/prismic/installation#optional-configure-the-prismicwysiwyg).
 
 ### Example with PrismicWysiwyg
 
 Update your schema to use the
-[`PrismicWysiwyg`](/docs/advanced/theme/wysiwyg-platform#PrismicWysiwyg) type
+[`PrismicWysiwyg`](/docs/advanced/theme/wysiwyg-platform#prismicwysiwyg) type
 instead of the
-[`DefaultWysiwyg`](/docs/advanced/theme/wysiwyg-platform#DefaultWysiwyg).
+[`DefaultWysiwyg`](/docs/advanced/theme/wysiwyg-platform#defaultwysiwyg).
 
 ```diff
 type MyAlbum {
@@ -160,7 +160,7 @@ loaders.Prismic.defineContentTransformers("album", {
 ```
 
 You can then follow the same steps form
-[`<WysiwygV2 /> usage`](/docs/advanced/theme/wysiwyg#lt-WysiwygV2-gt-usage) to
+[`<WysiwygV2 /> usage`](/docs/advanced/theme/wysiwyg#lt-wysiwygv2-gt-usage) to
 implement the Wysiwyg in your client-side.
 
 ### Adding additional Embed loading scripts

--- a/docs/prismic/expose-content.mdx
+++ b/docs/prismic/expose-content.mdx
@@ -155,7 +155,7 @@ We will use some of them in the following examples.
 ## Implementation examples
 
 Those examples assume that you have created
-[a GraphQL module](/docs/essentials/extend-the-graphql-schema#Create-a-new-GraphQL-module)
+[a GraphQL module](/docs/essentials/extend-the-graphql-schema#create-a-new-graphql-module)
 and that it is already registered. Before being able to use the Prismic module
 API, you have to make sure `Prismic/Core` is a dependency of your module. In
 addition, we will use the Wysiwyg feature provided by `Front-Commerce/Wysiwyg`,
@@ -291,7 +291,7 @@ export default {
 > The `ImageTransformer` also rewrites the image path provided by the Prismic
 > API to use a custom image proxy defined by the module. This path rewrite makes
 > those image path directly usable by
-> [Front-Commerce's `<Image />` component](/docs/advanced/production-ready/media-middleware#lt-Image-gt-component).
+> [Front-Commerce's `<Image />` component](/docs/advanced/production-ready/media-middleware#lt-image-gt-component).
 
 In addition, each view carries some metadata like the alternative text or the
 image dimensions. The following changes allow to expose the alternative text of

--- a/docs/prismic/integration-fields.mdx
+++ b/docs/prismic/integration-fields.mdx
@@ -28,14 +28,14 @@ Front-Commerce application and data.
 Front-Commerce currently support Integration fields in a "Pull" mode. Here is
 how it works:
 
-1. [Developers register Integration fields in Front-Commerce](#Register-Integration-fields-in-Front-Commerce)
+1. [Developers register Integration fields in Front-Commerce](#register-integration-fields-in-front-commerce)
    for the data to expose to Prismic (with code)
-1. [Configure the Integration field in Prismic](#Configure-Integration-fields-in-Prismic)
+1. [Configure the Integration field in Prismic](#configure-integration-fields-in-prismic)
 1. Prismic will regularly pull data from a Front-Commerce read API endpoint
-1. [Add these fields to custom types or Slices](#Update-your-types-and-data-in-Prismic)
+1. [Add these fields to custom types or Slices](#update-your-types-and-data-in-prismic)
    so Content managers will see up-to-date data in the writing room and could
    select elements made available by Front-Commerce
-1. [Developers implement Prismic requests that know how to transform values from an integration field](#Expose-data-in-your-GraphQL-schema)
+1. [Developers implement Prismic requests that know how to transform values from an integration field](#expose-data-in-your-graphql-schema)
    into rich data from their application (with code)
 1. Frontend developers can build pages by requesting data from GraphQL as usual.
    There is no difference in data that comes from Prismic or the eCommerce
@@ -50,13 +50,13 @@ Registering a new Integration field allows to expose custom data in an API that
 can be used by Prismic. Front-Commerce's Prismic module provides a generic way
 to register Integration fields.
 
-See the [Implementations](#Implementations) section to learn more about existing
+See the [Implementations](#implementations) section to learn more about existing
 implementations.
 
 :::note
 
 In this example, we will use the
-[`SitemapableIntegrationField`](#SitemapableIntegrationField) implementation for
+[`SitemapableIntegrationField`](#sitemapableintegrationfield) implementation for
 more concise examples. Keep in mind that any `IntegrationField` implementation
 can be registered in a similar way.
 
@@ -148,7 +148,7 @@ field from the **"Settings > Integration Fields"** page.
    `https://your-store.example.com/prismic/integration/{name}`
 2. the **"Access token"** value must be the value of your
    `FRONT_COMMERCE_PRISMIC_WEBHOOK_SECRET` environment variable
-   ([also used for webhooks](/docs/prismic/installation#Configure-the-environment-for-Prismic))
+   ([also used for webhooks](/docs/prismic/installation#configure-the-environment-for-prismic))
 3. create the Integration field
 
 The **"Settings > Integration Fields"** page will now display the Integration
@@ -212,10 +212,10 @@ type MyPrismicContent {
 
 You then have to instruct Front-Commerce Prismic module to transform data from
 Prismic with information from a
-[registered integration field](#Register-Integration-fields-in-Front-Commerce).
+[registered integration field](#register-integration-fields-in-front-commerce).
 
 The `IntegrationFieldTransformer` will transform data from
-[an Integration Field implementation](#Implementations). We can get the correct
+[an Integration Field implementation](#implementations). We can get the correct
 Integration field instance using the name used when registering the Integration
 field, using Prismic loader's `getIntegrationField` method.
 
@@ -308,7 +308,7 @@ const categoryIntegrationField = new SitemapableIntegrationField(
 To create a `SitemapableIntegrationField`, you must provide:
 
 - `entityName`: the name of the Sitemapable entity
-  [used during sitemapable pages registration](/docs/advanced/production-ready/sitemap#Add-dynamic-pages)
+  [used during sitemapable pages registration](/docs/advanced/production-ready/sitemap#add-dynamic-pages)
 - `SitemapLoader`: a Front-Commerce Sitemap loader instance (e.g:
   `loaders.Sitemap`)
 - `resolveEntity`: a Function to resolve the entity from the `id` value of the

--- a/docs/prismic/resolver-cache.mdx
+++ b/docs/prismic/resolver-cache.mdx
@@ -24,7 +24,7 @@ Returns a resolver that caches the result of the given resolver.
 **Arguments:**
 
 - `resolver`: A
-  [custom resolver](/docs/advanced/graphql/change-resolver-behavior#Implement-your-custom-resolver-logic)
+  [custom resolver](/docs/advanced/graphql/change-resolver-behavior#implement-your-custom-resolver-logic)
   that returns a `Content` or an array of `Content`,
 - `options` : An object with the following properties:
   - `mapParamsToId` A function that maps the resolver parameters to a unique id.

--- a/docs/prismic/routable-types.mdx
+++ b/docs/prismic/routable-types.mdx
@@ -77,7 +77,7 @@ field of our custom Prismic type.
 
 Now you need to add your type to the GraphQL dispatcher query. For more info on
 the topic please refer to
-[Add GraphQL type to the dispatcher query section of the route dispatcher documentation](/docs/advanced/theme/route-dispatcher#Add-GraphQL-type-to-the-dispatcher-query)
+[Add GraphQL type to the dispatcher query section of the route dispatcher documentation](/docs/advanced/theme/route-dispatcher#add-graphql-type-to-the-dispatcher-query)
 
 ## Register the Prismic custom type as a routable type
 
@@ -126,7 +126,7 @@ export default {
 
 The `postTransformer` above is optional. It is a function that will be called
 after
-[the transformation is done using `contentTransformOptions`](/docs/prismic/expose-content#Field-Transformers).
+[the transformation is done using `contentTransformOptions`](/docs/prismic/expose-content#field-transformers).
 It is given the current URL being resolved and the transformed document. It can
 be used if you have some custom logic to apply to the document or if you want to
 prevent the document from showing using some custom logic (returning a _falsy_
@@ -193,7 +193,7 @@ export const dispatchedRoutes = {
 ```
 
 For more details please refer to
-[Add the mapping between the type and the page component](/docs/advanced/theme/route-dispatcher#Add-the-mapping-between-the-type-and-the-page-component)
+[Add the mapping between the type and the page component](/docs/advanced/theme/route-dispatcher#add-the-mapping-between-the-type-and-the-page-component)
 in the [route dispatcher](/docs/advanced/theme/route-dispatcher).
 
 Now an instance of the custom Prismic type with the `url` field set to

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -112,7 +112,7 @@ There are two modes available:
 
 This command checks your translations and adds the missing one to
 `translations/[lang].json` in the root of your application. See
-[Translate what's in your components](/docs/advanced/theme/translations#Translate-what’s-in-your-components)
+[Translate what's in your components](/docs/advanced/theme/translations#translate-what’s-in-your-components)
 for more information.
 
 If some translations are missing, the script will throw an error. This lets you

--- a/docs/reference/configurations.mdx
+++ b/docs/reference/configurations.mdx
@@ -25,14 +25,14 @@ in Front-Commerce. If you want to override some, duplicate those in
 
 > _New in version `1.0.0-beta.3`:_ configurations are inherited across themes
 > declared in your `.front-commerce.js` in a similar fashion than
-> [theme overrides](/docs/essentials/extend-the-theme#Understanding-theme-overrides).
+> [theme overrides](/docs/essentials/extend-the-theme#understanding-theme-overrides).
 
 :::caution Security Notice
 
 Please keep in mind that most of these configurations are imported and bundled
 into your client application. Thus it is important to not include private
 configurations in them, and to use
-[environment variables](/docs/reference/environment-variables#Add-your-own-environment-variables)
+[environment variables](/docs/reference/environment-variables#add-your-own-environment-variables)
 instead.
 
 :::
@@ -62,7 +62,7 @@ your website. The term website refers to what a
   the loss of valuable analytics insights.
 - `default_image_url` (ex: an absolute URL of an image): which image to use when
   no image path has been given to
-  [`<ResizedImage>`](/docs/advanced/production-ready/media-middleware#lt-ResizedImage-gt-component)
+  [`<ResizedImage>`](/docs/advanced/production-ready/media-middleware#lt-resizedimage-gt-component)
 - `defaultTitle`: the default meta title of your application
 - `defaultDescription`: the default meta description of your application
 - `available_page_sizes`: which page sizes to display in a product list page (or
@@ -236,7 +236,7 @@ implementations. It can export a configuration with the following keys:
 Each strategy can be configured with the keys below:
 
 - `implementation`: name of the
-  [implementation of this strategy](/docs/advanced/graphql/dataloaders-and-cache-invalidation#Caching-strategies)
+  [implementation of this strategy](/docs/advanced/graphql/dataloaders-and-cache-invalidation#caching-strategies)
   (**mandatory**)
 - `supports`: list of loaders impacted by this strategy. Either an array of
   values or `"*"` for all. (**mandatory**)
@@ -298,5 +298,5 @@ Allows to define configurations related to GraphQL rate limiting feature.
   memory
 
 See
-[Use a persistent store](/docs/advanced/graphql/rate-limiting#Use-a-persistent-store)
+[Use a persistent store](/docs/advanced/graphql/rate-limiting#use-a-persistent-store)
 for further information.

--- a/docs/reference/debugging.mdx
+++ b/docs/reference/debugging.mdx
@@ -56,7 +56,7 @@ following content:
 }
 ```
 
-If you're [changing the port number](/docs/reference/environment-variables#Host)
+If you're [changing the port number](/docs/reference/environment-variables#host)
 your application starts on, replace the `4000` in `http://localhost:4000` with
 the port you're using instead. You can use the same url defined in your
 `FRONT_COMMERCE_URL`.
@@ -156,4 +156,4 @@ following documentation:
 - [The Firefox JavaScript Debugger](https://firefox-source-docs.mozilla.org/devtools-user/debugger/index.html)
   (Client Only)
 - [Node.js Inspector Clients](https://nodejs.org/en/docs/guides/debugging-getting-started/#inspector-clients)
-- [Debug with log output](/docs/reference/environment-variables#Debugging)
+- [Debug with log output](/docs/reference/environment-variables#debugging)

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -23,7 +23,7 @@ files no matter if it is a server-side or client-side file. However, not all
 variables are exposed in your client code. Client code only have access to
 variables such as `FRONT_COMMERCE_WEB_*` which were defined during
 `front-commerce build`. See
-[Add your own environment variables](/docs/reference/environment-variables#Add-your-own-environment-variables)
+[Add your own environment variables](/docs/reference/environment-variables#add-your-own-environment-variables)
 for more details.
 
 ## How to update environment variables
@@ -88,7 +88,7 @@ redirects user to the HTTPS version of a page in this case. Use the
 
 - `FRONT_COMMERCE_CACHE_API_TOKEN`: a token that will let external applications
   invalidate parts of Front-Commerce cache. See
-  [Invalidating the cache](/docs/advanced/graphql/dataloaders-and-cache-invalidation#Invalidating-the-cache)
+  [Invalidating the cache](/docs/advanced/graphql/dataloaders-and-cache-invalidation#invalidating-the-cache)
   for more details.
 
 ### Performance
@@ -141,7 +141,7 @@ redirects user to the HTTPS version of a page in this case. Use the
 ### DX
 
 - `FRONT_COMMERCE_DEV_SSR_FALLBACK_DISABLE`: disables
-  [the SSR warning page](/docs/advanced/theme/server-side-rendering#SSR-Fallback-when-things-go-wrong)
+  [the SSR warning page](/docs/advanced/theme/server-side-rendering#ssr-fallback-when-things-go-wrong)
   before loading. This allows you to see what happens in production.
 - `FRONT_COMMERCE_DEV_IMAGE_ERROR_DISABLE`: disables the image resizing errors
   in case you've passed malformed requests to the server. This allows you to see
@@ -209,7 +209,7 @@ variables:
 :::info
 
 As of Front-Commerce 2.6,
-[the Algolia Front-Commerce module](/docs/magento1/search-engine#Algolia) is
+[the Algolia Front-Commerce module](/docs/magento1/search-engine#algolia) is
 automatically configured based on Magento1 configuration. Those environment
 variables only apply to Front-Commerce 2.5 with Magento1.
 
@@ -269,7 +269,7 @@ keys** page from the menu.
 Get your access keys by following the
 [Payzen documentation](https://payzen.io/fr-FR/rest/V4.0/api/get_my_keys.html).
 See
-[our documentation page](/docs/advanced/payments/payzen#Configure-your-environment)
+[our documentation page](/docs/advanced/payments/payzen#configure-your-environment)
 for further details.
 
 - `FRONT_COMMERCE_PAYZEN_PUBLIC_KEY`
@@ -282,12 +282,12 @@ for further details.
 ### BuyBox
 
 See
-[our dedicated documentation page](/docs/advanced/payments/buybox#Configure-your-environment).
+[our dedicated documentation page](/docs/advanced/payments/buybox#configure-your-environment).
 
 ### Capency
 
 See
-[our related documentation](/docs/advanced/features/smart-forms#Capency-CapAddress-CapPhone-CapEmail)
+[our related documentation](/docs/advanced/features/smart-forms#capency-capaddress-capphone-capemail)
 for details.
 
 - `FRONT_COMMERCE_CAPENCY_DISABLED`: set to `true` to temporary disable all the
@@ -374,7 +374,7 @@ Here is a list of available debug namespaces:
   VERBOSE!**)
 - `front-commerce:graphql`: debugs GraphQL related code
 - `front-commerce:httpauth`: debugs how
-  [basic authorization](/docs/reference/configurations#config-httpAuth-js) is
+  [basic authorization](/docs/reference/configurations#config-httpauth-js) is
   enabled
 - `front-commerce:image`: debugs image proxy actions (useful to troubleshoot
   interactions with remote media servers)

--- a/docs/reference/front-commerce-js.mdx
+++ b/docs/reference/front-commerce-js.mdx
@@ -51,7 +51,7 @@ It is for instance used as the link target for the name in the
 :::note
 
 Use
-[the `FRONT_COMMERCE_URL` environment variable](/docs/reference/environment-variables#Host)
+[the `FRONT_COMMERCE_URL` environment variable](/docs/reference/environment-variables#host)
 to configure the URL used to access to your application.
 
 :::
@@ -192,7 +192,7 @@ _Default value: `[ /.*.story.js$/ ]`_
 
 A list of regexes that match the Storybook stories you want to use in your
 styleguide, so you can
-[only display relevant stories in your Design System](/docs/essentials/add-component-to-storybook#Display-only-the-relevant-stories-to-your-Design-System).
+[only display relevant stories in your Design System](/docs/essentials/add-component-to-storybook#display-only-the-relevant-stories-to-your-design-system).
 
 ```js
 module.exports = {

--- a/docs/reference/front-commerce-prepare.mdx
+++ b/docs/reference/front-commerce-prepare.mdx
@@ -14,9 +14,9 @@ any web modules folder. Front-Commerce supports the keys detailed below:
 ## `onCreateRoute`
 
 A function that transforms a `route` found in the modules defined in
-[`.front-commerce.js:webModules`](/docs/reference/front-commerce-js#webModules).
+[`.front-commerce.js:webModules`](/docs/reference/front-commerce-js#webmodules).
 
-See [Routing reference](/docs/reference/routing#How-routes-are-loaded) for
+See [Routing reference](/docs/reference/routing#how-routes-are-loaded) for
 details about the terms used.
 
 ### Parameters
@@ -25,7 +25,7 @@ details about the terms used.
   - `fromModule` (string): path of the web module defining the current route
   - `filepath` (string): absolute path to the route file
   - `path` (string): `path` that will be used for mapping URLs to this file (see
-    [Routing reference](/docs/reference/routing#How-routes-are-loaded) for
+    [Routing reference](/docs/reference/routing#how-routes-are-loaded) for
     details)
   - `isLayout` (bool): Is the file a `_layout.js`?
   - `isLayoutAddition` (bool): Is the file a layout customization? (`_error.js`
@@ -40,7 +40,7 @@ An optional route object with the following keys:
 - `fromModule` (string): path of the web module defining the current route
 - `filepath` (string): absolute path to the route file
 - `path` (string): `path` that will be used for mapping URLs to this file (see
-  [Routing reference](/docs/reference/routing#How-routes-are-loaded) for
+  [Routing reference](/docs/reference/routing#how-routes-are-loaded) for
   details)
 
 If no route is returned, the route is ignored.

--- a/docs/reference/graphql-context.mdx
+++ b/docs/reference/graphql-context.mdx
@@ -53,4 +53,4 @@ use it directly. Resolvers should to use [`loaders`](#loaders) instead.
 
 One of the reason why it has been introduced in the core, is to allow context
 customization in Remote schema stitching scenario. See
-[`linkContextBuilders` for an usage example](/docs/reference/graphql-module-definition#linkContextBuilders-optional).
+[`linkContextBuilders` for an usage example](/docs/reference/graphql-module-definition#linkcontextbuilders-optional).

--- a/docs/reference/graphql-module-definition.mdx
+++ b/docs/reference/graphql-module-definition.mdx
@@ -201,7 +201,7 @@ keys:
 - `req`: the current server request
 - `loaders`: current loaders (from module initialized beforehand)
 - `makeDataLoader`: a factory to build a dataloader (see
-  [`makeDataLoader` usage](/docs/advanced/graphql/dataloaders-and-cache-invalidation#makeDataLoader-usage))
+  [`makeDataLoader` usage](/docs/advanced/graphql/dataloaders-and-cache-invalidation#makedataloader-usage))
 - `config`: the global configuration
 
 Example:
@@ -250,7 +250,7 @@ export default {
 
 By default all queries and mutations are merged with the current schema. A set
 of default transformations are applied: read
-[the dedicated documentation section](/docs/advanced/graphql/remote-schemas#Default-transforms)
+[the dedicated documentation section](/docs/advanced/graphql/remote-schemas#default-transforms)
 for further information.
 
 ### `transforms` (optional)
@@ -261,7 +261,7 @@ before it is stitched with the existing Front-Commerce schema.
 It must be an array of valid
 [`graphql-tools` Schema Transforms](https://www.graphql-tools.com/docs/schema-stitching/#using-with-transforms),
 and will be applied **before** Front-Commerce’s
-[default transforms](/docs/advanced/graphql/remote-schemas#Default-transforms).
+[default transforms](/docs/advanced/graphql/remote-schemas#default-transforms).
 
 Example:
 
@@ -297,7 +297,7 @@ system in your remote service.
 You can create your own executor from scratch by following
 [Creating an executor](https://www.graphql-tools.com/docs/remote-schemas/#creating-an-executor)
 from GraphQL Tools or use the
-[`makeExecutor` helper](/docs/reference/remote-schema-helpers#makeExecutor)
+[`makeExecutor` helper](/docs/reference/remote-schema-helpers#makeexecutor)
 available in Front-Commerce.
 
 The following example demonstrates how to add an `Authorization` header to your

--- a/docs/reference/routing.mdx
+++ b/docs/reference/routing.mdx
@@ -12,7 +12,7 @@ description:
 
 Routes are loaded depending on the web modules declared in `.front-commerce.js`.
 See
-[`.front-commerce.js::webModules`](/docs/reference/front-commerce-js#webModules).
+[`.front-commerce.js::webModules`](/docs/reference/front-commerce-js#webmodules).
 
 ## How routes are loaded?
 

--- a/docs/reference/scripts.mdx
+++ b/docs/reference/scripts.mdx
@@ -70,7 +70,7 @@ application.
 
 It uses pages exposed in the `Query.sitemap` root query of the application
 GraphQL server to generate one sitemap per
-[store configured](/docs/essentials/installation#Configure-stores) along with a
+[store configured](/docs/essentials/installation#configure-stores) along with a
 sitemap index.
 
 To run this script, you can add the following line in your application’s


### PR DESCRIPTION
Looks like docusaurus is not able to preserve the case of anchors… this patch fixes the anchors we have in the doc so that it works while browsing. Unfortunately, any external link using an anchor with an uppercase letter that existed before is now broken