### PR TITLE
docs(b2b): document the extraction of an Adobe B2B Magento module

### DIFF
--- a/docs/appendices/migration-guides/index.mdx
+++ b/docs/appendices/migration-guides/index.mdx
@@ -106,6 +106,32 @@ it. The main use case for this variable was to change `npm run lint` behavior so
 that it triggers a warning instead of an error when a deprecated GraphQL is
 used. This is now the default behavior.
 
+### New Adobe Commerce B2B PHP module
+
+Some B2B features were previously leveraging features from the
+[Magento2 Commerce module](/docs/magento2/commerce#magento2-commerce-module-installation).
+During this release, we've extracted B2B related features into their own
+repository.
+
+**If you work on an Adobe Commerce B2B project**, you must:
+
+- update `front-commerce/magento2-commerce-module` to
+  [version 2.x](https://gitlab.com/front-commerce/magento2-commerce-module-front-commerce/-/releases)
+  (currently `2.0.0`)
+- install `front-commerce/magento2-b2b-module` to its latest version
+
+Here are the commands to achieve this:
+
+```shell
+composer require front-commerce/magento2-commerce-module:2.0.0
+
+composer config repositories.front-commerce-magento2-b2b git \
+    git@gitlab.com:front-commerce/magento2-b2b-module-front-commerce.git
+composer require front-commerce/magento2-b2b-module:1.1.0
+
+bin/magento setup:upgrade
+```
+
 ## `2.16.0` -> `2.17.0`
 
 ### Adyen's Stored payment methods

--- a/docs/magento2/b2b.mdx
+++ b/docs/magento2/b2b.mdx
@@ -34,6 +34,18 @@ and requires at least Adobe Commerce 2.4.3.
 On Magento2 side, you need to
 [install the Front-Commerce Magento2 Commerce module](/docs/magento2/commerce#Magento2-Commerce-module-installation).
 
+You must then install the
+[`front-commerce/magento2-b2b-module-front-commerce`](https://gitlab.com/front-commerce/magento2-b2b-module-front-commerce)
+module:
+
+```shell
+composer config repositories.front-commerce-magento2-b2b git \
+    git@gitlab.com:front-commerce/magento2-b2b-module-front-commerce.git
+composer require front-commerce/magento2-b2b-module
+
+bin/magento setup:upgrade
+```
+
 ### Front-Commerce configuration
 
 To leverage those features, you need to enable and integrate the Magento2 B2B


### PR DESCRIPTION
from our Adobe Commerce one

This is something that happened during the period of this release.

Previews: 
- https://deploy-preview-468--heuristic-almeida-1a1f35.netlify.app/docs/magento2/b2b#requirements
- https://deploy-preview-468--heuristic-almeida-1a1f35.netlify.app/docs/appendices/migration-guides/