### PR TITLE
Document how to customize CORS HTTP headers

### DIFF
--- a/docs/advanced/performance/assets-cdn-domain.mdx
+++ b/docs/advanced/performance/assets-cdn-domain.mdx
@@ -39,6 +39,10 @@ Serving assets from a custom domain can be done with a configuration change:
 1. [Configure the <abbr title="Content Security Policy">CSP</abbr>](/docs/reference/configurations#configwebsitejs)
    so that assets can be loaded from this external URL
 
+1. You might also have to
+   [allow this domain in CORS origins](/docs/advanced/server/customize-response-http-headers#cross-origin-resource-sharing-aka-cors)
+   to prevent "_has been blocked by CORS policy_" errors
+
 After restarting Front-Commerce, your assets should be loaded from this custom
 domain.
 

--- a/docs/advanced/server/customize-response-http-headers.mdx
+++ b/docs/advanced/server/customize-response-http-headers.mdx
@@ -31,6 +31,69 @@ In Front-Commerce, the content of this header can be controlled by tweaking
 This is where you will be able to let the browser know that for instance it can
 safely load a JavaScript file from a given origin.
 
+## Cross-Origin Resource Sharing (_aka_ CORS)
+
+According to
+[Cross-Origin Resource Sharing (CORS) MDN article](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS):
+
+> Cross-Origin Resource Sharing (CORS) is an HTTP-header based mechanism that
+> allows a server to indicate any origins (domain, scheme, or port) other than
+> its own from which a browser should permit loading resources.
+
+In a nutshell, <abbr title="Cross-Origin Resource Sharing">CORS</abbr> headers
+instructs browsers and remote services whether they're allowed to load a
+specific content or not. This check usually happens with
+[an `OPTIONS` HTTP preflight request](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request).
+
+A typical error you might encounter would be:
+
+> Access to font at
+> 'https://example.com/public/fonts/my-font.priority.xxxx.woff2' from origin
+> 'https://other.example.org' has been blocked by CORS policy: No
+> 'Access-Control-Allow-Origin' header is present on the requested resource.
+
+**In Front-Commerce, the content of this header can be controlled by customizing
+the `cors.origin` configuration** from the
+[`corsConfigProvider`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/server/express/withGlobalHeaders.js#L13).
+
+You must do it from a custom configuration provider. See the
+[Register a configuration provider](/docs/advanced/server/configurations#register-a-configuration-provider)
+guide to learn how to register it in your application.
+
+Here is an example allowing browsers to load your pages from
+`webcache.googleusercontent.com` and `other.example.org` domains:
+
+```js
+const corsOverrideConfigProvider = {
+  name: "corsOverride",
+  values: Promise.resolve({
+    cors: {
+      // This value is the one transmitted to the cors() middleware
+      // see https://www.npmjs.com/package/cors#configuration-options for details
+      origin: {
+        googleCache: "webcache.googleusercontent.com",
+        otherSite: "other.example.org",
+      },
+    },
+  }),
+};
+
+configService.insertAfter("cors", corsOverrideConfigProvider);
+```
+
+:::tip
+
+You can test headers returned from a specific origin by using the `Origin` HTTP
+header. Example:
+
+```shell
+curl -sI https://example.com/ \
+  -H "Origin:webcache.googleusercontent.com" \
+  | grep -i access-control
+```
+
+:::
+
 ## Other headers
 
 To customize other headers send by default, you have to write a custom express

--- a/docs/advanced/server/customize-response-http-headers.mdx
+++ b/docs/advanced/server/customize-response-http-headers.mdx
@@ -45,12 +45,13 @@ instructs browsers and remote services whether they're allowed to load a
 specific content or not. This check usually happens with
 [an `OPTIONS` HTTP preflight request](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request).
 
-A typical error you might encounter would be:
+:::danger A typical error you might encounter would be:
 
-> Access to font at
-> 'https://example.com/public/fonts/my-font.priority.xxxx.woff2' from origin
-> 'https://other.example.org' has been blocked by CORS policy: No
-> 'Access-Control-Allow-Origin' header is present on the requested resource.
+Access to font at 'https://example.com/public/fonts/my-font.priority.xxxx.woff2'
+from origin 'https://other.example.org' has been blocked by CORS policy: No
+'Access-Control-Allow-Origin' header is present on the requested resource.
+
+:::
 
 **In Front-Commerce, the content of this header can be controlled by customizing
 the `cors.origin` configuration** from the


### PR DESCRIPTION
This MR documents how to customize CORS headers.

That has proven to be a useful thing to do for [some customers setting up a CDN](https://app.intercom.com/a/inbox/ehgzoeah/inbox/admin/5209667/conversation/188350900000078#part_id=comment-188350900000078-11599982732) or in other use cases.
For this reason, I also added a link to this new section from  the ["Serving assets from a CDN/custom domain" page (preview)](https://deploy-preview-477--heuristic-almeida-1a1f35.netlify.app/docs/advanced/performance/assets-cdn-domain).

**Preview:** https://deploy-preview-477--heuristic-almeida-1a1f35.netlify.app/docs/advanced/server/customize-response-http-headers#cross-origin-resource-sharing-aka-cors