### PR TITLE
fix(migration): add index.html change on 2.7  to 2.8 migration

### DIFF
--- a/docs/appendices/migration-guides/archives.mdx
+++ b/docs/appendices/migration-guides/archives.mdx
@@ -154,6 +154,17 @@ extension** or the `.html` extension.
 If your application contains pages whose URL have extensions other than `.html`,
 please <ContactLink />.
 
+### Custom headers in index.html
+
+If you overrode the theme's index.html, add the following line.
+
+```js title="src/template/index.html"
+    <link rel="shortcut icon" href="%%__ASSETS_BASE_URL__%%/favicon.ico" />
+    // highlight-next-line
+    <%= htmlWebpackPlugin.tags.headTags %>
+    <link rel="manifest" href="%%__BASE_URL__%%/manifest.json" />
+```
+
 ### New features in `2.8.0`
 
 These new features may be relevant for your existing application:


### PR DESCRIPTION
The addition of a line was not documented in the migration guide 
This answers to intercom : https://app.intercom.com/a/inbox/ehgzoeah/inbox/admin/5305956/conversation/188350900000497

See gitlab:  https://gitlab.com/search?search=%3C%25%3D%20htmlWebpackPlugin.tags.headTags%20%25%3E&nav_source=navbar&project_id=9218054&group_id=3903300&search_code=true&repository_ref=main

