### PR TITLE
docs(express): Documented way to override express configuration provider

### DIFF
--- a/docs/advanced/server/configurations.mdx
+++ b/docs/advanced/server/configurations.mdx
@@ -366,6 +366,35 @@ const serviceOverrideProvider = {
 configService.insertAfter("serviceProvider", serviceOverrideProvider);
 ```
 
+### Overriding express configuration provider
+
+If you want to override the configuration of express, you will need to add the
+new configuration in a middleware definition file `module.config.js`.
+
+For example, if you want to increase the maximum size for `POST` payloads:
+
+```js title="my-module/server/module.config.js"
+import configService from "server/core/config/configService";
+
+const expressServiceProvider = {
+  name: "expressOverride",
+  values: {
+    express: {
+      jsonParserConfig: {
+        limit: "10mb",
+      },
+      graphQLBodyParserConfig: {
+        limit: "10mb",
+      },
+    },
+  },
+};
+
+configService.append(expressServiceProvider);
+
+export default {};
+```
+
 ## Core configuration providers
 
 Our goal is to use these configuration providers for any configuration that

--- a/docs/appendices/troubleshooting.mdx
+++ b/docs/appendices/troubleshooting.mdx
@@ -146,7 +146,8 @@ such as cache invalidation) can be overridden using a
 
 In DEV mode, you can view the current value for these configurations by opening
 the [/\_\_front-commerce/debug](http://localhost:4000/__front-commerce/debug)
-URL.
+URL with the
+[`DEBUG="front-commerce:config"` environment variable](/docs/reference/environment-variables#debugging).
 
 :::
 
@@ -169,7 +170,7 @@ export default {
 ```
 
 The provider must then be
-[registered in your application](/docs/advanced/server/configurations#register-a-configuration-provider)
+[registered in your application](/docs/advanced/server/configurations#overriding-express-configuration-provider)
 as any other one.
 
 ## The signature is invalid. Verify and try again.


### PR DESCRIPTION
This aims to help integrator override express configuration by providing an easy copy-pastable example in their code.