### PR TITLE
fix(cloud): caching and session cloud variables

### DIFF
--- a/docs/advanced/graphql/dataloaders-and-cache-invalidation.mdx
+++ b/docs/advanced/graphql/dataloaders-and-cache-invalidation.mdx
@@ -458,7 +458,7 @@ It uses node's [`redis` package](https://www.npmjs.com/package/redis) as a redis
 client. Please refer to the package documentation for
 [all the available options](https://www.npmjs.com/package/redis#options-object-properties).
 
-Here is a configuration example:
+Here is a full configuration example:
 
 ```js title="my-module/config/caching.js"
 export default {
@@ -468,9 +468,18 @@ export default {
       supports: "*",
       config: {
         // see https://www.npmjs.com/package/redis#options-object-properties
-        host: "127.0.0.1",
-        port: 6379,
-        db: 1,
+        host:
+          process.env.FRONT_COMMERCE_CLOUD_REDIS_HOST || // Front-Commerce Cloud variables
+          process.env.FRONT_COMMERCE_REDIS_HOST || // default variables
+          "127.0.0.1", // default value (localhost)
+        port:
+          process.env.FRONT_COMMERCE_CLOUD_REDIS_PORT ||
+          process.env.FRONT_COMMERCE_REDIS_PORT ||
+          6379,
+        db:
+          process.env.FRONT_COMMERCE_CLOUD_REDIS_DB ||
+          process.env.FRONT_COMMERCE_REDIS_DB ||
+          0,
         // defaultExpireInSeconds: 82800 // default: 23 hours
       },
     },

--- a/docs/advanced/production-ready/sessions.mdx
+++ b/docs/advanced/production-ready/sessions.mdx
@@ -35,7 +35,10 @@ const redisClient = createClient({
     process.env.FRONT_COMMERCE_CLOUD_REDIS_SESSIONS_PORT ||
     process.env.FRONT_COMMERCE_REDIS_SESSIONS_PORT ||
     6379,
-  db: process.env.FRONT_COMMERCE_REDIS_SESSIONS_DB || 2,
+  db:
+    process.env.FRONT_COMMERCE_CLOUD_REDIS_SESSIONS_DB ||
+    process.env.FRONT_COMMERCE_REDIS_SESSIONS_DB ||
+    2,
 });
 
 module.exports = {

--- a/docs/reference/configurations.mdx
+++ b/docs/reference/configurations.mdx
@@ -251,7 +251,9 @@ Loaders are identified with a key. The key is the first argument passed to the
 
 :::
 
-Example of a recommended configuration for Magento stores:
+Example of a recommended configuration for Magento stores.
+
+Reminder: ensure to take a look at [the redis strategy for the fully configured redis setup](/docs/advanced/graphql/dataloaders-and-cache-invalidation#redis)
 
 ```js
 export default {
@@ -262,7 +264,7 @@ export default {
       supports: "*",
       config: {
         host: "redis",
-        // host: "127.0.0.1"
+        // full configuration at https://developers.front-commerce.com/docs/advanced/graphql/dataloaders-and-cache-invalidation#redis
       },
     },
     {


### PR DESCRIPTION
# What

Following support discussions, the need to clarify the config files for cloud appeared.

I took this opportunity to introduce the new FRONT_COMMERCE_CLOUD_REDIS_DB which will need to be implemented at some point.

# Links

- https://deploy-preview-484--heuristic-almeida-1a1f35.netlify.app/docs/reference/configurations#configcachingjs
- https://deploy-preview-484--heuristic-almeida-1a1f35.netlify.app/docs/advanced/graphql/dataloaders-and-cache-invalidation#redis
- https://deploy-preview-484--heuristic-almeida-1a1f35.netlify.app/docs/advanced/production-ready/sessions