### PR TITLE
Minor improvement to Magento1's custom payment method guide

### DIFF
--- a/docs/magento1/headless-payments.mdx
+++ b/docs/magento1/headless-payments.mdx
@@ -95,3 +95,32 @@ Don't forget to replace `{payment_method_code}` by your method payment code and
 - `returnAction(String $action, [String] $additionalData): Boolean` Callback
   after payment, for example, you can add your custom code here for retrieve
   customer cart after cancel payment
+
+:::tip REMINDER
+
+Don't forget to override or update `theme/pages/Checkout/checkoutFlowOf.js` to
+ensure your payment code will use the correct client-side checkout flow:
+
+```diff
+const checkoutFlowOf = (method) => {
+  if (method === "ops_cc") return "redirectAfterOrder";
+  if (method === "ops_cc_redirect") return "redirectAfterOrder";
+  if (method === "payzen_standard") return "redirectAfterOrder";
+  if (method === "paypal_standard") return "redirectAfterOrder";
++  if (method === "payment_method_code") return "redirectAfterOrder";
+
+  if (method === "paypal_express") return "redirectBeforeOrder";
+  if (method === "buybox") return "redirectBeforeOrder";
+
+  if (method.startsWith("adyen_")) return "directOrderWithAdditionalAction";
+  if (method.startsWith("hipay_")) return "directOrderWithAdditionalAction";
+
+  if (method === "payzen_embedded") return "asyncOrder";
+
+  return "directOrder";
+};
+
+export default checkoutFlowOf;
+```
+
+:::

--- a/docs/magento1/headless-payments.mdx
+++ b/docs/magento1/headless-payments.mdx
@@ -67,7 +67,7 @@ register it in your `config.xml` file with the following XML node:
 
 :::note
 
-Don't forget to replace `{payment_method_code}` by your method payment code and
+Don't forget to replace `{payment_method_code}` by your payment method code and
 `{class_name}` by the class names you've just created
 
 :::
@@ -98,10 +98,10 @@ Don't forget to replace `{payment_method_code}` by your method payment code and
 
 :::tip REMINDER
 
-Don't forget to override or update `theme/pages/Checkout/checkoutFlowOf.js` to
+Don't forget to override or update `checkoutFlowOf.js` to
 ensure your payment code will use the correct client-side checkout flow:
 
-```diff
+```diff title="theme/pages/Checkout/checkoutFlowOf.js"
 const checkoutFlowOf = (method) => {
   if (method === "ops_cc") return "redirectAfterOrder";
   if (method === "ops_cc_redirect") return "redirectAfterOrder";

--- a/docs/magento1/headless-payments.mdx
+++ b/docs/magento1/headless-payments.mdx
@@ -53,12 +53,24 @@ so we can provide information about a potential upcoming native support for it.
 
 First, you need to create your own model implementing the
 `FrontCommerce_Integration_Model_Headlesspayment_Interface` interface and
-register it using the
-`<config><frontcommerce><payment_instances><{payment_method_code}>{class_name}</{payment_method_code}></payment_instances></frontcommerce></config>`
-XML node in your `config.xml` file.
+register it in your `config.xml` file with the following XML node:
 
-**Note:** don't forget to replace `{payment_method_code}` by your method payment
-code and `{class_name}` by the class names you've just created
+```xml
+<config>
+  <frontcommerce>
+    <payment_instances>
+      <{payment_method_code}>{class_name}</{payment_method_code}>
+    </payment_instances>
+  </frontcommerce>
+</config>
+```
+
+:::note
+
+Don't forget to replace `{payment_method_code}` by your method payment code and
+`{class_name}` by the class names you've just created
+
+:::
 
 2. Implement the interface methods in your own model:
 


### PR DESCRIPTION
This MR adds a reminder to the Magento1 headless payments section roughly explaining how to create a custom method.

Based on [a feedback from support](https://app.intercom.com/a/inbox/ehgzoeah/inbox/admin/5209667/conversation/188350900000480#part_id=comment-188350900000480-16880376118), I added a reminder to ensure that the newly created payment method uses the correct workflow in the checkout process (client-side).