### PR TITLE
chore: replace gitlab.com with gitlab.blackswift.cloud

### DIFF
--- a/changelog/front-commerce-2.0-rc.1-ecommerce-web-performance-for-humans.mdx
+++ b/changelog/front-commerce-2.0-rc.1-ecommerce-web-performance-for-humans.mdx
@@ -44,7 +44,7 @@ week to dig into the new features that makes Front-Commerce fast.
 By then, you can browse our documentation and the
 [Migration guides since the last 1.0.0-beta.3 release](/docs/appendices/migration-guides).
 As always, partners and customers can read our
-[full changelog from Front-Commerce release notes](https://gitlab.com/front-commerce/front-commerce/-/releases).
+[full changelog from Front-Commerce release notes](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases).
 
 Feel free to send us [an email](mailto:contact@front-commerce.com) or a
 [Slack](https://join.slack.com/t/front-commerce/shared_invite/enQtMzI2OTEyMDYzOTkxLWEzODg2NjM5MmVhNGUwODE0OTI4MWMwYTcxZWZkNzE1YjU4MzRlZmQ0YWY5NDNkZWM0ZGMzMGQ4NDc4OTgxMTU)

--- a/changelog/front-commerce-2.1.mdx
+++ b/changelog/front-commerce-2.1.mdx
@@ -90,6 +90,6 @@ overall web performance.**
 
 [Upgrade to Front-Commerce 2.1.0](/docs/appendices/migration-guides#2-0-0-gt-2-1-0)
 or
-[read the full changelog (Customers only)](https://gitlab.com/front-commerce/front-commerce/-/releases/2.1.0)
+[read the full changelog (Customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.1.0)
 
 </ChangelogFooter>

--- a/changelog/front-commerce-2.10.mdx
+++ b/changelog/front-commerce-2.10.mdx
@@ -104,12 +104,13 @@ is required for Front-Commerce to work.**
 
 Fixes from the 2.10 version have also been backported into previous minor
 versions. The following patch versions were released:
-[2.4.8](https://gitlab.com/front-commerce/front-commerce/-/releases/2.4.8),
-[2.5.4](https://gitlab.com/front-commerce/front-commerce/-/releases/2.5.4),
-[2.6.2](https://gitlab.com/front-commerce/front-commerce/-/releases/2.6.2),
-[2.7.3](https://gitlab.com/front-commerce/front-commerce/-/releases/2.7.3),
-[2.8.4](https://gitlab.com/front-commerce/front-commerce/-/releases/2.8.4) and
-[2.9.2](https://gitlab.com/front-commerce/front-commerce/-/releases/2.9.2).
+[2.4.8](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.4.8),
+[2.5.4](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.5.4),
+[2.6.2](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.6.2),
+[2.7.3](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.7.3),
+[2.8.4](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.8.4)
+and
+[2.9.2](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.9.2).
 
 <hr />
 
@@ -117,6 +118,6 @@ versions. The following patch versions were released:
 
 [Upgrade to Front-Commerce 2.10.0](/docs/appendices/migration-guides#2-9-0-gt-2-10-0)
 or
-[read the full changelog (Customers only)](https://gitlab.com/front-commerce/front-commerce/-/releases/2.10.0)
+[read the full changelog (Customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.10.0)
 
 </ChangelogFooter>

--- a/changelog/front-commerce-2.11.mdx
+++ b/changelog/front-commerce-2.11.mdx
@@ -150,13 +150,13 @@ Specifically in this version you can :
 - **[Adyen](/docs/advanced/payments/adyen#Install-and-configure-the-Adyen-Payment-Magento2-extension-7-2):**
   payment with Adyen can now be used in a multi server architecture
 - The Magento1 module
-  ([version 1.4.1](https://gitlab.com/front-commerce/magento1-module-front-commerce/-/compare/master...1.4.1))
+  ([version 1.4.1](https://gitlab.blackswift.cloud/front-commerce/magento1-module-front-commerce/-/compare/master...1.4.1))
   now supports batch cache invalidation for better performance
 - Bug fixes:
   - The _estimate shipping_ block was not updated on cart change on chocolatine
     theme
   - We fixed an issue in the Magento2 module
-    ([version 2.4.2](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/releases/2.4.2))
+    ([version 2.4.2](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/releases/2.4.2))
     leading to some GraphQL errors on Magento Cloud and other read only file
     systems
   - Products name in carts and minicarts did not display special characters well
@@ -169,13 +169,14 @@ Specifically in this version you can :
 
 Fixes from the 2.11 version have also been backported into previous minor
 versions. The following patch versions were released:
-[2.4.9](https://gitlab.com/front-commerce/front-commerce/-/releases/2.4.9),
-[2.5.5](https://gitlab.com/front-commerce/front-commerce/-/releases/2.5.5),
-[2.6.3](https://gitlab.com/front-commerce/front-commerce/-/releases/2.6.3),
-[2.7.4](https://gitlab.com/front-commerce/front-commerce/-/releases/2.7.4),
-[2.8.5](https://gitlab.com/front-commerce/front-commerce/-/releases/2.8.5),
-[2.9.4](https://gitlab.com/front-commerce/front-commerce/-/releases/2.9.4) and
-[2.10.2](https://gitlab.com/front-commerce/front-commerce/-/releases/2.10.2).
+[2.4.9](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.4.9),
+[2.5.5](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.5.5),
+[2.6.3](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.6.3),
+[2.7.4](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.7.4),
+[2.8.5](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.8.5),
+[2.9.4](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.9.4)
+and
+[2.10.2](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.10.2).
 
 <hr />
 
@@ -183,6 +184,6 @@ versions. The following patch versions were released:
 
 [Upgrade to Front-Commerce 2.11.0](/docs/appendices/migration-guides#2-10-0-gt-2-11-0)
 or
-[read the full changelog (Customers only)](https://gitlab.com/front-commerce/front-commerce/-/releases/2.11.0)
+[read the full changelog (Customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.11.0)
 
 </ChangelogFooter>

--- a/changelog/front-commerce-2.12.mdx
+++ b/changelog/front-commerce-2.12.mdx
@@ -139,7 +139,7 @@ identified axis of improvement
 
 - **Dependencies**: we’re continuing to upgrade dependencies to their latest
   versions, see
-  [the 28 Merge Requests of 2.12](https://gitlab.com/front-commerce/front-commerce/-/merge_requests?scope=all&state=merged&label_name[]=depfu&milestone_title=2.12)
+  [the 28 Merge Requests of 2.12](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests?scope=all&state=merged&label_name[]=depfu&milestone_title=2.12)
 - **DX:** `reorderForIds` related messages are now displayed as `DEBUG=axios`
   messages. Your logs will ❤️ it!
 - **Analytics:** the consent cookie is now valid for 12 months by default
@@ -171,15 +171,15 @@ identified axis of improvement
 
 Fixes from the 2.12 version have also been backported into previous minor
 versions. The following patch versions were released:
-[2.4.10](https://gitlab.com/front-commerce/front-commerce/-/releases/2.4.10),
-[2.5.6](https://gitlab.com/front-commerce/front-commerce/-/releases/2.5.6),
-[2.6.4](https://gitlab.com/front-commerce/front-commerce/-/releases/2.6.4),
-[2.7.5](https://gitlab.com/front-commerce/front-commerce/-/releases/2.7.5),
-[2.8.6](https://gitlab.com/front-commerce/front-commerce/-/releases/2.8.6),
-[2.9.5](https://gitlab.com/front-commerce/front-commerce/-/releases/2.9.5)
-[2.10.3](https://gitlab.com/front-commerce/front-commerce/-/releases/2.10.3).
+[2.4.10](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.4.10),
+[2.5.6](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.5.6),
+[2.6.4](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.6.4),
+[2.7.5](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.7.5),
+[2.8.6](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.8.6),
+[2.9.5](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.9.5)
+[2.10.3](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.10.3).
 and
-[2.11.1](https://gitlab.com/front-commerce/front-commerce/-/releases/2.11.1).
+[2.11.1](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.11.1).
 
 <hr />
 
@@ -187,6 +187,6 @@ and
 
 [Upgrade to Front-Commerce 2.12.0](/docs/appendices/migration-guides#2-11-0-gt-2-12-0)
 or
-[read the full changelog (Customers only)](https://gitlab.com/front-commerce/front-commerce/-/releases/2.12.0)
+[read the full changelog (Customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.12.0)
 
 </ChangelogFooter>

--- a/changelog/front-commerce-2.13.mdx
+++ b/changelog/front-commerce-2.13.mdx
@@ -150,21 +150,21 @@ You can check it out here:
 
 Fixes from the 2.13 version have also been backported into previous minor
 versions. The following patch versions were released:
-[2.5.7](https://gitlab.com/front-commerce/front-commerce/-/releases/2.5.7),
-[**2.5.8**](https://gitlab.com/front-commerce/front-commerce/-/releases/2.5.8),
-[2.6.5](https://gitlab.com/front-commerce/front-commerce/-/releases/2.6.5),
-[**2.6.6**](https://gitlab.com/front-commerce/front-commerce/-/releases/2.6.6),
-[2.7.6](https://gitlab.com/front-commerce/front-commerce/-/releases/2.7.6),
-[**2.7.7**](https://gitlab.com/front-commerce/front-commerce/-/releases/2.7.7),
-[2.8.7](https://gitlab.com/front-commerce/front-commerce/-/releases/2.8.7),
-[**2.8.8**](https://gitlab.com/front-commerce/front-commerce/-/releases/2.8.8),
-[2.9.6](https://gitlab.com/front-commerce/front-commerce/-/releases/2.9.6),
-[**2.9.7**](https://gitlab.com/front-commerce/front-commerce/-/releases/2.9.7),
-[2.10.4](https://gitlab.com/front-commerce/front-commerce/-/releases/2.10.4),
-[**2.10.5**](https://gitlab.com/front-commerce/front-commerce/-/releases/2.10.5),
-[**2.11.2**](https://gitlab.com/front-commerce/front-commerce/-/releases/2.11.2)
+[2.5.7](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.5.7),
+[**2.5.8**](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.5.8),
+[2.6.5](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.6.5),
+[**2.6.6**](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.6.6),
+[2.7.6](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.7.6),
+[**2.7.7**](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.7.7),
+[2.8.7](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.8.7),
+[**2.8.8**](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.8.8),
+[2.9.6](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.9.6),
+[**2.9.7**](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.9.7),
+[2.10.4](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.10.4),
+[**2.10.5**](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.10.5),
+[**2.11.2**](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.11.2)
 and
-[**2.12.1**](https://gitlab.com/front-commerce/front-commerce/-/releases/2.12.1).
+[**2.12.1**](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.12.1).
 
 ### Performance Improvements
 
@@ -186,6 +186,6 @@ and
 
 [Upgrade to Front-Commerce 2.13.0](/docs/appendices/migration-guides#2-12-0-gt-2-13-0)
 or
-[read the full changelog (Customers only)](https://gitlab.com/front-commerce/front-commerce/-/releases/2.13.0)
+[read the full changelog (Customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.13.0)
 
 </ChangelogFooter>

--- a/changelog/front-commerce-2.14.mdx
+++ b/changelog/front-commerce-2.14.mdx
@@ -133,14 +133,15 @@ We hope you find these improvements helpful!
 
 Fixes from the 2.14 version have also been backported into previous minor
 versions. The following patch versions were released:
-[2.6.7](https://gitlab.com/front-commerce/front-commerce/-/releases/2.6.7),
-[2.7.8](https://gitlab.com/front-commerce/front-commerce/-/releases/2.7.8),
-[2.8.9](https://gitlab.com/front-commerce/front-commerce/-/releases/2.8.9),
-[2.9.8](https://gitlab.com/front-commerce/front-commerce/-/releases/2.9.8),
-[2.10.6](https://gitlab.com/front-commerce/front-commerce/-/releases/2.10.6),
-[2.11.3](https://gitlab.com/front-commerce/front-commerce/-/releases/2.11.3)
-[2.12.2](https://gitlab.com/front-commerce/front-commerce/-/releases/2.12.2) and
-[2.13.3](https://gitlab.com/front-commerce/front-commerce/-/releases/2.13.3).
+[2.6.7](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.6.7),
+[2.7.8](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.7.8),
+[2.8.9](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.8.9),
+[2.9.8](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.9.8),
+[2.10.6](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.10.6),
+[2.11.3](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.11.3)
+[2.12.2](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.12.2)
+and
+[2.13.3](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.13.3).
 
 ### Features
 
@@ -162,6 +163,6 @@ versions. The following patch versions were released:
 
 [Upgrade to Front-Commerce 2.14.0](/docs/appendices/migration-guides#2-13-0-gt-2-14-0)
 or
-[read the full changelog (Customers only)](https://gitlab.com/front-commerce/front-commerce/-/releases/2.14.0)
+[read the full changelog (Customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.14.0)
 
 </ChangelogFooter>

--- a/changelog/front-commerce-2.15.mdx
+++ b/changelog/front-commerce-2.15.mdx
@@ -161,6 +161,6 @@ to deliver media on your e-commerce website.
 
 [Upgrade to Front-Commerce 2.15.0](/docs/appendices/migration-guides#2-14-0-gt-2-15-0)
 or
-[read the full changelog (Customers only)](https://gitlab.com/front-commerce/front-commerce/-/releases/2.15.0)
+[read the full changelog (Customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.15.0)
 
 </ChangelogFooter>

--- a/changelog/front-commerce-2.16.mdx
+++ b/changelog/front-commerce-2.16.mdx
@@ -99,66 +99,66 @@ maintenance page.
 ### Features
 
 - **dx:** debug the available payment methods
-  ([25cb164](https://gitlab.com/front-commerce/front-commerce/commit/25cb1643010f9c31ee62b9b9f0ba1c228fb92bd6))
+  ([25cb164](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/25cb1643010f9c31ee62b9b9f0ba1c228fb92bd6))
 - **graph:** created fc core order type
-  ([1adba61](https://gitlab.com/front-commerce/front-commerce/commit/1adba61e76cc8be00d6118d5384f764ddbb67b83))
+  ([1adba61](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/1adba61e76cc8be00d6118d5384f764ddbb67b83))
 - **magento2:** uses SHA256 for admin OAuth encryption for 2.4.4 compat
-  ([4707b2b](https://gitlab.com/front-commerce/front-commerce/commit/4707b2b629528299766c081fc4c5bdc24278bd33))
+  ([4707b2b](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/4707b2b629528299766c081fc4c5bdc24278bd33))
 - **react:** prevent client side hydration with `window.__HYDRATE__ = false`
-  ([d545655](https://gitlab.com/front-commerce/front-commerce/commit/d545655d9d21df4874505e185d4f8f0b02225bfa))
+  ([d545655](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/d545655d9d21df4874505e185d4f8f0b02225bfa))
 
 ### Bug Fixes
 
 - **build:** fixed build following simultaneous uncompatible merges
-  ([53620ef](https://gitlab.com/front-commerce/front-commerce/commit/53620ef1d5744ff7cba36bce4e9ea0363e758b2a))
+  ([53620ef](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/53620ef1d5744ff7cba36bce4e9ea0363e758b2a))
 - **buybox:** additionnalData casting for ReturnFromPayment workflow
-  ([64ec5d1](https://gitlab.com/front-commerce/front-commerce/commit/64ec5d18a51e3d1652c5502d897a4b5de19b5a56))
+  ([64ec5d1](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/64ec5d18a51e3d1652c5502d897a4b5de19b5a56))
 - **buybox:** doExpressCheckoutPayment must return an object
-  ([24c955c](https://gitlab.com/front-commerce/front-commerce/commit/24c955caa5726c74d7e54621ba5725262bf70aac))
+  ([24c955c](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/24c955caa5726c74d7e54621ba5725262bf70aac))
 - **checkout:** return only free payment method when applicable
-  ([8fc4c72](https://gitlab.com/front-commerce/front-commerce/commit/8fc4c7210a12161811834fbdb8041631849f05f6))
+  ([8fc4c72](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/8fc4c7210a12161811834fbdb8041631849f05f6))
 - **dataLoader:** properly handle error in makeBatchLoaderFromSingleFetch
-  ([3f15c52](https://gitlab.com/front-commerce/front-commerce/commit/3f15c52e92da01becc45b7e527fa02a5914053ff))
+  ([3f15c52](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/3f15c52e92da01becc45b7e527fa02a5914053ff))
 - **dependencies:** directly install @types/node
-  ([894efc6](https://gitlab.com/front-commerce/front-commerce/commit/894efc680ed212913eaae3e57a8fd268406082cc))
+  ([894efc6](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/894efc680ed212913eaae3e57a8fd268406082cc))
 - **e2e:** M2 prices after tax change
-  ([16a14cd](https://gitlab.com/front-commerce/front-commerce/commit/16a14cde0a626150e21aa1bade1b5490a260ffa4))
+  ([16a14cd](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/16a14cde0a626150e21aa1bade1b5490a260ffa4))
 - **e2e:** M2 prices after tax change
-  ([88af0e8](https://gitlab.com/front-commerce/front-commerce/commit/88af0e89db956df5cd63a18c87cae73911db41f1))
+  ([88af0e8](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/88af0e89db956df5cd63a18c87cae73911db41f1))
 - **hipay:** PaymentAuthorized saved with undefined transactionReference
-  ([15981b9](https://gitlab.com/front-commerce/front-commerce/commit/15981b920dc7f1ecb07ac853b9a535a0fd3c1c1f))
+  ([15981b9](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/15981b920dc7f1ecb07ac853b9a535a0fd3c1c1f))
 - **search:** adjusted for tax for M2 native search
-  ([773473a](https://gitlab.com/front-commerce/front-commerce/commit/773473a432ee1fae628bb04e99d9fca44cd8a5a6))
+  ([773473a](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/773473a432ee1fae628bb04e99d9fca44cd8a5a6))
 - translations
-  ([ca70d5e](https://gitlab.com/front-commerce/front-commerce/commit/ca70d5e2ca25d7c78a11687bee7a64a5c7895425))
+  ([ca70d5e](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/ca70d5e2ca25d7c78a11687bee7a64a5c7895425))
 - **hipay:** delay PaymentCaptured event to prevent overlapping
-  ([1718a93](https://gitlab.com/front-commerce/front-commerce/commit/1718a93c1cf4c27f09646fbc286e19d0b2ca4568))
+  ([1718a93](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/1718a93c1cf4c27f09646fbc286e19d0b2ca4568))
 - **hipay:** reference the transactionId in order history for all payments
-  ([4b768bb](https://gitlab.com/front-commerce/front-commerce/commit/4b768bb7e28c2ce480a12d5373146b9ecc59793e))
+  ([4b768bb](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/4b768bb7e28c2ce480a12d5373146b9ecc59793e))
 - **magento1:** remove invoice schema import
-  ([980c847](https://gitlab.com/front-commerce/front-commerce/commit/980c8477f9ef3999f82835ceac797e864c32b2f3))
+  ([980c847](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/980c8477f9ef3999f82835ceac797e864c32b2f3))
 - **payline:** add an additional delayed API initialization
-  ([90cb675](https://gitlab.com/front-commerce/front-commerce/commit/90cb675a61153822ef069e76db7b7736ddc18e52))
+  ([90cb675](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/90cb675a61153822ef069e76db7b7736ddc18e52))
 - **payline:** initialize the payment widget ourselves to prevent safari issues
-  ([a4b0e70](https://gitlab.com/front-commerce/front-commerce/commit/a4b0e7002e51d5269a9982404707af91c9a9da03))
+  ([a4b0e70](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/a4b0e7002e51d5269a9982404707af91c9a9da03))
 - **payments:** provide a paymentDetails loader in withPaymentApi
-  ([aef830c](https://gitlab.com/front-commerce/front-commerce/commit/aef830c64095d14aa2b98f43270705d92c71abd0))
+  ([aef830c](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/aef830c64095d14aa2b98f43270705d92c71abd0))
 - **search:** elasticsuite compatibility for version >= 2.10.6
-  ([7436c31](https://gitlab.com/front-commerce/front-commerce/commit/7436c3153ce1c1a6f8f37e2831894622f3410c2a))
+  ([7436c31](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/7436c3153ce1c1a6f8f37e2831894622f3410c2a))
 
 Fixes from the
-[2.16](https://gitlab.com/front-commerce/front-commerce/-/releases/2.16.0)
+[2.16](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.16.0)
 version have also been backported into previous minor versions. The following
 patch versions were released:
-[2.8.12](https://gitlab.com/front-commerce/front-commerce/-/releases/2.8.12),
-[2.9.11](https://gitlab.com/front-commerce/front-commerce/-/releases/2.9.11),
-[2.10.9](https://gitlab.com/front-commerce/front-commerce/-/releases/2.10.9),
-[2.11.6](https://gitlab.com/front-commerce/front-commerce/-/releases/2.11.6)
-[2.12.5](https://gitlab.com/front-commerce/front-commerce/-/releases/2.12.5)
-[2.13.6](https://gitlab.com/front-commerce/front-commerce/-/releases/2.13.6).
-[2.14.3](https://gitlab.com/front-commerce/front-commerce/-/releases/2.14.3).
+[2.8.12](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.8.12),
+[2.9.11](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.9.11),
+[2.10.9](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.10.9),
+[2.11.6](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.11.6)
+[2.12.5](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.12.5)
+[2.13.6](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.13.6).
+[2.14.3](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.14.3).
 and
-[2.15.2](https://gitlab.com/front-commerce/front-commerce/-/releases/2.15.2).
+[2.15.2](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.15.2).
 
 <hr />
 
@@ -166,6 +166,6 @@ and
 
 [Upgrade to Front-Commerce 2.16.0](/docs/appendices/migration-guides#2-14-0-gt-2-15-0)
 or
-[read the full changelog (Customers only)](https://gitlab.com/front-commerce/front-commerce/-/releases/2.15.0)
+[read the full changelog (Customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.15.0)
 
 </ChangelogFooter>

--- a/changelog/front-commerce-2.17.mdx
+++ b/changelog/front-commerce-2.17.mdx
@@ -118,31 +118,31 @@ this new feature! Want to see more? Here is the demo:
 ```
 
 - **logging:** add custom type to provide winston transport directly
-  ([18a37b7](https://gitlab.com/front-commerce/front-commerce/commit/18a37b7c5a54a2d52e87335c60412361e35e3d16))
+  ([18a37b7](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/18a37b7c5a54a2d52e87335c60412361e35e3d16))
 - **cache:** allow passing a cacheMap to redis-dataloader
-  ([a38e5e7](https://gitlab.com/front-commerce/front-commerce/commit/a38e5e7af0e12cf242797c93dbf97ddc31f6ff30))
+  ([a38e5e7](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/a38e5e7af0e12cf242797c93dbf97ddc31f6ff30))
 - **checkout:** limit cart status to customers carts
-  ([81896bb](https://gitlab.com/front-commerce/front-commerce/commit/81896bb8bf1c821a934a0d9ab9181383d91fb002))
+  ([81896bb](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/81896bb8bf1c821a934a0d9ab9181383d91fb002))
 - **magento2:** cancel the order on PaymentRefused
-  ([600fd7c](https://gitlab.com/front-commerce/front-commerce/commit/600fd7ca2272f4866798a962212adacfbf1dc5a0))
+  ([600fd7c](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/600fd7ca2272f4866798a962212adacfbf1dc5a0))
 - **magento2:** handle guest cart to order for PlaceOrderCommand
-  ([6848e4f](https://gitlab.com/front-commerce/front-commerce/commit/6848e4f9eec97904e0ec1267e508880fe575959d))
+  ([6848e4f](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/6848e4f9eec97904e0ec1267e508880fe575959d))
 - **magento2:** handle PlaceOrder payment command
-  ([65f9b6c](https://gitlab.com/front-commerce/front-commerce/commit/65f9b6c2b8bb9b25ffc25e7b0e432a199733711a))
+  ([65f9b6c](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/65f9b6c2b8bb9b25ffc25e7b0e432a199733711a))
 - **magento2:** use checkout status on asyncOrder
-  ([d97511a](https://gitlab.com/front-commerce/front-commerce/commit/d97511abe02cbe1320c666b52b3d29a561332c49))
+  ([d97511a](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/d97511abe02cbe1320c666b52b3d29a561332c49))
 - **payment:** allow DomainEvents to ref by cartId
-  ([c1b0220](https://gitlab.com/front-commerce/front-commerce/commit/c1b0220ed34b423d85c2eef0e9c03b07fff181ec))
+  ([c1b0220](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/c1b0220ed34b423d85c2eef0e9c03b07fff181ec))
 - **payments:** create command dispatcher for IPN notifications
-  ([d8b9135](https://gitlab.com/front-commerce/front-commerce/commit/d8b91353d407ea848a1ea99e10f11231d1cb95da))
+  ([d8b9135](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/d8b91353d407ea848a1ea99e10f11231d1cb95da))
 - **paypal:** use DomainEvents properly
-  ([b00f371](https://gitlab.com/front-commerce/front-commerce/commit/b00f371f125a556211d39aab3172170f8ab2f9ee))
+  ([b00f371](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/b00f371f125a556211d39aab3172170f8ab2f9ee))
 - **payzen:** capture payment by IPN
-  ([edf0f5d](https://gitlab.com/front-commerce/front-commerce/commit/edf0f5dbc46e53d79007e7f9991a0c034ce3b863))
+  ([edf0f5d](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/edf0f5dbc46e53d79007e7f9991a0c034ce3b863))
 - **payzen:** create AsyncOrder payment workflow
-  ([11026ec](https://gitlab.com/front-commerce/front-commerce/commit/11026ec32778d67bd8a38f2146c366857aa0c5fa))
+  ([11026ec](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/11026ec32778d67bd8a38f2146c366857aa0c5fa))
 - **payzen:** finalize IPN handling
-  ([2d83039](https://gitlab.com/front-commerce/front-commerce/commit/2d83039a2aa5188d6c19aa0463e16538301339be))
+  ([2d83039](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/2d83039a2aa5188d6c19aa0463e16538301339be))
 
 ```mdx-code-block
 </details>
@@ -151,19 +151,19 @@ this new feature! Want to see more? Here is the demo:
 ```
 
 - **headers:** configure helmet 5.x to have the same behavior as helmet 4.x
-  ([2457057](https://gitlab.com/front-commerce/front-commerce/commit/245705798ac2fc48bed42bd1a58c6f1aeca42413))
+  ([2457057](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/245705798ac2fc48bed42bd1a58c6f1aeca42413))
 - **lint:** Fixed lint
-  ([5aee0d4](https://gitlab.com/front-commerce/front-commerce/commit/5aee0d471450feac8649a3f0edaa7fcecdb868d8))
+  ([5aee0d4](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/5aee0d471450feac8649a3f0edaa7fcecdb868d8))
 - **prices:** magento 1 product min price don't care tier prices
-  ([ce7d43f](https://gitlab.com/front-commerce/front-commerce/commit/ce7d43f931108832243869404d168ef0e1705cd7))
+  ([ce7d43f](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/ce7d43f931108832243869404d168ef0e1705cd7))
 - **magento2:** allow to return RMA items with custom attributes
-  ([a620ee1](https://gitlab.com/front-commerce/front-commerce/commit/a620ee12a618b153a3a474509ba3ec9842c37a47))
+  ([a620ee1](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/a620ee12a618b153a3a474509ba3ec9842c37a47))
 - **magento2:** expose actual store credit in orders instead of 0
-  ([74b8c73](https://gitlab.com/front-commerce/front-commerce/commit/74b8c73d2921815e9764b4933af490220793a3b5))
+  ([74b8c73](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/74b8c73d2921815e9764b4933af490220793a3b5))
 - **magento2:** Fix crash when customer loader call fails
-  ([5ecf11a](https://gitlab.com/front-commerce/front-commerce/commit/5ecf11a12455b095a5f67afa683b66f3ec52541a))
+  ([5ecf11a](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/5ecf11a12455b095a5f67afa683b66f3ec52541a))
 - **payzen:** duplicated place order notification
-  ([e2883de](https://gitlab.com/front-commerce/front-commerce/commit/e2883de624e4f4326a204103f2816b440374905a))
+  ([e2883de](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/e2883de624e4f4326a204103f2816b440374905a))
 
 ```mdx-code-block
 </details>
@@ -188,6 +188,6 @@ this new feature! Want to see more? Here is the demo:
 
 [Upgrade to Front-Commerce 2.17.0](/docs/appendices/migration-guides#2160---2170)
 or
-[read the full changelog (Customers only)](https://gitlab.com/front-commerce/front-commerce/-/releases/2.17.0)
+[read the full changelog (Customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.17.0)
 
 </ChangelogFooter>

--- a/changelog/front-commerce-2.18.mdx
+++ b/changelog/front-commerce-2.18.mdx
@@ -5,26 +5,38 @@ date: 2022-09-15T18:00
 hide_table_of_contents: true
 ---
 
-
 ## 2.18: Improvements and fixes on our payment modules (Adyen, Lyra, PayPal), Prismic: 1.0.0 and major change, end of our migration from [Platform.sh](http://Platform.sh) to Front-Commerce Cloud, based on GCP
 
-It is back to school time! After a very (very) hot summer, during which we all enjoyed a well-deserved break, the Front-Commerce team is back and raring to go 💪
+It is back to school time! After a very (very) hot summer, during which we all
+enjoyed a well-deserved break, the Front-Commerce team is back and raring to go
+💪
 
-We are pleased to welcome [Alice](https://www.linkedin.com/in/alice-malby-343383132/) to the team, who joins Rachael's marketing team as Lead Generation Manager. Welcome Alice!
+We are pleased to welcome
+[Alice](https://www.linkedin.com/in/alice-malby-343383132/) to the team, who
+joins Rachael's marketing team as Lead Generation Manager. Welcome Alice!
 
-Concerning the 2.18.0 release, it will certainly appear less packed than usual, because of the holiday in August and because we made progress on projects that we will reveal publicly a little later 🍿
+Concerning the 2.18.0 release, it will certainly appear less packed than usual,
+because of the holiday in August and because we made progress on projects that
+we will reveal publicly a little later 🍿
 
 So here is Front-Commerce 2.18:
 
 - We have made improvements to our payment modules (PayPal, Lyra, Adyen)
-- We made the official 1.0.0 tag of our Prismic module and modified the way we manage it, see below for details
-- We have made progress on our connector with the search and merchandising solution [Attraqt](https://attraqt.com/), which will be released in a beta version in the coming weeks, stay tuned!
-- We added the reset my password feature to our BigCommerce connector: every essential e-commerce feature is now available for this connector!
-- Our cloud offer is gradually being strengthened with the implementation of an interface to manage your instances! All our sites are now switched to our cloud offer 🎉
+- We made the official 1.0.0 tag of our Prismic module and modified the way we
+  manage it, see below for details
+- We have made progress on our connector with the search and merchandising
+  solution [Attraqt](https://attraqt.com/), which will be released in a beta
+  version in the coming weeks, stay tuned!
+- We added the reset my password feature to our BigCommerce connector: every
+  essential e-commerce feature is now available for this connector!
+- Our cloud offer is gradually being strengthened with the implementation of an
+  interface to manage your instances! All our sites are now switched to our
+  cloud offer 🎉
 
 We wish you all the best for Q4! As for us, we're all set 😎
 
-As always, should you have any requests regarding the product roadmap, do not hesitate to contact Josquin 👋
+As always, should you have any requests regarding the product roadmap, do not
+hesitate to contact Josquin 👋
 
 <!--truncate-->
 
@@ -33,17 +45,26 @@ import BackportList from "@site/src/components/BackportList";
 
 ### ❕Prismic: tag of the 1.0.0 of the module and major change starting from 2.18
 
-Starting from Front-Commerce 2.18.0, we will change the way we work with our Prismic connector.
+Starting from Front-Commerce 2.18.0, we will change the way we work with our
+Prismic connector.
 
-Until now, the Prismic connector was delivered in a dedicated module with its own release cadence and versioning. We did this to be able to deliver improvements and new features faster to our early adopters.
+Until now, the Prismic connector was delivered in a dedicated module with its
+own release cadence and versioning. We did this to be able to deliver
+improvements and new features faster to our early adopters.
 
-Now that several customers have proven the robustness of the module and its APIs for integrators, we consider it as stable and tagged a final version 1.0.0 for the module.
+Now that several customers have proven the robustness of the module and its APIs
+for integrators, we consider it as stable and tagged a final version 1.0.0 for
+the module.
 
-As of 2.18.0, this module is now in the Front-Commerce core. New features and improvements will follow [our usual release cadence](https://developers.front-commerce.com/docs/appendices/release-process) and predictability for integrators and merchants.
+As of 2.18.0, this module is now in the Front-Commerce core. New features and
+improvements will follow
+[our usual release cadence](https://developers.front-commerce.com/docs/appendices/release-process)
+and predictability for integrators and merchants.
 
 ![Before 2.17.X (included): final version 1.0.0 for the the Front-Commerce Prismic module](./assets/Untitled.png)
 
-Before 2.17.X (included): final version 1.0.0 for the the Front-Commerce Prismic module
+Before 2.17.X (included): final version 1.0.0 for the the Front-Commerce Prismic
+module
 
 ![From 2.18.0 (included): the module is now in the Front-Commerce core](./assets/prismic.png)
 
@@ -51,17 +72,31 @@ From 2.18.0 (included): the module is now in the Front-Commerce core
 
 ### About Front-Commerce Cloud
 
-In August we migrated every front-end hosted by Front-Commerce to our new infrastructure, Front-Commerce Cloud. They are all now up and running 😎
+In August we migrated every front-end hosted by Front-Commerce to our new
+infrastructure, Front-Commerce Cloud. They are all now up and running 😎
 
-This allows merchants to benefit from auto-scaling (environments automatically add resources to handle the load), better reliability, and better monitoring and support!
+This allows merchants to benefit from auto-scaling (environments automatically
+add resources to handle the load), better reliability, and better monitoring and
+support!
 
-And in regards to our support offer, we are working on a nice interface so that you will be able to monitor your infrastructures, deal with environment variables and quickly access our support team: more to come (very) soon 👀
+And in regards to our support offer, we are working on a nice interface so that
+you will be able to monitor your infrastructures, deal with environment
+variables and quickly access our support team: more to come (very) soon 👀
 
 ### Improvements in our payment modules
 
-With the release of Magento 2.4.4, we had to adapt parts of our modules to ensure compatibility: that was the case for [our Adyen connector](https://developers.front-commerce.com/docs/advanced/payments/adyen)
+With the release of Magento 2.4.4, we had to adapt parts of our modules to
+ensure compatibility: that was the case for
+[our Adyen connector](https://developers.front-commerce.com/docs/advanced/payments/adyen)
 
-For our [PayPal](https://developers.front-commerce.com/docs/advanced/payments/paypal) and our [Lyra](https://developers.front-commerce.com/docs/advanced/payments/payzen) integrations, we worked on payments IPN improvements (Instant Payment Notification) to provide asynchronous validation for embedded payments and other improvements from customer feedback. Want to know more about it? Read [the documentation about payments with Front-Commerce!](https://developers.front-commerce.com/docs/category/payments)
+For our
+[PayPal](https://developers.front-commerce.com/docs/advanced/payments/paypal)
+and our
+[Lyra](https://developers.front-commerce.com/docs/advanced/payments/payzen)
+integrations, we worked on payments IPN improvements (Instant Payment
+Notification) to provide asynchronous validation for embedded payments and other
+improvements from customer feedback. Want to know more about it? Read
+[the documentation about payments with Front-Commerce!](https://developers.front-commerce.com/docs/category/payments)
 
 ## Other changes
 
@@ -82,9 +117,11 @@ For our [PayPal](https://developers.front-commerce.com/docs/advanced/payments/pa
 
 - **BigCommerce:** add an image proxy to serve resized and optimized images
 - **BigCommerce:** reset my password
-- **GraphQL:** remove FRONT_COMMERCE_WEB_UNSAFE_USE_DEPRECATED_FIELDS env. support
+- **GraphQL:** remove FRONT_COMMERCE_WEB_UNSAFE_USE_DEPRECATED_FIELDS env.
+  support
 - **UX:** prevent event propagation on clicks on a pending button
-- **Front-Commerce Prismic module:** add default preset format for image transformer
+- **Front-Commerce Prismic module:** add default preset format for image
+  transformer
 
 <BackportList
   currentVersion={"2.18.0"}
@@ -106,6 +143,6 @@ For our [PayPal](https://developers.front-commerce.com/docs/advanced/payments/pa
 
 [Upgrade to Front-Commerce 2.18.0](/docs/appendices/migration-guides#2170---2180)
 or
-[read the full changelog (Customers only)](https://gitlab.com/front-commerce/front-commerce/-/releases/2.18.0)
+[read the full changelog (Customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.18.0)
 
 </ChangelogFooter>

--- a/changelog/front-commerce-2.2.mdx
+++ b/changelog/front-commerce-2.2.mdx
@@ -84,6 +84,6 @@ Wordpress.
 
 [Upgrade to Front-Commerce 2.2.0](/docs/appendices/migration-guides#2-1-x-gt-2-2-0)
 or
-[read the full changelog (Customers only)](https://gitlab.com/front-commerce/front-commerce/-/releases/2.2.0)
+[read the full changelog (Customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.2.0)
 
 </ChangelogFooter>

--- a/changelog/front-commerce-2.3.mdx
+++ b/changelog/front-commerce-2.3.mdx
@@ -88,6 +88,6 @@ releases will bring new features in that sense too.
 
 [Upgrade to Front-Commerce 2.3.0](/docs/appendices/migration-guides#2-2-x-gt-2-3-0)
 or
-[read the full changelog (Customers only)](https://gitlab.com/front-commerce/front-commerce/-/releases/2.3.0)
+[read the full changelog (Customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.3.0)
 
 </ChangelogFooter>

--- a/changelog/front-commerce-2.4.mdx
+++ b/changelog/front-commerce-2.4.mdx
@@ -111,6 +111,6 @@ from them depending on their context.
 
 [Upgrade to Front-Commerce 2.4.0](/docs/appendices/migration-guides#2-3-x-gt-2-4-0)
 or
-[read the full changelog (Customers only)](https://gitlab.com/front-commerce/front-commerce/-/releases/2.4.0)
+[read the full changelog (Customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.4.0)
 
 </ChangelogFooter>

--- a/changelog/front-commerce-2.5.mdx
+++ b/changelog/front-commerce-2.5.mdx
@@ -149,6 +149,6 @@ your bookmarks as we will enrich it over time!
 
 [Upgrade to Front-Commerce 2.5.0](/docs/appendices/migration-guides#2-4-0-gt-2-5-0)
 or
-[read the full changelog (Customers only)](https://gitlab.com/front-commerce/front-commerce/-/releases/2.5.0)
+[read the full changelog (Customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.5.0)
 
 </ChangelogFooter>

--- a/changelog/front-commerce-2.6.mdx
+++ b/changelog/front-commerce-2.6.mdx
@@ -162,6 +162,6 @@ your specific context. Together, let's make it even better!**
 
 [Upgrade to Front-Commerce 2.6.0](/docs/appendices/migration-guides#2-5-0-gt-2-6-0)
 or
-[read the full changelog (Customers only)](https://gitlab.com/front-commerce/front-commerce/-/releases/2.6.0)
+[read the full changelog (Customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.6.0)
 
 </ChangelogFooter>

--- a/changelog/front-commerce-2.7.mdx
+++ b/changelog/front-commerce-2.7.mdx
@@ -80,6 +80,6 @@ areas:
 
 [Upgrade to Front-Commerce 2.7.0](/docs/appendices/migration-guides#2-6-0-gt-2-7-0)
 or
-[read the full changelog (Customers only)](https://gitlab.com/front-commerce/front-commerce/-/releases/2.7.0)
+[read the full changelog (Customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.7.0)
 
 </ChangelogFooter>

--- a/changelog/front-commerce-2.8.mdx
+++ b/changelog/front-commerce-2.8.mdx
@@ -67,7 +67,7 @@ warnings and errors aggregated from Front-Commerce Cloud customers' logs. We've
 also spent time on performance testing and profiled our server to optimize some
 areas.
 
-[Bugfixes](https://gitlab.com/front-commerce/front-commerce/-/releases/2.8.0#bug-fixes)
+[Bugfixes](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.8.0#bug-fixes)
 will be backported to all 2.4+ Front-Commerce versions in the next few days, so
 they can benefit all customers.
 
@@ -92,6 +92,6 @@ they can benefit all customers.
 
 [Upgrade to Front-Commerce 2.8.0](/docs/appendices/migration-guides#2-7-0-gt-2-8-0)
 or
-[read the full changelog (Customers only)](https://gitlab.com/front-commerce/front-commerce/-/releases/2.8.0)
+[read the full changelog (Customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.8.0)
 
 </ChangelogFooter>

--- a/changelog/front-commerce-2.9.mdx
+++ b/changelog/front-commerce-2.9.mdx
@@ -25,12 +25,13 @@ It allows customers to update their project without waiting for a minor version
 upgrade. Each release contains bugfixes fixed in later minor versions.
 
 For details, please visit each version’s release page:
-[2.8.1](https://gitlab.com/front-commerce/front-commerce/-/releases/2.8.1),
-[2.7.2](https://gitlab.com/front-commerce/front-commerce/-/releases/2.7.2),
-[2.7.1](https://gitlab.com/front-commerce/front-commerce/-/releases/2.7.1),
-[2.6.1](https://gitlab.com/front-commerce/front-commerce/-/releases/2.6.1),
-[2.5.3](https://gitlab.com/front-commerce/front-commerce/-/releases/2.5.3) and
-[2.4.7](https://gitlab.com/front-commerce/front-commerce/-/releases/2.4.7).
+[2.8.1](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.8.1),
+[2.7.2](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.7.2),
+[2.7.1](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.7.1),
+[2.6.1](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.6.1),
+[2.5.3](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.5.3)
+and
+[2.4.7](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.4.7).
 
 ## Front-Commerce payments improved
 
@@ -95,7 +96,7 @@ More details on the
   (Chocolatine theme)
 - added JSDoc type checking as part of our CI pipeline. To know more about our
   typing strategy, please read
-  [the related <abbr title="Architecture Decision Record">ADR</abbr> (customers only)](https://gitlab.com/front-commerce/front-commerce/-/blob/main/docs/adr/0003-jsdoc-typing.md)
+  [the related <abbr title="Architecture Decision Record">ADR</abbr> (customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/docs/adr/0003-jsdoc-typing.md)
 
 <hr />
 
@@ -103,6 +104,6 @@ More details on the
 
 [Upgrade to Front-Commerce 2.9.0](/docs/appendices/migration-guides#2-8-0-gt-2-9-0)
 or
-[read the full changelog (Customers only)](https://gitlab.com/front-commerce/front-commerce/-/releases/2.9.0)
+[read the full changelog (Customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.9.0)
 
 </ChangelogFooter>

--- a/changelog/release-1.0.0-alpha.2.mdx
+++ b/changelog/release-1.0.0-alpha.2.mdx
@@ -115,7 +115,7 @@ There are a few other things that were included in this release:
 To know more about this release, we recommend you to check the following pages:
 
 - [Migration guide from 1.0.0-alpha.1 to 1.0.0-alpha.2](/docs/appendices/migration-guides#1-0-0-alpha-1-gt-1-0-0-alpha-2)
-- [Full changelog from release notes](https://gitlab.com/front-commerce/front-commerce/releases)
+- [Full changelog from release notes](https://gitlab.blackswift.cloud/front-commerce/front-commerce/releases)
   (Partners and Customers only)
 
 As always, feel free to send us [an email](mailto:contact@front-commerce.com) or

--- a/changelog/release-1.0.0-beta.0.mdx
+++ b/changelog/release-1.0.0-beta.0.mdx
@@ -159,9 +159,9 @@ deploy the demo since 0.14 (june 2018)!
 To know more about this release, we recommend you to check the following pages:
 
 - [Migration guide from 1.0.0-alpha.2 to 1.0.0-beta.0](/docs/appendices/migration-guides#1-0-0-alpha-2-gt-1-0-0-beta-0)
-- [Full changelog from Front-Commerce release notes](https://gitlab.com/front-commerce/front-commerce/releases)
+- [Full changelog from Front-Commerce release notes](https://gitlab.blackswift.cloud/front-commerce/front-commerce/releases)
   and
-  [its Magento 2 extension](https://gitlab.com/front-commerce/magento2-module-front-commerce/releases)
+  [its Magento 2 extension](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/releases)
   (Partners and Customers only)
 
 As always, feel free to send us [an email](mailto:contact@front-commerce.com) or

--- a/changelog/release-1.0.0-beta.3.mdx
+++ b/changelog/release-1.0.0-beta.3.mdx
@@ -159,9 +159,9 @@ instance!
 To know more about this release, we recommend you to check the following pages:
 
 - [Migration guide from 1.0.0-beta.0 to 1.0.0-beta.3](/docs/appendices/migration-guides#1-0-0-beta-0-gt-1-0-0-beta-3)
-- [Full changelog from Front-Commerce release notes](https://gitlab.com/front-commerce/front-commerce/releases)
+- [Full changelog from Front-Commerce release notes](https://gitlab.blackswift.cloud/front-commerce/front-commerce/releases)
   and
-  [its Magento 2 extension](https://gitlab.com/front-commerce/magento2-module-front-commerce/releases)
+  [its Magento 2 extension](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/releases)
   (Partners and Customers only)
 
 As always, feel free to send us [an email](mailto:contact@front-commerce.com) or

--- a/changelog/to-1.0-and-beyond.mdx
+++ b/changelog/to-1.0-and-beyond.mdx
@@ -81,8 +81,8 @@ debt and will continue on our path until we are confident that we could follow
 our roadmap with semantic versioning in mind.
 
 We invite you to read our
-[releases page](https://gitlab.com/front-commerce/front-commerce/releases) (if
-you have access to our private Gitlab instance), or our
+[releases page](https://gitlab.blackswift.cloud/front-commerce/front-commerce/releases)
+(if you have access to our private Gitlab instance), or our
 [Migration Guides](https://developers.front-commerce.com/docs/appendices/migration-guides).
 We will announce new releases on this blog too from now on.
 

--- a/docs/advanced/checkout/add-custom-checkout-step.mdx
+++ b/docs/advanced/checkout/add-custom-checkout-step.mdx
@@ -71,7 +71,7 @@ reuse it for your own project.
 
 To do so, you will need to reuse the `theme/modules/Checkout/withMultiStep`
 enhancer file defined in
-[`node_modules/front-commerce/src/web/theme/modules/Checkout/withMultiStep/`](https://gitlab.com/front-commerce/front-commerce/tree/85f1a8ef55a351f0feb9309c666992bbbb153993/src/web/theme/modules/Checkout/withMultiStep).
+[`node_modules/front-commerce/src/web/theme/modules/Checkout/withMultiStep/`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tree/85f1a8ef55a351f0feb9309c666992bbbb153993/src/web/theme/modules/Checkout/withMultiStep).
 
 This enhance takes 4 arguments:
 
@@ -86,6 +86,6 @@ This enhance takes 4 arguments:
   that might not be possible
 
 We also advise you to look at
-[`theme/components/templates/MultiStep`](https://gitlab.com/front-commerce/front-commerce/tree/85f1a8ef55a351f0feb9309c666992bbbb153993/src/web/theme/components/templates/MultiStep)
+[`theme/components/templates/MultiStep`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tree/85f1a8ef55a351f0feb9309c666992bbbb153993/src/web/theme/components/templates/MultiStep)
 template that will let you reuse the props created by `withMultiStep` and
 display them in a React Component with a progress bar and the current step.

--- a/docs/advanced/features/display-a-map.mdx
+++ b/docs/advanced/features/display-a-map.mdx
@@ -28,23 +28,23 @@ consistent across different components.
 
 #### Map Component
 
-| Property        | Description                              | Type                                                                                                                                             |
-| --------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| locations       | A list of locations used for the markers | [`LocationInputShape[]`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/web/theme/components/organisms/Map/location.js#L65-74) |
-| getMarker       | The marker node for locations            | `(location) => ReactNode`                                                                                                                        |
-| zoom            | Default zoom level                       | `number`                                                                                                                                         |
-| defaultBounds   | The default map bounds                   | [`CoordinatesShape[]`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/web/theme/components/organisms/Map/location.js#L59-62)   |
-| defaultCenter   | The default center for the map.          | [`CoordinatesShape` ](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/web/theme/components/organisms/Map/location.js#L59-62)    |
-| onBoundsChanged | Event handler for bound changes          | `(event) => void`                                                                                                                                |
+| Property        | Description                              | Type                                                                                                                                                          |
+| --------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| locations       | A list of locations used for the markers | [`LocationInputShape[]`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/components/organisms/Map/location.js#L65-74) |
+| getMarker       | The marker node for locations            | `(location) => ReactNode`                                                                                                                                     |
+| zoom            | Default zoom level                       | `number`                                                                                                                                                      |
+| defaultBounds   | The default map bounds                   | [`CoordinatesShape[]`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/components/organisms/Map/location.js#L59-62)   |
+| defaultCenter   | The default center for the map.          | [`CoordinatesShape` ](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/components/organisms/Map/location.js#L59-62)    |
+| onBoundsChanged | Event handler for bound changes          | `(event) => void`                                                                                                                                             |
 
 #### Marker Component
 
-| Property      | Description                            | Type                                                                                                                                            |
-| ------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| location      | Location for the marker                | [`LocationInputShape` ](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/web/theme/components/organisms/Map/location.js#L65-74) |
-| icon          | Allows you to override the marker icon | [`object`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/web/theme/components/organisms/Map/index.js#L25-31)                 |
-| isPopupOpened | Controlled method for marker popup     | `boolean`                                                                                                                                       |
-| onClick       | Event handler on marker click          | `(event) => void`                                                                                                                               |
+| Property      | Description                            | Type                                                                                                                                                         |
+| ------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| location      | Location for the marker                | [`LocationInputShape` ](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/components/organisms/Map/location.js#L65-74) |
+| icon          | Allows you to override the marker icon | [`object`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/components/organisms/Map/index.js#L25-31)                 |
+| isPopupOpened | Controlled method for marker popup     | `boolean`                                                                                                                                                    |
+| onClick       | Event handler on marker click          | `(event) => void`                                                                                                                                            |
 
 ### Open Street Map (OSM) with Leaflet
 
@@ -107,7 +107,7 @@ Until it is fixed, or Front-Commerce has migrated to Webpack5 please use
 Once that has been added you can restart your application, that should be it. 🎉
 
 You should be able to use the Map component. See
-[Map.story.js](https://gitlab.com/front-commerce/front-commerce/-/blob/main/modules/map-leaflet/web/theme/components/organisms/Map/Map.story.js)
+[Map.story.js](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/modules/map-leaflet/web/theme/components/organisms/Map/Map.story.js)
 for details. _Please keep in mind, that the Map component should be used in an
 element with a fixed height._
 
@@ -189,7 +189,7 @@ If you don't, you can create one by following
 Once that has been added you can restart your application, that should be it. 🎉
 
 You should be able to use the Map component. See
-[Map.story.js](https://gitlab.com/front-commerce/front-commerce/-/blob/main/modules/map-googlemap/web/theme/components/organisms/Map/Map.story.js)
+[Map.story.js](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/modules/map-googlemap/web/theme/components/organisms/Map/Map.story.js)
 for details.
 
 :::note

--- a/docs/advanced/features/feature-flags.mdx
+++ b/docs/advanced/features/feature-flags.mdx
@@ -9,12 +9,12 @@ features.
 ## Enabling or Disabling a feature
 
 Feature flags are resolved by the
-[FeatureFlagLoader](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/server/modules/front-commerce/core/loaders.js#L7)
+[FeatureFlagLoader](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/front-commerce/core/loaders.js#L7)
 which is typically overrided in the
 [`contextEnhancer`](/docs/reference/graphql-module-definition#contextenhancer-optional)
 of each module supporting a feature flag (e.g.
-[wishlist](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/server/modules/magento2/wishlist/index.js#L21),
-[search](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/server/modules/front-commerce/search/index.js#L41)).
+[wishlist](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/magento2/wishlist/index.js#L21),
+[search](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/front-commerce/search/index.js#L41)).
 
 To enable or disable a feature one must update the overriden `FeatureFlag`
 loader in the `contexEnhancer` of the module and ensure `isActive` returns

--- a/docs/advanced/features/smart-forms.mdx
+++ b/docs/advanced/features/smart-forms.mdx
@@ -50,7 +50,7 @@ know</ContactLink>!
 
 We have shipped a Capency implementation with Front-Commerce 2.7. You can check
 it out in the
-[smart-forms-capency module](https://gitlab.com/front-commerce/front-commerce/-/tree/2.7.0/modules/smart-forms-capency/server/modules/capency).
+[smart-forms-capency module](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/2.7.0/modules/smart-forms-capency/server/modules/capency).
 
 To enable the Capency Smart Form module you need to:
 
@@ -368,7 +368,7 @@ const MyAwesomeForm = ({ email }) => {
 
 With this code, when the user submits the form, the hook will call the GraphQL
 API to validate the email. The GraphQL email validation API is designed
-[to return different validation statuses](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/server/modules/front-commerce/smart-forms/schema.gql#L22)
+[to return different validation statuses](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/front-commerce/smart-forms/schema.gql#L22)
 (not only valid/invalid) and by default, the `onSubmit` handler returned by
 `useEmailServerValidation` has the following behaviour:
 
@@ -444,7 +444,7 @@ context object that contains the following properties:
 - `formModel`: an object with the value of fields in the form
 - `emailField`: the name of the email field passed to `useEmailServerValidation`
 - `validationResult`:
-  [the validation result](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/server/modules/front-commerce/smart-forms/schema.gql#L29)
+  [the validation result](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/front-commerce/smart-forms/schema.gql#L29)
   returned by the server
 - `updateInputsWithError`: a function to
   [update a field with an error message](https://github.com/formsy/formsy-react/blob/master/API.md#updateInputsWithError)

--- a/docs/advanced/graphql/change-resolver-behavior.mdx
+++ b/docs/advanced/graphql/change-resolver-behavior.mdx
@@ -31,7 +31,7 @@ export default {
 Before being able to inject you custom resolver logic, you first need to find
 the module that defines the resolver for the field. In our example, the Product
 `meta_description` is resolved
-[by the resolver provided by the `Magento2/Catalog/Products` module](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/server/modules/magento2/catalog/products/resolvers.js#L245-248).
+[by the resolver provided by the `Magento2/Catalog/Products` module](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/magento2/catalog/products/resolvers.js#L245-248).
 As a result, the `Magento2/Catalog/Products` module must be added as a
 dependency of our custom module:
 

--- a/docs/advanced/graphql/dataloaders-and-cache-invalidation.mdx
+++ b/docs/advanced/graphql/dataloaders-and-cache-invalidation.mdx
@@ -317,7 +317,7 @@ Writing batching functions and loaders could lead to reusing the same patterns.
 We have extracted some utility functions to help you in this task.
 
 You can find them in the
-[`server/core/graphql/dataloaderHelpers`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/server/core/graphql/dataloaderHelpers.js)
+[`server/core/graphql/dataloaderHelpers`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/server/core/graphql/dataloaderHelpers.js)
 module.
 
 ### `reorderForIds`
@@ -405,7 +405,7 @@ makeBatchLoaderFromSingleFetch = (
 ```
 
 Example (from
-[the Magento2 category loader](https://gitlab.com/front-commerce/front-commerce/-/blob/6ba7ceed3244c47f1c75e03a60c8a5e87a3f5104/src/server/modules/magento1/catalog/categories/categoryLoader.js#L6)):
+[the Magento2 category loader](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/6ba7ceed3244c47f1c75e03a60c8a5e87a3f5104/src/server/modules/magento1/catalog/categories/categoryLoader.js#L6)):
 
 ```js
 import { makeBatchLoaderFromSingleFetch } from "server/core/graphql/dataloaderHelpers";
@@ -694,7 +694,7 @@ below.
 :::info
 
 The payload is
-[limited to 1Mb by default](https://gitlab.com/front-commerce/front-commerce/-/blob/2af896b935b2ead5d1ea5b76bc6109b1a3f56ecd/src/server/express/config/expressConfigProvider.js#L10)
+[limited to 1Mb by default](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2af896b935b2ead5d1ea5b76bc6109b1a3f56ecd/src/server/express/config/expressConfigProvider.js#L10)
 to prevent abuses. You can extend this limit using configurations. See
 ["I cannot `POST` a big payload to the server "](/docs/appendices/troubleshooting#i-cannot-post-a-big-payload-to-the-server)
 for a way to define a greater value.

--- a/docs/advanced/graphql/remote-schemas.mdx
+++ b/docs/advanced/graphql/remote-schemas.mdx
@@ -258,8 +258,9 @@ type Query {
 }
 ```
 
-See [#196](https://gitlab.com/front-commerce/front-commerce/issues/196) for more
-information.
+See
+[#196](https://gitlab.blackswift.cloud/front-commerce/front-commerce/issues/196)
+for more information.
 
 ---
 

--- a/docs/advanced/payments/front-commerce-payments.mdx
+++ b/docs/advanced/payments/front-commerce-payments.mdx
@@ -111,7 +111,7 @@ payment methods have to be registered from a GraphQL module. Let’s create a ne
 :::note
 
 We encourage you to investigate `payment-` modules' source code from
-[Front-Commerce's core](https://gitlab.com/front-commerce/front-commerce/-/tree/main/src/server/modules)
+[Front-Commerce's core](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/src/server/modules)
 to learn about advanced patterns.
 
 :::

--- a/docs/advanced/payments/paypal.mdx
+++ b/docs/advanced/payments/paypal.mdx
@@ -149,8 +149,8 @@ custom transformers.
 
 See the tests for an example (while a detailed documentation is being written):
 
-- https://gitlab.com/front-commerce/front-commerce/-/blob/c1ca1ef8a60ecb545e2758d04a4d11577e764658/src/server/modules/payment-paypal/__pacts__/loaders.js#L230
-- https://gitlab.com/front-commerce/front-commerce/-/blob/c1ca1ef8a60ecb545e2758d04a4d11577e764658/src/server/modules/payment-paypal/__pacts__/loaders.js#L281
+- https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/c1ca1ef8a60ecb545e2758d04a4d11577e764658/src/server/modules/payment-paypal/__pacts__/loaders.js#L230
+- https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/c1ca1ef8a60ecb545e2758d04a4d11577e764658/src/server/modules/payment-paypal/__pacts__/loaders.js#L281
 
 ## Magento2 module
 

--- a/docs/advanced/payments/payzen.mdx
+++ b/docs/advanced/payments/payzen.mdx
@@ -180,7 +180,7 @@ custom transformers.
 
 See the test for an example (while a detailed documentation is being written):
 
-- https://gitlab.com/front-commerce/front-commerce/-/blob/c1ca1ef8a60ecb545e2758d04a4d11577e764658/src/server/modules/payment-payzen/__pacts__/loader.js#L132
+- https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/c1ca1ef8a60ecb545e2758d04a4d11577e764658/src/server/modules/payment-payzen/__pacts__/loader.js#L132
 
 ## Magento2 module
 

--- a/docs/advanced/payments/stripe.mdx
+++ b/docs/advanced/payments/stripe.mdx
@@ -124,5 +124,5 @@ custom transformers.
 
 See the tests for an example (while a detailed documentation is being written):
 
-- https://gitlab.com/front-commerce/front-commerce/blob/3c550dfa0142dde7da3761011379118612841de7/src/server/modules/payment-stripe/__tests__/loader.js#L77
-- https://gitlab.com/front-commerce/front-commerce/blob/3c550dfa0142dde7da3761011379118612841de7/src/server/modules/payment-stripe/__tests__/loader.js#L147
+- https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/3c550dfa0142dde7da3761011379118612841de7/src/server/modules/payment-stripe/__tests__/loader.js#L77
+- https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/3c550dfa0142dde7da3761011379118612841de7/src/server/modules/payment-stripe/__tests__/loader.js#L147

--- a/docs/advanced/production-ready/checklist-before-production.mdx
+++ b/docs/advanced/production-ready/checklist-before-production.mdx
@@ -67,8 +67,8 @@ want to overcome this limitation (which we don’t recommend!), you may use the
 :::info
 
 It provides informations about the application so that the web browser can
-detect whether it's a Progressive Web Application. See [the customize
-manifest.json guide](/docs/advanced/theme/manifest-json).
+detect whether it's a Progressive Web Application. See
+[the customize manifest.json guide](/docs/advanced/theme/manifest-json).
 
 :::
 
@@ -81,7 +81,7 @@ manifest.json guide](/docs/advanced/theme/manifest-json).
 :::info
 
 It instructs bots what they can access. By default,
-[it forbids crawling to prevent unexpectedly exposing dev applications](https://gitlab.com/front-commerce/front-commerce/-/blob/main/public/robots.txt).
+[it forbids crawling to prevent unexpectedly exposing dev applications](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/public/robots.txt).
 
 :::
 

--- a/docs/advanced/production-ready/media-middleware.mdx
+++ b/docs/advanced/production-ready/media-middleware.mdx
@@ -413,7 +413,7 @@ We recommend that you experiment with the `front-commerce:image` debug flag
 enabled to understand how it works and get familiar with it.
 
 You can also read
-[Magento's proxy code from our codebase](https://gitlab.com/front-commerce/front-commerce/-/blob/ed655f75bb868b59511ba5e679d9683412175845/src/server/express/withMagentoProxy.js#L15)
+[Magento's proxy code from our codebase](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/ed655f75bb868b59511ba5e679d9683412175845/src/server/express/withMagentoProxy.js#L15)
 to learn more.
 
 ## Image caching
@@ -458,7 +458,7 @@ This pattern will be matched against the file full URL without the query string
 
 Setting `FRONT_COMMERCE_BACKEND_IGNORE_CACHE_REGEX` will set the
 `ignoreCacheRegex` config of the
-[`expressConfigProvider`](https://gitlab.com/front-commerce/front-commerce/-/blob/cf83e8bac722295403cc89c66fa39758eeaa25c6/src/server/express/config/expressConfigProvider.js#L53).
+[`expressConfigProvider`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/cf83e8bac722295403cc89c66fa39758eeaa25c6/src/server/express/config/expressConfigProvider.js#L53).
 Consequently it will be available on
 `staticConfigFromProviders.express.ignoreCacheRegex` should you ever need it.
 

--- a/docs/advanced/production-ready/multistore.mdx
+++ b/docs/advanced/production-ready/multistore.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 title: Configure multiple stores
-wip: https://gitlab.com/front-commerce/front-commerce/issues/22
+wip: https://gitlab.blackswift.cloud/front-commerce/front-commerce/issues/22
 description:
   A same instance of Front-Commerce can handle several stores at the same time.
   This guide explains how to configure a multi-store application.

--- a/docs/advanced/server/add-http-endpoint.mdx
+++ b/docs/advanced/server/add-http-endpoint.mdx
@@ -51,7 +51,7 @@ information.
 In the case of the WYSIWYG preview, let's say that when a user visits the
 `wysiwyg-preview` URL, we want to display static files that will let anyone
 preview how an html string will be transformed by
-[Front-Commerce's Wysiwyg component](https://gitlab.com/front-commerce/front-commerce/tree/main/src/web/theme/modules/Wysiwyg).
+[Front-Commerce's Wysiwyg component](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tree/main/src/web/theme/modules/Wysiwyg).
 
 To do so, we need to create our server config file, and configure its
 `entrypoint` key.
@@ -81,7 +81,7 @@ app.use("/wysiwyg-preview", router());
 :::note
 
 See our express middleware to understand how the magic works:
-[`withCustomRouters`](https://gitlab.com/front-commerce/front-commerce/blob/daade2b43df41d4a387a04fe87f432afc1f7208b/src/server/express/withCustomRouters.js#L23).
+[`withCustomRouters`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/daade2b43df41d4a387a04fe87f432afc1f7208b/src/server/express/withCustomRouters.js#L23).
 
 :::
 

--- a/docs/advanced/server/configurations.mdx
+++ b/docs/advanced/server/configurations.mdx
@@ -283,7 +283,7 @@ need it in most cases.
 `fetchRemoteConfiguration` is a function that is called at a later stage in
 Front-Commerce request handling cycle to receive a fully initialized `request`
 object, so that, for instance,
-[you can instantiate a loader to retrieve some configuration from Magento](https://gitlab.com/front-commerce/front-commerce/-/commit/f57ccabae32ebe6243fc213485078cb1f98f8a30#9e3c152a167c50222b152728db1b5946d409ba89_0_29).
+[you can instantiate a loader to retrieve some configuration from Magento](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/f57ccabae32ebe6243fc213485078cb1f98f8a30#9e3c152a167c50222b152728db1b5946d409ba89_0_29).
 
 :::caution
 

--- a/docs/advanced/server/customize-response-http-headers.mdx
+++ b/docs/advanced/server/customize-response-http-headers.mdx
@@ -55,7 +55,7 @@ from origin 'https://other.example.org' has been blocked by CORS policy: No
 
 **In Front-Commerce, the content of this header can be controlled by customizing
 the `cors.origin` configuration** from the
-[`corsConfigProvider`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/server/express/withGlobalHeaders.js#L13).
+[`corsConfigProvider`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/express/withGlobalHeaders.js#L13).
 
 You must do it from a custom configuration provider. See the
 [Register a configuration provider](/docs/advanced/server/configurations#register-a-configuration-provider)

--- a/docs/advanced/shipping/colissimo.mdx
+++ b/docs/advanced/shipping/colissimo.mdx
@@ -61,7 +61,7 @@ module.exports = {
 ```
 
 - Import Colissimo component in by overriding the
-  [`getAdditionalDataComponent`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js)
+  [`getAdditionalDataComponent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js)
   used for Shipping methods
 
 ```diff title="src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js"

--- a/docs/advanced/shipping/custom-shipping-information.mdx
+++ b/docs/advanced/shipping/custom-shipping-information.mdx
@@ -48,7 +48,7 @@ GraphQL query should return your method's codes.
 Once you've done this request, you will be able to get the `carrier_code` and
 the `method_code` of your shipping method. You should use those to register a
 new component by overriding the
-[`getAdditionalDataComponent.js`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js)
+[`getAdditionalDataComponent.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js)
 by following this template:
 
 ```js title="theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js"
@@ -115,8 +115,8 @@ export default CustomMethod;
 
 You can reference one of our implementations to get you started
 
-- [`<ModialRelay />`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/modules/shipping-mondialrelay/web/theme/modules/MondialRelay/MondialRelay.js)
-- [`<Colissimo />`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/modules/shipping-colissimo-magento2/web/theme/modules/Colissimo/Colissimo.js)
+- [`<ModialRelay />`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/modules/shipping-mondialrelay/web/theme/modules/MondialRelay/MondialRelay.js)
+- [`<Colissimo />`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/modules/shipping-colissimo-magento2/web/theme/modules/Colissimo/Colissimo.js)
 
 :::
 

--- a/docs/advanced/shipping/mondial-relay.mdx
+++ b/docs/advanced/shipping/mondial-relay.mdx
@@ -62,7 +62,7 @@ Then, within your Front-Commerce project, you have to:
   ```
 
 - Import MondialRelay component in by overriding the
-  [`getAdditionalDataComponent`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js)
+  [`getAdditionalDataComponent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js)
   used for Shipping methods
 
   ```diff title='src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js'
@@ -120,7 +120,7 @@ Then, within your Front-Commerce project, you have to:
   ```
 
 - Import MondialRelay component in by overriding the
-  [`getAdditionalDataComponent`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js)
+  [`getAdditionalDataComponent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js)
   used for Shipping methods
 
   ```diff title="src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js"

--- a/docs/advanced/theme/form.mdx
+++ b/docs/advanced/theme/form.mdx
@@ -332,7 +332,7 @@ and transformed into either a datepicker or multiple input fields without
 impacting the external API.
 
 You can look at
-[`node_modules/front-commerce/src/web/theme/components/atoms/Form/Input/Checkbox/Checkbox.js`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/web/theme/components/atoms/Form/Input/Checkbox/Checkbox.js)
+[`node_modules/front-commerce/src/web/theme/components/atoms/Form/Input/Checkbox/Checkbox.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/components/atoms/Form/Input/Checkbox/Checkbox.js)
 to better understand how the form input api works.
 
 ### Use another form library than Formsy

--- a/docs/advanced/theme/server-side-rendering.mdx
+++ b/docs/advanced/theme/server-side-rendering.mdx
@@ -176,7 +176,7 @@ key with the following information that you can use to if needed:
 ```
 
 If you want to tweak this behavior, we invite you to browse the
-[`deviceConfigProvider`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/server/express/ssr/deviceConfigProvider.js)
+[`deviceConfigProvider`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/express/ssr/deviceConfigProvider.js)
 for implementation details and <ContactLink /> if you think of any improvements.
 
 ## SSR Fallback when things go wrong

--- a/docs/advanced/theme/translations.mdx
+++ b/docs/advanced/theme/translations.mdx
@@ -66,7 +66,7 @@ import { FormattedNumber } from "react-intl";
 
 However, for this particular use case we have abstracted this in Front-Commerce
 with the
-[`theme/components/atoms/Price`](https://gitlab.com/front-commerce/front-commerce/tree/main/src/web/theme/components/atoms/Typography/Price)
+[`theme/components/atoms/Price`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tree/main/src/web/theme/components/atoms/Typography/Price)
 component (and its variants: `ProductPrice`, `PriceOrFree`). We recommend you to
 use it instead, so you could benefit from better integration with its related
 GraphQL Type.

--- a/docs/advanced/theme/wysiwyg/README.mdx
+++ b/docs/advanced/theme/wysiwyg/README.mdx
@@ -52,9 +52,9 @@ export default (props) => <WysiwygV2 content={props.cms.contentWysiwyg} />;
 
 The `contentWysiwyg` property must come from a GraphQL field of type `Wysiwyg`,
 you should add the `WysiwygFragment` available at
-[`theme/modules/WysiwygV2/WysiwygFragment.gql`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/theme/modules/WysiwygV2/WysiwygFragment.gql),
+[`theme/modules/WysiwygV2/WysiwygFragment.gql`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/theme/modules/WysiwygV2/WysiwygFragment.gql),
 to the `CmsPageFragment` available at
-[`theme/pages/CmsPage/CmsPageFragment.gql`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/theme/pages/CmsPage/CmsPageFragment.gql).
+[`theme/pages/CmsPage/CmsPageFragment.gql`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/theme/pages/CmsPage/CmsPageFragment.gql).
 
 ```diff title="my-module/modules/CmsPage/CmsPageFragment.gql"
 #import "theme/modules/CmsPage/CmsPageSeo/CmsPageSeoFragment.gql"
@@ -186,7 +186,7 @@ If you want to customize `MagentoWysiwyg` instead, please refer to
 transformations before displaying the content
 
 1.  Duplicate the
-    [`DefaultWysiwyg.js`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/WysiwygV2/DefaultWysiwyg.js)
+    [`DefaultWysiwyg.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/WysiwygV2/DefaultWysiwyg.js)
     component to `theme/modules/WysiwygV2/CustomWysiwyg`.
 1.  Override `theme/modules/WysiwygV2/appWysiwygComponents.js` and map your new
     `CustomWysiwyg` typename (the one used in your GraphQL schema) to

--- a/docs/appendices/migration-guides/archives.mdx
+++ b/docs/appendices/migration-guides/archives.mdx
@@ -26,9 +26,9 @@ npx sass-migrator division --no-multiplication src/web/**/*.scss
 
 This features requires an up-to-date Magento module, for Magento1 you need at
 least
-[the version 1.3.3](https://gitlab.com/front-commerce/magento1-module-front-commerce/-/releases/1.3.3)
+[the version 1.3.3](https://gitlab.blackswift.cloud/front-commerce/magento1-module-front-commerce/-/releases/1.3.3)
 while for Magento2, the minimum required version is
-[the 2.5.0](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/releases/2.5.0).
+[the 2.5.0](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/releases/2.5.0).
 
 :::
 
@@ -45,7 +45,7 @@ been modified:
 - `theme/modules/ProductView/withSelectedCustomOptions.js`
 
 So if you have overridden those files, you have to apply
-[the same update than the one done in Front-Commerce](https://gitlab.com/front-commerce/front-commerce/-/commit/71ddc7be40df3fb05574bb46b39becbed12cf5ef?merge_request_iid=622).
+[the same update than the one done in Front-Commerce](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/71ddc7be40df3fb05574bb46b39becbed12cf5ef?merge_request_iid=622).
 
 We highly recommend you to test your product and cart pages for products with
 custom options of both "fixed price" and "percentage" types if your project
@@ -61,7 +61,7 @@ the Prismic module:
 
 It is very unlikely that you were using these features but if you did, please
 read
-[the related Merge Request](https://gitlab.com/front-commerce/front-commerce-prismic/-/merge_requests/43)
+[the related Merge Request](https://gitlab.blackswift.cloud/front-commerce/front-commerce-prismic/-/merge_requests/43)
 for replacement options.
 
 ### Front-Commerce Payment module
@@ -181,7 +181,7 @@ To allow
 we had to do some changes to our themes' `template/index.html`,
 `template/error.html` and `core/shop/ShopQuery.gql`, so if you have overridden
 one of those files, you have to apply
-[similar changes](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/557/diffs):
+[similar changes](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/557/diffs):
 
 1. in `index.html`, make sure there's a `script` tag defining
    `window.__ASSETS_BASE_URL__` for instance right after the one defining
@@ -218,7 +218,7 @@ will solve issues with existing media, but one must keep in mind that it may
 lead to an orientation different from previous versions.
 
 See
-[the related Merge Request](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/544)
+[the related Merge Request](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/544)
 for details.
 
 ### Canonical URLs
@@ -226,14 +226,14 @@ for details.
 In this release, we have changed both the default theme and the theme
 chocolatine to add the canonical URL to the category, cms, product and home
 pages. For the category, cms and product pages, the
-[`CategorySeo`](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/519),
-[`CmsPageSeo`](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/513)
+[`CategorySeo`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/519),
+[`CmsPageSeo`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/513)
 and
-[`ProductSeo`](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/498)
+[`ProductSeo`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/498)
 components have respectively been modified, so if you have overridden one of
 those, you might want to synchronize your own version with these changes. For
 the home page, we have introduced the
-[`HomeSeo`](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/511)
+[`HomeSeo`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/511)
 component that you might want to use on own home page implementation.
 
 ### More reliable facets generation with Elasticsearch
@@ -277,7 +277,7 @@ import { describeWithProvider } from "server/model/__fixtures__/provider/magento
 ```
 
 Since
-[Front-Commerce 2.0.0](https://gitlab.com/front-commerce/front-commerce/commit/f69fd72717e99040e7e613705752f1175f589509),
+[Front-Commerce 2.0.0](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/f69fd72717e99040e7e613705752f1175f589509),
 we use the latest `@pact-foundation/pact` library. Front-Commerce's
 [`test` CLI command](/docs/reference/cli#front-commerce-test) will automatically
 provide a `describeWithProvider` function in your tests from the `__pacts__`
@@ -292,9 +292,9 @@ deprecated `describeWithProvider` will now fail unless you:
 - add the dependency back to your project
 - or (**RECOMMENDED**) you move your tests to a `__pacts__` directory and update
   them a bit. See
-  [commits from our own migration](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/520/commits)
+  [commits from our own migration](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/520/commits)
   (especially
-  [this one](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/520/diffs?commit_id=f195479395a51f62664ca5522e0915f345ff22b4))
+  [this one](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/520/diffs?commit_id=f195479395a51f62664ca5522e0915f345ff22b4))
   for examples and details.
 
 ### `root_categories_path` configuration removed
@@ -372,7 +372,7 @@ functionality, you need to ensure you add the suggestions functionality to
 `<BaseInput>`, `<Input>` and `<Textarea>`, and also add the `useFormFieldState`,
 `useFormDataSetter` and `useFormErrorSetter` to `<FormComponent>`. For further
 reference please take a look at the corresponding files in
-[the 2.6-2.7 diff](https://gitlab.com/front-commerce/front-commerce/-/compare/2.6.0...2.7.0?from_project_id=9218054)
+[the 2.6-2.7 diff](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/compare/2.6.0...2.7.0?from_project_id=9218054)
 to help you integrate the updates in the files you have overridden.
 
 ### Style sheets updates
@@ -461,12 +461,12 @@ Deprecated queries/fragments:
 The wishlist provider is enabled by default in Front-Commerce 2.6.0. However you
 need to make sure you have not overridden the following:
 
-- [`src/web/makeApp.js`](https://gitlab.com/front-commerce/front-commerce/-/blob/2.6.0/src/web/makeApp.js)
+- [`src/web/makeApp.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2.6.0/src/web/makeApp.js)
 - any story that uses the wishlist
 
 If you have overridden `src/web/makeApp.js` (**which is NOT recommended! ;-)**)
 you need to make sure that the provider is included in the `makeApp` function
-[just above the `<Routes>` component](https://gitlab.com/front-commerce/front-commerce/-/blob/2.6.0/src/web/makeApp.js#L53)
+[just above the `<Routes>` component](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2.6.0/src/web/makeApp.js#L53)
 as follows:
 
 ```jsx
@@ -495,7 +495,7 @@ more details
 
 In this release we added the functionality to share a wishlist. As such we
 needed a share icon. We added this icon in
-[the theme's `<Icon>` component](https://gitlab.com/front-commerce/front-commerce/-/blob/2.6.0/src/web/theme/components/atoms/Icon/Icon.js#L95).
+[the theme's `<Icon>` component](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2.6.0/src/web/theme/components/atoms/Icon/Icon.js#L95).
 If you have overridden the `<Icon>` component please add an icon named `share`
 to the list of icons. Failing to display a `<Icon icon="share">` component will
 result in an error message being displayed when users visit their wishlist page.
@@ -582,7 +582,7 @@ to illustrate this.
 ### Updated dependencies
 
 In this release we have updated
-[several dependencies](https://gitlab.com/front-commerce/front-commerce/-/commits/main/package.json).
+[several dependencies](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commits/main/package.json).
 For most of them, the upgrade will be transparent. However, the following
 dependency updates require some attention though:
 
@@ -591,7 +591,7 @@ dependency updates require some attention though:
   installed on your environment by running `npm i base-64`.
 - [`eslint-config-react-app`](https://www.npmjs.com/package/eslint-config-react-app)
   has been updated to 6.0.0. In this new release, there's
-  [a new rule we don't follow and we had to override](https://gitlab.com/front-commerce/front-commerce/-/commit/576554fd32057e33f7b4f8b05d9b322e5c3dd54a#dbc0c31823b8f2e4ed04a397722fed33a67f123f_79_80).
+  [a new rule we don't follow and we had to override](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/576554fd32057e33f7b4f8b05d9b322e5c3dd54a#dbc0c31823b8f2e4ed04a397722fed33a67f123f_79_80).
   If your `.eslintrc.js` doesn't include Front-Commerce one, you'll probably
   need to do the same change. In addition, depending on your code, eslint might
   also warn you about new errors.
@@ -620,13 +620,13 @@ To leverage all the new features, we recommend that you upgrade your Magento
 modules to their latest version:
 
 - Magento 1:
-  [1.3.0](https://gitlab.com/front-commerce/magento1-module-front-commerce/-/releases/1.3.0) +
-  [EE module](https://gitlab.com/front-commerce/magento1-module-enterprise-front-commerce)
+  [1.3.0](https://gitlab.blackswift.cloud/front-commerce/magento1-module-front-commerce/-/releases/1.3.0) +
+  [EE module](https://gitlab.blackswift.cloud/front-commerce/magento1-module-enterprise-front-commerce)
 - Magento 2:
-  [2.3.0](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/releases/2.3.0)
+  [2.3.0](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/releases/2.3.0)
 
 Front-Commerce Cloud customers must update the FCC submodule to version
-[1.4.0](https://gitlab.com/front-commerce/front-commerce-cloud/-/releases/1.4.0).
+[1.4.0](https://gitlab.blackswift.cloud/front-commerce/front-commerce-cloud/-/releases/1.4.0).
 
 ### Default Redis TTL change
 
@@ -678,7 +678,7 @@ This first feature is RMA (Return Merchandize Authorization). In order to add
 support for this feature, you will need to:
 
 - Install the new
-  [front-commerce/magento1-module-enterprise](https://gitlab.com/front-commerce/magento1-module-enterprise-front-commerce).
+  [front-commerce/magento1-module-enterprise](https://gitlab.blackswift.cloud/front-commerce/magento1-module-enterprise-front-commerce).
   The installation documentation is available in the
   [Magento 1 installation guide](/docs/magento1/installation).
 - Add the Magento1 Enterprise GraphQL module in your `.front-commerce.js`
@@ -813,7 +813,7 @@ website**.
 
 If you've overridden these components, please update them to ensure they can
 handle such use-case. You can refer to
-[these changes as an example](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/339/diffs#41f37f156cb39d8de257eb219fc96d2a29e3c398).
+[these changes as an example](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/339/diffs#41f37f156cb39d8de257eb219fc96d2a29e3c398).
 
 ### Ensure that invoices are appropriately exposed to Customers
 
@@ -890,9 +890,9 @@ Magento 2). In order to use this feature, please make sure that:
   1.3.0 & front-commerce/magento2-module >= 2.3.0)
 - you didn't override the `<AddressForm />` component or apply the updates to
   your own version. You can have a look at these two commits
-  ([807fa0a8](https://gitlab.com/front-commerce/front-commerce/-/commit/807fa0a81669067b9e78ebe412de1c71ced35a90)
+  ([807fa0a8](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/807fa0a81669067b9e78ebe412de1c71ced35a90)
   &
-  [49be4da9](https://gitlab.com/front-commerce/front-commerce/-/commit/49be4da9d0efa47eaac8d06dad80a689f4260dc6))
+  [49be4da9](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/49be4da9d0efa47eaac8d06dad80a689f4260dc6))
   to learn how to update your own component.
 
 ### Virtual products (Magento 2)
@@ -946,7 +946,7 @@ Magento 1).
 If you have updated the `Form`, `AddressForm` or `CountryFieldWithRegion`
 components, please consider backporting the changes from Front-Commerce. Details
 can be found
-[in this merge request](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/272/diffs).
+[in this merge request](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/272/diffs).
 If you have any trouble upgrading, feel free to <ContactLink />.
 
 ### Product reviews for Magento < 2.4.1
@@ -970,7 +970,7 @@ might want to integrate in your checkout.
 When enabling the guest checkout, we recommend that you rigorously test your
 checkout process as a guest to ensure your customizations supports it. A common
 issue could be that
-[you rely on an address `id` or customer `id` whereas in such scenario there aren't any](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/242).
+[you rely on an address `id` or customer `id` whereas in such scenario there aren't any](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/242).
 
 Custom payment and shipping methods may not support it too. You can look at how
 Front-Commerce's core payment methods handle this as an inspiration. If you have
@@ -980,7 +980,7 @@ any questions, please don't hesitate to <ContactLink />.
 
 The payment form was heavily covered with tests and some edge cases were fixed.
 If you had overridden it, please check
-[these changes](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/316/diffs#62ede4890a658456822c51902ba132fb53a655bc)
+[these changes](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/316/diffs#62ede4890a658456822c51902ba132fb53a655bc)
 to backport them in your theme.
 
 #### Addresses and transitions
@@ -992,9 +992,9 @@ support them. If you have overridden the `stepDefinitions.js`, the
 might want to double check the differences.
 
 See the Pull Requests
-[#253](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/253)
+[#253](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/253)
 and
-[#242](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/242).
+[#242](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/242).
 
 ### Impersonate as customer (Magento 2)
 
@@ -1137,7 +1137,7 @@ header. If this is not the case, please check if you have changed the header
 behavior and add `<CurrencySelector />` from
 `theme/modules/User/CurrencySelector` in the relevant locations. In
 Front-Commerce's core,
-[it is used in `theme/layouts/Header/TopBar`](https://gitlab.com/front-commerce/front-commerce/-/blob/11cda1367e693fc228cf2bf92b3f7cc54c260e2f/src/web/theme/layouts/Header/TopBar.js#L23).
+[it is used in `theme/layouts/Header/TopBar`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/11cda1367e693fc228cf2bf92b3f7cc54c260e2f/src/web/theme/layouts/Header/TopBar.js#L23).
 
 ### Regions/State in addresses for some countries
 
@@ -1283,9 +1283,9 @@ npm install --save date-fns@1.30.1
 > **Logging format update:** a timestamp is now automatically added to log
 > messages as the `timestamp` field of each entry (in GMT time). `date` fields
 > were removed. You can update your custom logs to do so too. See
-> [this commit](https://gitlab.com/front-commerce/front-commerce/-/commit/bf9f9ace04bc24a7391fe36c267dd94857663db0)
+> [this commit](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/bf9f9ace04bc24a7391fe36c267dd94857663db0)
 > and
-> [this one](https://gitlab.com/front-commerce/front-commerce/-/commit/60c31720fe3f113961555c493417b8c8bd45509b)
+> [this one](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/60c31720fe3f113961555c493417b8c8bd45509b)
 > for an overview of those changes.
 
 ### Make linting pass again
@@ -1417,7 +1417,7 @@ guide.
   `@graphql-tools/wrap` instead of `graphql-tools`.
 
 Here is an example from
-[Front-Commerce's Magento 2 GraphQL remote schema module's migration](https://gitlab.com/front-commerce/front-commerce/-/commit/964cb0dee8b614053c9147997f26c07327e61a0a#e9c8fef58455edd870533da439f028dca7618e8c_1_1):
+[Front-Commerce's Magento 2 GraphQL remote schema module's migration](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/964cb0dee8b614053c9147997f26c07327e61a0a#e9c8fef58455edd870533da439f028dca7618e8c_1_1):
 
 ```diff
 - import { FilterRootFields } from "graphql-tools";
@@ -1462,7 +1462,7 @@ Another low-level change from 0.17 is that the base url is now prepended to the
 **If your app relies on custom interceptors, please ensure they are still
 working correctly.** You can use the `finalUrlFromConfig` helper function from a
 helper module added to mimic `axios` core feature. See
-[this commit](https://gitlab.com/front-commerce/front-commerce/-/commit/3fff1a398f7b33d56546b987e15c5f5dc6d43524#24dda67967f430db4a7fe8010764e27d5d7d01b6_63_67)
+[this commit](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/3fff1a398f7b33d56546b987e15c5f5dc6d43524#24dda67967f430db4a7fe8010764e27d5d7d01b6_63_67)
 for an example.
 
 ### `react-intl`: changes for strings containing HTML tags
@@ -1592,7 +1592,7 @@ so you could upgrade to future Front-Commerce releases.**
 If your store was running on `2.0.0-rc.1`, you should empty the application
 cache (usually Redis) upon deployment. It is required to solve an issue with
 incorrect category urls being cached in Redis (see
-[#204](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/204)).
+[#204](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/204)).
 
 ### More flexible store URLs
 
@@ -1635,7 +1635,7 @@ remove it from your stories.
 
 If you were manually building a Magento2 `CustomerLoader` instance, be aware
 that it should now receive a `StoreLoader` instance
-[as its third parameter](https://gitlab.com/front-commerce/front-commerce/commit/806d823b22581b0b30b15d11b5cc71e4468b88d7#3a33198cb5af2c4610c273715db7e7760721223a_21_21).
+[as its third parameter](https://gitlab.blackswift.cloud/front-commerce/front-commerce/commit/806d823b22581b0b30b15d11b5cc71e4468b88d7#3a33198cb5af2c4610c273715db7e7760721223a_21_21).
 
 ### Elasticsearch related changes
 
@@ -1669,9 +1669,9 @@ We encourage you to read every deprecation warnings and
 to find where your code has to be updated. It usually will be a matter of
 removing or adding parameters to a few function calls. Here are commits with
 similar changes
-[for Magento2](https://gitlab.com/front-commerce/front-commerce/-/commit/be41695d641b737b7cc2f5264e86f75bb8be06ac#d0457c5131ec744f37d2b22a05e5a2c74373fc27_24_24)
+[for Magento2](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/be41695d641b737b7cc2f5264e86f75bb8be06ac#d0457c5131ec744f37d2b22a05e5a2c74373fc27_24_24)
 and
-[Magento 1](https://gitlab.com/front-commerce/front-commerce/-/commit/b8334bbc0472e955f371566f42195fe4cd8f3bb1#b2e36e5bd4c8d1090c6a594713752185d0a2544b_38_38)
+[Magento 1](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/b8334bbc0472e955f371566f42195fe4cd8f3bb1#b2e36e5bd4c8d1090c6a594713752185d0a2544b_38_38)
 modules in Front-Commerce's core.
 
 _Please <ContactLink /> if do not understand what change needs to be done._
@@ -1919,11 +1919,11 @@ For more information, please have a look at
 For existing projects, the goal would be to replace `formsy-react`'s HOC by
 `withFormHandlers`. The best way to migrate components you have overriden in
 your project is to look at the core's implementation of form inputs like
-[`Input`](https://gitlab.com/front-commerce/front-commerce/-/blob/720ac5e4c5dc28850b0fbdf1c02705b48d7610a1/src/web/theme/components/atoms/Form/Input/Input.js),
-[`Textarea`](https://gitlab.com/front-commerce/front-commerce/-/blob/720ac5e4c5dc28850b0fbdf1c02705b48d7610a1/src/web/theme/components/atoms/Form/Input/Textarea/Textarea.js),
-[`Checkbox`](https://gitlab.com/front-commerce/front-commerce/-/blob/720ac5e4c5dc28850b0fbdf1c02705b48d7610a1/src/web/theme/components/atoms/Form/Input/Checkbox/Checkbox.js)
+[`Input`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/720ac5e4c5dc28850b0fbdf1c02705b48d7610a1/src/web/theme/components/atoms/Form/Input/Input.js),
+[`Textarea`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/720ac5e4c5dc28850b0fbdf1c02705b48d7610a1/src/web/theme/components/atoms/Form/Input/Textarea/Textarea.js),
+[`Checkbox`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/720ac5e4c5dc28850b0fbdf1c02705b48d7610a1/src/web/theme/components/atoms/Form/Input/Checkbox/Checkbox.js)
 or
-[`Select`](https://gitlab.com/front-commerce/front-commerce/-/blob/720ac5e4c5dc28850b0fbdf1c02705b48d7610a1/src/web/theme/components/atoms/Form/Input/Select/Select.js).
+[`Select`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/720ac5e4c5dc28850b0fbdf1c02705b48d7610a1/src/web/theme/components/atoms/Form/Input/Select/Select.js).
 
 ### Move to a file first routing declaration
 
@@ -2223,7 +2223,7 @@ module.exports = {
 We are now entering a `beta` phase. Be sure to update your dependency as follow:
 
 ```
-npm install --save git+ssh://git@gitlab.com/front-commerce/front-commerce.git#semver:^1.0.0-beta
+npm install --save git+ssh://git@gitlab.blackswift.cloud/front-commerce/front-commerce.git#semver:^1.0.0-beta
 ```
 
 Same goes for the Magento 2 module. Please update your PHP dependencies by using
@@ -2357,14 +2357,14 @@ The symptoms are errors of this type in your application:
 > for an exhaustive list of breaking changes and other minor releases for new
 > features.
 
-### Atoms refactoring ([#178](https://gitlab.com/front-commerce/front-commerce/issues/178))
+### Atoms refactoring ([#178](https://gitlab.blackswift.cloud/front-commerce/front-commerce/issues/178))
 
 One of the goals of `1.0.0` is to rewrite our CSS classes to make it easier for
 new external contributors to dive into Front-Commerce. However, this is a lot of
 work because of the many features already implemented in Front-Commerce. Thus,
 we've splitted this in 5 smaller iterations (see
-([#97](https://gitlab.com/front-commerce/front-commerce/issues/97)) for more
-details). This release is the first step towards this goal.
+([#97](https://gitlab.blackswift.cloud/front-commerce/front-commerce/issues/97))
+for more details). This release is the first step towards this goal.
 
 This means that:
 
@@ -2473,7 +2473,7 @@ main changes you will need to take care of are the translations.
 Please refer to the translations files in the core of front-commerce to get the
 new translations within your application. This process should be easier in the
 future by using
-[translations fallbacks that is under development](https://gitlab.com/front-commerce/front-commerce/issues/54#note_152801124).
+[translations fallbacks that is under development](https://gitlab.blackswift.cloud/front-commerce/front-commerce/issues/54#note_152801124).
 
 #### Styles
 

--- a/docs/appendices/migration-guides/index.mdx
+++ b/docs/appendices/migration-guides/index.mdx
@@ -141,7 +141,7 @@ Here are the commands to achieve this:
 composer require front-commerce/magento2-commerce-module:2.0.0
 
 composer config repositories.front-commerce-magento2-b2b git \
-    git@gitlab.com:front-commerce/magento2-b2b-module-front-commerce.git
+    git@gitlab.blackswift.cloud:front-commerce/magento2-b2b-module-front-commerce.git
 composer require front-commerce/magento2-b2b-module:1.1.0
 
 bin/magento setup:upgrade

--- a/docs/appendices/migration-guides/index.mdx
+++ b/docs/appendices/migration-guides/index.mdx
@@ -17,11 +17,11 @@ import TabItem from "@theme/TabItem";
 ### The Prismic module has moved to a new home.
 
 We have tagged the last version of the Prismic module in the
-[external repository](https://gitlab.com/front-commerce/front-commerce-prismic)
+[external repository](https://gitlab.blackswift.cloud/front-commerce/front-commerce-prismic)
 `v1` 🥳
 
 Since this version we have moved the Prismic module
-[into the core repository](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic)
+[into the core repository](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic)
 of Front-Commerce, moving forward any new features will be made available and
 follow the same
 [semantic versioning](/docs/appendices/release-process#semantic-versioning) as
@@ -131,7 +131,7 @@ repository.
 **If you work on an Adobe Commerce B2B project**, you must:
 
 - update `front-commerce/magento2-commerce-module` to
-  [version 2.x](https://gitlab.com/front-commerce/magento2-commerce-module-front-commerce/-/releases)
+  [version 2.x](https://gitlab.blackswift.cloud/front-commerce/magento2-commerce-module-front-commerce/-/releases)
   (currently `2.0.0`)
 - install `front-commerce/magento2-b2b-module` to its latest version
 
@@ -219,7 +219,7 @@ const EnhancePlaceOrder = ({
 The DomainEvent class was reworked.
 
 If you handled payment events on orders (backend operation) using
-[DomainEvent implementations](https://gitlab.com/front-commerce/front-commerce/-/tree/main/src/server/modules/front-commerce/payment/domain/events),
+[DomainEvent implementations](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/src/server/modules/front-commerce/payment/domain/events),
 these implementations now base on a `PurchaseIdentifier` instead of a direct
 `orderId` (this allows to update order events based on a cartId)
 
@@ -270,7 +270,7 @@ As part of our continuous dependencies upgrade process, we've upgraded the
 `dotenv` dependency to its latest version. We've updated it from version `8.2.0`
 (October 2019) to version `16.0.0` (February 2022). Technically, **it contains 2
 Breaking Changes** that we've decided to be pragmatic about.
-[We prioritized having an up-to-date dependency with a minor migration check, over an outdated one for pure SemVer compatibility.](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/1231#note_927541557)
+[We prioritized having an up-to-date dependency with a minor migration check, over an outdated one for pure SemVer compatibility.](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/1231#note_927541557)
 Please check that your environment variables are not impacted by these breaking
 changes:
 
@@ -580,14 +580,14 @@ that could impact your codebase:
 
 - If after the above fixes there is still `@apollo/*` dependencies and you are
   not sure how to resolve please <ContactLink /> for support. You can also check
-  [here](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/1215/diffs?commit_id=8fae8438d46200cbd310b16c30b3078da28b7d42)
+  [here](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/1215/diffs?commit_id=8fae8438d46200cbd310b16c30b3078da28b7d42)
   and
-  [here](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/1215/diffs?commit_id=418a291f917660b18672b6be2eb2778cb51dfef9)
+  [here](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/1215/diffs?commit_id=418a291f917660b18672b6be2eb2778cb51dfef9)
   for the changes we did to our codebase.
 - Resolvers for fields that are not in the `schema` now throw errors. To avoid
   this remove all unneeded `field`/`Type` resolvers that do not have a
   representation in the GraphQL `schema`. Check our
-  [cleaning commit](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/1216/diffs?commit_id=1e2e04e7f28dba2ebd36da50701478a13a58a238)
+  [cleaning commit](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/1216/diffs?commit_id=1e2e04e7f28dba2ebd36da50701478a13a58a238)
   regarding this issue.
 - `makeApolloClientStub` now expects resolvers as an argument instead of mocks.
   This is in tandem with the
@@ -670,7 +670,7 @@ please add the following line to it:
 The logic of `withFlashMessages` is now also exported as a hook
 `useFlashMessages`. If you have overridden `withFlashMessages` please apply the
 changes in
-[this diff](https://gitlab.com/front-commerce/front-commerce/-/commit/11e7d55bc68d22b422ea5bc9c8357551cd2412ea)
+[this diff](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/11e7d55bc68d22b422ea5bc9c8357551cd2412ea)
 to it.
 
 ### Added downloadable products support for Magento2
@@ -689,17 +689,17 @@ apply the following diffs to your project:
 
 If you are using the base theme:
 
-- [AccountNavigation](https://gitlab.com/front-commerce/front-commerce/-/commit/6f83e7b889369efab8a2560c66a410a1b3a6f7db?view=parallel#9f4b70799a5d0472977d4a6992b5f751d4c7b2a3)
-- [AccountLayout](https://gitlab.com/front-commerce/front-commerce/-/commit/6f83e7b889369efab8a2560c66a410a1b3a6f7db?page=2#a85a9f3a6d6111152efe2fc74320dfab7295d39d)
-- [EnhanceAccount](https://gitlab.com/front-commerce/front-commerce/-/commit/6f83e7b889369efab8a2560c66a410a1b3a6f7db?page=2#92527070b393735c35c5825b3174987e566962e6)
-- [\_modules.scss](https://gitlab.com/front-commerce/front-commerce/-/commit/6f83e7b889369efab8a2560c66a410a1b3a6f7db?page=2#f9a39a6723f4100486c2658dff702698421eae41)
+- [AccountNavigation](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/6f83e7b889369efab8a2560c66a410a1b3a6f7db?view=parallel#9f4b70799a5d0472977d4a6992b5f751d4c7b2a3)
+- [AccountLayout](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/6f83e7b889369efab8a2560c66a410a1b3a6f7db?page=2#a85a9f3a6d6111152efe2fc74320dfab7295d39d)
+- [EnhanceAccount](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/6f83e7b889369efab8a2560c66a410a1b3a6f7db?page=2#92527070b393735c35c5825b3174987e566962e6)
+- [\_modules.scss](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/6f83e7b889369efab8a2560c66a410a1b3a6f7db?page=2#f9a39a6723f4100486c2658dff702698421eae41)
 
 If you are using theme chocolatine:
 
-- [AccountNavigation](https://gitlab.com/front-commerce/front-commerce/-/commit/6f83e7b889369efab8a2560c66a410a1b3a6f7db?page=2#e7af65f5100c0e8b1d5bda98a735eb5744a44386)
-- [AccountLayout](https://gitlab.com/front-commerce/front-commerce/-/commit/6f83e7b889369efab8a2560c66a410a1b3a6f7db?page=2#f7e1de354176dd6902903dc889133f0c5f2733e3)
-- [EnhanceAccount](https://gitlab.com/front-commerce/front-commerce/-/commit/6f83e7b889369efab8a2560c66a410a1b3a6f7db?page=3#899be9e8de73bf492922cdfdd67ff14b859454a0)
-- [\_modules.scss](https://gitlab.com/front-commerce/front-commerce/-/commit/6f83e7b889369efab8a2560c66a410a1b3a6f7db?page=2#ec9462e7d49a82bcb8c759d1fb734ce39160140b)
+- [AccountNavigation](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/6f83e7b889369efab8a2560c66a410a1b3a6f7db?page=2#e7af65f5100c0e8b1d5bda98a735eb5744a44386)
+- [AccountLayout](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/6f83e7b889369efab8a2560c66a410a1b3a6f7db?page=2#f7e1de354176dd6902903dc889133f0c5f2733e3)
+- [EnhanceAccount](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/6f83e7b889369efab8a2560c66a410a1b3a6f7db?page=3#899be9e8de73bf492922cdfdd67ff14b859454a0)
+- [\_modules.scss](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/6f83e7b889369efab8a2560c66a410a1b3a6f7db?page=2#ec9462e7d49a82bcb8c759d1fb734ce39160140b)
 
 ### PaymentMethodLabel relocated
 
@@ -760,7 +760,7 @@ Please update your code to fit the new behavior.
 ### Code clean up
 
 In this release, we have removed some dead and unused code
-([see corresponding MR](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/967)):
+([see corresponding MR](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/967)):
 
 - `src/theme/pages/Account/Account.js` that despites its name is not used at all
   and very unlikely to be used by any project
@@ -838,7 +838,7 @@ const isCompanyUser = (user) => {
   - Support for [trailing slashes](/docs/prismic/routable-types#trailing-slash)
   - Support for [path rewrites](/docs/prismic/routable-types#path-rewrites)
   - Exposed the `url` to the
-    [Content type](https://gitlab.com/front-commerce/front-commerce-prismic/-/blob/main/prismic/server/modules/prismic/core/loaders/Content.js)
+    [Content type](https://gitlab.blackswift.cloud/front-commerce/front-commerce-prismic/-/blob/main/prismic/server/modules/prismic/core/loaders/Content.js)
 
 :::note
 
@@ -847,7 +847,7 @@ When a Prismic document has been registered using the
 method or the
 [`registerPrismicRoute`](/docs/prismic/routable-types#registerprismicroute-options)
 method, A `url` property is exposed in the
-[Content type object](https://gitlab.com/front-commerce/front-commerce-prismic/-/blob/main/prismic/server/modules/prismic/core/loaders/Content.js).
+[Content type object](https://gitlab.blackswift.cloud/front-commerce/front-commerce-prismic/-/blob/main/prismic/server/modules/prismic/core/loaders/Content.js).
 This property contains the resolved url of the document.
 
 :::
@@ -869,7 +869,7 @@ composer update front-commerce/magento2-module
 :::info
 
 You can refer to the `Magento2` module
-[changelog](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/main/CHANGELOG.md)
+[changelog](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/blob/main/CHANGELOG.md)
 for the full details.
 
 :::
@@ -879,7 +879,7 @@ for the full details.
 The `front-commerce-prismic` module is now using the latest version of prismic.
 
 ```shell
-npm install git+ssh://git@gitlab.com/front-commerce/front-commerce-prismic.git#1.0.0
+npm install git+ssh://git@gitlab.blackswift.cloud/front-commerce/front-commerce-prismic.git#1.0.0
 ```
 
 The most notable breaking changes is the removal of the
@@ -889,7 +889,7 @@ The most notable breaking changes is the removal of the
 :::info
 
 You can refer to the `front-commerce-prismic` module
-[changelog](https://gitlab.com/front-commerce/front-commerce-prismic/-/blob/main/CHANGELOG.md)
+[changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce-prismic/-/blob/main/CHANGELOG.md)
 for the full details.
 
 :::
@@ -1145,9 +1145,9 @@ it from your application:
 If you are using base theme and wish to use the B2B module you have to override
 `theme/modules/ProductView/Synthesis/AddProductToCart.js` from the base theme
 and provide a way to add to requisition list from the product page (see
-[AddProductToRequisitionList](https://gitlab.com/front-commerce/front-commerce/-/blob/2.12.0/modules/front-commerce-b2b/web/theme/modules/RequisitionList/AddProductToRequisitionList/AddProductToRequisitionList.js)
+[AddProductToRequisitionList](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2.12.0/modules/front-commerce-b2b/web/theme/modules/RequisitionList/AddProductToRequisitionList/AddProductToRequisitionList.js)
 and
-[B2B's AddProductToCart](https://gitlab.com/front-commerce/front-commerce/-/blob/2.12.0/modules/front-commerce-b2b/web/theme/modules/ProductView/Synthesis/AddProductToCart.js)
+[B2B's AddProductToCart](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2.12.0/modules/front-commerce-b2b/web/theme/modules/ProductView/Synthesis/AddProductToCart.js)
 for inspiration). You also need to override
 `theme/modules/AddToCart/_AddToCart.scss` if you have not already and just copy
 the styles from the base theme to it
@@ -1713,7 +1713,7 @@ In the base theme, the `<Gallery />` component is rendered by
 
 If you want to add that feature to your project you have to define an image
 format named `zoomable`. For instance, we have added one in
-[the last version of the Skeleton](https://gitlab.com/front-commerce/front-commerce-skeleton/-/commit/4b0d4175f9468c47e1a9af9329f3856c2b00c025)
+[the last version of the Skeleton](https://gitlab.blackswift.cloud/front-commerce/front-commerce-skeleton/-/commit/4b0d4175f9468c47e1a9af9329f3856c2b00c025)
 but the actual format parameters depends on your project constraints.
 
 :::note
@@ -1727,9 +1727,9 @@ render the image on which the customer can zoom in. This component accepts an
 Then, depending on the amount of customization, you might also have to bring
 changes similar to what we have done in the merge requests for that feature:
 
-- https://gitlab.com/front-commerce/front-commerce/-/merge_requests/699/diffs
-- https://gitlab.com/front-commerce/front-commerce/-/merge_requests/717/diffs
-- https://gitlab.com/front-commerce/front-commerce/-/merge_requests/719/diffs
+- https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/699/diffs
+- https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/717/diffs
+- https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/719/diffs
 
 In a nutshell, when the feature is enabled, we place a transparent button on top
 of the product image; if the customer clicks on it, we then render a
@@ -1746,7 +1746,7 @@ to
 ### New icons required
 
 In this release, two new icons (`warn` and `users`) were added to
-[the `<Icon>` component](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/web/theme/components/atoms/Icon/Icon.js).
+[the `<Icon>` component](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/components/atoms/Icon/Icon.js).
 
 If you have overridden the `<Icon>` component, you need to add both icons as
 follows to the list of icons to avoid any error messages at page loading:
@@ -1776,12 +1776,12 @@ weird issue after upgrading:
 
 - `axios` does not append the `charset=utf-8` anymore for requests with
   `Content-Type:application/json`. See
-  [#680](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/680#note_711807434),
+  [#680](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/680#note_711807434),
   [#4016](https://github.com/axios/axios/issues/4016) and
   [#2154](https://github.com/axios/axios/issues/2154) and for details.
 - `prettier` has been updated
   [from 2.2.1 to 2.4.1](https://github.com/prettier/prettier/blob/main/CHANGELOG.md)
-  ([MR!742](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/742)).
+  ([MR!742](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/742)).
   We've reformatted our code with this version, so it may lead to style
   differences with your overrides. To update your application code, you can run
   `npx prettier -w ./path/to/your/directories` and commit the changes.
@@ -1802,7 +1802,7 @@ The product overview component does not need to escape the product name with
 `safeHtml`.
 
 If you did override any of the following components, you can safely
-[remove `safeHtml` calls](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/750)
+[remove `safeHtml` calls](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/750)
 in them:
 
 - `src/web/theme/modules/ProductView/Overview/Overview.js`
@@ -1820,7 +1820,7 @@ new components to the
 [default `MagentoWysiwyg` transforms](/docs/advanced/theme/wysiwyg-platform#magentowysiwyg).
 
 See
-[the Page Builder ones](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/WysiwygV2/MagentoWysiwyg/PageBuilder/index.js)
+[the Page Builder ones](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/WysiwygV2/MagentoWysiwyg/PageBuilder/index.js)
 and ensure there is no collision with your custom WYSIWYG components. While very
 unlikely, it could be possible. For instance, if you may have overridden the
 `theme/modules/WysiwygV2/MagentoWysiwyg/MagentoWysiwyg.js` to add a custom
@@ -1841,7 +1841,7 @@ These new features may be relevant for your existing application:
   using [Depfu](https://depfu.com/). Patches are automatically applied if the CI
   is green, minor versions are manually approved. We always review changelogs
   provided by Depfu. **You can review updates any time
-  [by filtering Merge Requests tagged `depfu`](https://gitlab.com/front-commerce/front-commerce/-/merge_requests?scope=all&state=merged&label_name[]=depfu).**
+  [by filtering Merge Requests tagged `depfu`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests?scope=all&state=merged&label_name[]=depfu).**
 
 <hr className="my-10" />
 
@@ -1877,7 +1877,7 @@ are needed to upgrade your project if you are using this payment platform:
    you have
    [to configure the environment so that it is defined](/docs/advanced/payments/adyen#add-the-adyen-client-key-in-the-environment)
 1. we have made some changes and fixes to
-   [the Adyen related frontend components](https://gitlab.com/front-commerce/front-commerce/-/tree/2.10.0/modules/payment-adyen/web/theme/modules/Adyen).
+   [the Adyen related frontend components](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/2.10.0/modules/payment-adyen/web/theme/modules/Adyen).
    If you have overridden some of those, you have to backport the changes.
 
 ### Magento1 Payline module update
@@ -1958,9 +1958,9 @@ support browser autocomplete.
 
 The public API remains unchanged but if you've overriden internal components,
 please check your overrides against their original. See these Merge Requests:
-[#641](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/641)
+[#641](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/641)
 and
-[#645](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/645)
+[#645](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/645)
 
 ### New features in `2.10.0`
 

--- a/docs/appendices/release-notes.mdx
+++ b/docs/appendices/release-notes.mdx
@@ -23,19 +23,30 @@ Compatible with:
 
 ## 2.18.0 (2022-09-15)
 
-> It is back to school time! After a very (very) hot summer, during which we all enjoyed a well-deserved break, the Front-Commerce team is back and raring to go 💪
+> It is back to school time! After a very (very) hot summer, during which we all
+> enjoyed a well-deserved break, the Front-Commerce team is back and raring to
+> go 💪
 >
-> Concerning the 2.18.0 release, it will certainly appear less packed than usual, because of the holiday in August and because we made progress on projects that we will reveal publicly a little later 🍿
+> Concerning the 2.18.0 release, it will certainly appear less packed than
+> usual, because of the holiday in August and because we made progress on
+> projects that we will reveal publicly a little later 🍿
 >
 > So here is Front-Commerce 2.18:
 >
 > - We have made improvements to our payment modules (PayPal, Lyra, Adyen)
-> - We made the official 1.0.0 tag of our Prismic module and modified the way we manage it, see below for details
-> - We have made progress on our connector with the search and merchandising solution [Attraqt](https://attraqt.com/), which will be released in a beta version in the coming weeks, stay tuned!
-> - We added the reset my password feature to our BigCommerce connector: every essential e-commerce feature is now available for this connector!
-> - Our cloud offer is gradually being strengthened with the implementation of an interface to manage your instances! All our sites are now switched to our cloud offer 🎉
+> - We made the official 1.0.0 tag of our Prismic module and modified the way we
+>   manage it, see below for details
+> - We have made progress on our connector with the search and merchandising
+>   solution [Attraqt](https://attraqt.com/), which will be released in a beta
+>   version in the coming weeks, stay tuned!
+> - We added the reset my password feature to our BigCommerce connector: every
+>   essential e-commerce feature is now available for this connector!
+> - Our cloud offer is gradually being strengthened with the implementation of
+>   an interface to manage your instances! All our sites are now switched to our
+>   cloud offer 🎉
 >
-> As always, should you have any requests regarding the product roadmap, do not hesitate to contact Josquin 👋
+> As always, should you have any requests regarding the product roadmap, do not
+> hesitate to contact Josquin 👋
 
 ## 2.17.0 (2022-08-04)
 
@@ -62,7 +73,7 @@ Compatible with:
 > contact Josquin 👋
 
 - [Announcement](/changelog/front-commerce-2.17/)
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.17.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.17.0)
 
 ## 2.16.0 (2022-06-24)
 
@@ -87,7 +98,7 @@ Compatible with:
 > Take some popcorn, have a seat and watch the show 🍿
 
 - [Announcement](/changelog/front-commerce-2.16/)
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.16.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.16.0)
 
 ## 2.15.0 (2022-05-12)
 
@@ -111,7 +122,7 @@ Compatible with:
 >   in beta) and will keep track on NodeJS releases starting from now on.
 
 - [Announcement](/changelog/front-commerce-2.15/)
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.15.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.15.0)
 
 ## 2.14.0 (2022-03-31)
 
@@ -130,7 +141,7 @@ Compatible with:
 > Stress tests for sites to launch soon on Front-Commerce!
 
 - [Announcement](/changelog/front-commerce-2.14/)
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.14.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.14.0)
 
 ## 2.13.0 (2022-02-17)
 
@@ -156,7 +167,7 @@ Compatible with:
 >   certainly interest you …
 
 - [Announcement](/changelog/front-commerce-2.13/)
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.13.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.13.0)
 
 ## 2.12.0 (2022-01-06)
 
@@ -176,7 +187,7 @@ Compatible with:
 > your Front-Commerce experience!
 
 - [Announcement](/changelog/front-commerce-2.12/)
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.12.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.12.0)
 
 ## 2.11.0 (2021-11-25)
 
@@ -189,7 +200,7 @@ Compatible with:
 > Front-Commerce instances even more efficient!
 
 - [Announcement](/changelog/front-commerce-2.11/)
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.11.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.11.0)
 
 ## 2.10.0 (2021-10-14)
 
@@ -201,7 +212,7 @@ Compatible with:
 > payment provider that solve B2C merchants needs.
 
 - [Announcement](/changelog/front-commerce-2.10/)
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.10.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.10.0)
 
 Requirement changes:
 
@@ -215,7 +226,7 @@ Magento 2.4.3 requires
 > We focused on delivering incremental improvements to existing features.
 
 - [Announcement](/changelog/front-commerce-2.9/)
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.9.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.9.0)
 
 ## 2.8.0 (2021-07-22)
 
@@ -225,7 +236,7 @@ Magento 2.4.3 requires
 > profilings, technical debt removal).
 
 - [Announcement](/changelog/front-commerce-2.8/)
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.8.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.8.0)
 
 Requirement changes:
 
@@ -244,12 +255,12 @@ Requirement changes:
 > Magento 2.4.2-p1 support, and many other miscellaneous features.
 
 - [Announcement](/changelog/front-commerce-2.7/)
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.7.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.7.0)
 
 Requirement changes:
 
 - Magento2: 2.3.2+ -> 2.4.2-p1 - requires
-  [magento module version 2.4.0+](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/releases/2.4.0) -
+  [magento module version 2.4.0+](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/releases/2.4.0) -
   (Open Source & Commerce)
 
 ## 2.6.0 (2021-04-29)
@@ -265,12 +276,12 @@ Requirement changes:
 > configuration), updated our dependencies and fixed several issues.
 
 - [Announcement](/changelog/front-commerce-2.6/)
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.6.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.6.0)
 
 Requirements:
 
 - Magento2: 2.3.2+ -> 2.4.1 - requires
-  [magento module version 2.2.0+](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/releases/2.2.0) -
+  [magento module version 2.2.0+](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/releases/2.2.0) -
   (Open Source & Commerce)
 - or Magento1: CE 1.7+, EE 1.12+,
   [OpenMageLTS](https://www.openmage.org/supported-versions.html) 19.4+
@@ -285,7 +296,7 @@ Requirements:
 
 > This release contains a bugfix of guest orders not being tracked.
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.5.1)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.5.1)
 
 Requirements: same as [2.4.0](#2-4-0-2021-01-22)
 
@@ -300,7 +311,7 @@ Requirements: same as [2.4.0](#2-4-0-2021-01-22)
 > - allow your Customers to return products with RMA
 > - leverage our low-level tools to improve your Core Web Vitals
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.5.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.5.0)
 
 Requirements: same as [2.4.0](#2-4-0-2021-01-22)
 
@@ -308,7 +319,7 @@ Requirements: same as [2.4.0](#2-4-0-2021-01-22)
 
 > This release contains a bugfix of guest orders not being tracked.
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.4.6)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.4.6)
 
 Requirements: same as [2.4.0](#2-4-0-2021-01-22)
 
@@ -317,7 +328,7 @@ Requirements: same as [2.4.0](#2-4-0-2021-01-22)
 > This release contains a bugfix that improves resilience in case of
 > ElasticSearch downtimes.
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.4.5)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.4.5)
 
 Requirements: same as [2.4.0](#2-4-0-2021-01-22)
 
@@ -326,7 +337,7 @@ Requirements: same as [2.4.0](#2-4-0-2021-01-22)
 > This release contains minor bugfixes related to displaying invoices and
 > dropdown.
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.4.4)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.4.4)
 
 Requirements: same as [2.4.0](#2-4-0-2021-01-22)
 
@@ -336,10 +347,10 @@ Requirements: same as [2.4.0](#2-4-0-2021-01-22)
 > fixes the payments method order if you are using Front-Commerce payments.
 >
 > It requires
-> [Front-Commerce Magento2 module 2.2.0](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/releases/2.2.0)
+> [Front-Commerce Magento2 module 2.2.0](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/releases/2.2.0)
 > to fully enable these fixes.
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.4.3)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.4.3)
 
 Requirements: same as [2.4.0](#2-4-0-2021-01-22)
 
@@ -351,7 +362,7 @@ Requirements: same as [2.4.0](#2-4-0-2021-01-22)
 > without accepting GSC (unless they temporarily select another payment method
 > and reselect the previous one).
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.4.2)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.4.2)
 
 Requirements: same as [2.4.0](#2-4-0-2021-01-22)
 
@@ -376,7 +387,7 @@ Requirements: same as [2.4.0](#2-4-0-2021-01-22)
 > We ended up fixing many things from the core ourselves, and hope you'll now
 > have a consistent catalog !
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.4.1)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.4.1)
 
 Requirements: same as [2.4.0](#2-4-0-2021-01-22)
 
@@ -393,7 +404,7 @@ Requirements: same as [2.4.0](#2-4-0-2021-01-22)
 Requirements:
 
 - Magento2: 2.3.2+ -> 2.4.1 - requires
-  [magento module version 2.2.0+](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/releases/2.2.0) -
+  [magento module version 2.2.0+](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/releases/2.2.0) -
   (Open Source & Commerce)
 - or Magento1: CE 1.7+, EE 1.12+,
   [OpenMageLTS](https://www.openmage.org/supported-versions.html) 19.4+
@@ -438,7 +449,7 @@ Requirements:
 > - Allow to link to external invoice files
 > - Performance improvements
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/-/releases/2.3.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.3.0)
 
 Requirements:
 
@@ -459,7 +470,7 @@ Requirements:
 > - Allow to switch currency inside of a store view
 > - Improve regions/state selectors
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/tags/2.2.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tags/2.2.0)
 
 Requirements: same as [2.1.0](#2-1-0)
 
@@ -470,7 +481,7 @@ Requirements: same as [2.1.0](#2-1-0)
 > - the "Use for shipping" toggle is now working again for new addresses created
 >   in the checkout (regression introduced in 2.0.0)
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/tags/2.1.3)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tags/2.1.3)
 
 Requirements: same as [2.1.0](#2-1-0)
 
@@ -483,7 +494,7 @@ Requirements: same as [2.1.0](#2-1-0)
 >   regression was introduced in [2.0.0](#2-0-0), when we've upgraded a
 >   dependency)
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/tags/2.1.2)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tags/2.1.2)
 
 Requirements: same as [2.1.0](#2-1-0)
 
@@ -491,7 +502,7 @@ Requirements: same as [2.1.0](#2-1-0)
 
 > - Fix a regression in cache invalidation using Redis strategy
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/tags/2.1.1)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tags/2.1.1)
 
 Requirements: same as [2.1.0](#2-1-0)
 
@@ -503,7 +514,7 @@ Requirements: same as [2.1.0](#2-1-0)
 > - Affirm and Adyen (developer preview) Magento2 payment methods
 > - Translation improvements
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/tags/2.1.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tags/2.1.0)
 
 Requirements:
 
@@ -522,7 +533,7 @@ Requirements:
 > - Remove deprecation warnings
 > - Update dependencies
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/tags/2.0.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tags/2.0.0)
 
 Requirements:
 
@@ -542,7 +553,7 @@ Requirements:
 > - Enable customizations for session storages (ex: Redis sessions)
 > - Improve caching and headers for all requests
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/tags/1.0.0-beta.4)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tags/1.0.0-beta.4)
 
 Requirements:
 
@@ -562,7 +573,7 @@ Requirements:
 > - Remote schema improvements (authentication…)
 > - Config files fallback mechanisms between modules
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/tags/1.0.0-beta.3)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tags/1.0.0-beta.3)
 
 Requirements:
 
@@ -578,7 +589,7 @@ Requirements:
 
 > - Bug fixes
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/tags/1.0.0-beta.2)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tags/1.0.0-beta.2)
 
 Requirements:
 
@@ -594,7 +605,7 @@ Requirements:
 
 > - Bug fixes
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/tags/1.0.0-beta.1)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tags/1.0.0-beta.1)
 
 Requirements:
 
@@ -615,7 +626,7 @@ Requirements:
 
 - [Announcement](/changelog/release-1.0.0-beta.0/)
 - [Migration guide](/docs/appendices/migration-guides#1-0-0-alpha-2-gt-1-0-0-beta-0)
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/tags/1.0.0-beta.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tags/1.0.0-beta.0)
 
 Requirements:
 
@@ -631,7 +642,7 @@ Requirements:
 
 > Add Stripe payment
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/tags/1.0.0-alpha.3)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tags/1.0.0-alpha.3)
 
 Requirements:
 
@@ -647,7 +658,7 @@ Requirements:
 
 - [Announcement](/changelog/release-1.0.0-alpha.2/)
 - [Migration guide](/docs/appendices/migration-guides#1-0-0-alpha-1-gt-1-0-0-alpha-2)
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/tags/1.0.0-alpha.2)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tags/1.0.0-alpha.2)
 
 Requirements:
 
@@ -661,7 +672,7 @@ Requirements:
 
 > Refactor environment definitions and bug fixes
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/tags/1.0.0-alpha.1)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tags/1.0.0-alpha.1)
 
 Requirements:
 
@@ -673,7 +684,7 @@ Requirements:
 
 ## 0.15.0 (2019-01-10)
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/tags/0.15.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tags/0.15.0)
 
 Requirements:
 
@@ -685,7 +696,7 @@ Requirements:
 
 ## 0.13.0 (2018-04-03)
 
-- [Changelog](https://gitlab.com/front-commerce/front-commerce/tags/0.13.0)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tags/0.13.0)
 
 Requirements:
 

--- a/docs/appendices/troubleshooting.mdx
+++ b/docs/appendices/troubleshooting.mdx
@@ -305,7 +305,7 @@ This is due to a known issue in ElasticSuite that
 
 **The solution is to update ElasticSuite to its latest version.** For a
 workaround in FC (not recommended!), see
-[this diff](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/1264/diffs).
+[this diff](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/1264/diffs).
 
 ## Another issue?
 

--- a/docs/essentials/adapt-theme-to-your-brand.mdx
+++ b/docs/essentials/adapt-theme-to-your-brand.mdx
@@ -47,7 +47,7 @@ theme.
 
 Since we use the Atomic Design principles, the tokens are within atoms of our
 base theme. From your application, you will find the base theme in the
-[`node_modules/front-commerce/src/web/`](https://gitlab.com/front-commerce/front-commerce/tree/main/src/web)
+[`node_modules/front-commerce/src/web/`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tree/main/src/web)
 directory and atoms under its `theme/components/atoms` subdirectory.
 
 In this guide, we'll focus on the colors and the typography settings. But feel

--- a/docs/essentials/add-component-to-storybook.mdx
+++ b/docs/essentials/add-component-to-storybook.mdx
@@ -143,7 +143,7 @@ add a new type of button: `tertiary`.
 To add this story, you will need to override the `Button.story.js` in the same
 way you overrode the `Button.js`. This means that you should copy the existing
 story from
-[`node_modules/front-commerce/src/web/theme/components/atoms/Button/Button.story.js`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/theme/components/atoms/Button/Button.story.js)
+[`node_modules/front-commerce/src/web/theme/components/atoms/Button/Button.story.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/theme/components/atoms/Button/Button.story.js)
 to `my-module/web/theme/components/atoms/Button/Button.story.js`.
 
 Once you have copied the file, you need to restart the Storybook with
@@ -174,17 +174,17 @@ issues and have created helpers that should make your life easier when
 documenting those complex components.
 
 These helpers are located in
-[`node_modules/front-commerce/src/web/storybook/addons`](https://gitlab.com/front-commerce/front-commerce/tree/main/src/web/storybook/addons)
+[`node_modules/front-commerce/src/web/storybook/addons`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tree/main/src/web/storybook/addons)
 and you can import them by using the alias `web/storybook/addons/...`. For now,
 we have four of them:
 
-- [`web/storybook/addons/apollo/ApolloDecorator`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/storybook/addons/apollo/ApolloDecorator.js):
+- [`web/storybook/addons/apollo/ApolloDecorator`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/storybook/addons/apollo/ApolloDecorator.js):
   mocks the data fetched by your components
-- [`web/storybook/addons/form/formDecorator`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/storybook/addons/form/formDecorator.js):
+- [`web/storybook/addons/form/formDecorator`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/storybook/addons/form/formDecorator.js):
   mocks a Form surounding the input component you are documenting
-- [`web/storybook/addons/intl/IntlDecorator`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/storybook/addons/intl/IntlDecorator.js):
+- [`web/storybook/addons/intl/IntlDecorator`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/storybook/addons/intl/IntlDecorator.js):
   allows you to switch between the languages of your shop
-- [`web/storybook/addons/router/routerDecorator`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/storybook/addons/router/routerDecorator.js):
+- [`web/storybook/addons/router/routerDecorator`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/storybook/addons/router/routerDecorator.js):
   mocks the routing and the URLs of your application
 
 <!-- TODO document usage of each of these helpers -->

--- a/docs/essentials/create-a-business-component.mdx
+++ b/docs/essentials/create-a-business-component.mdx
@@ -103,7 +103,7 @@ Before starting to edit the Home page, you first need to extend the theme. If
 you don't have a module yet, please refer to
 [Extend the theme](./extend-the-theme#configure-your-custom-theme-and-use-it-in-your-application).
 Once you have one, the goal will be to override the Home component from
-[`node_modules/front-commerce/src/web/theme/pages/Home/Home.js`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/theme/pages/Home/Home.js)
+[`node_modules/front-commerce/src/web/theme/pages/Home/Home.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/theme/pages/Home/Home.js)
 to `my-module/web/theme/pages/Home/Home.js`.
 
 :::warning
@@ -111,7 +111,7 @@ to `my-module/web/theme/pages/Home/Home.js`.
 Do not forget to restart your application (`npm run start`) in case the override
 do not work. There is an upcoming improvement that should make things easier in
 the future (see
-[#63](https://gitlab.com/front-commerce/front-commerce/issues/63)).
+[#63](https://gitlab.blackswift.cloud/front-commerce/front-commerce/issues/63)).
 
 :::
 

--- a/docs/essentials/create-a-ui-component.mdx
+++ b/docs/essentials/create-a-ui-component.mdx
@@ -31,7 +31,7 @@ your stories later, feel free to leave the parts mentioning Storybook later.
 
 Front-Commerce’s core UI components follow the same principles and you could
 dive into the
-[`node_modules/front-commerce/src/web/theme/components`](https://gitlab.com/front-commerce/front-commerce/tree/main/src/web/theme/components)
+[`node_modules/front-commerce/src/web/theme/components`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tree/main/src/web/theme/components)
 folder to find examples into our source code.
 
 But first, let's define what is an ideal UI Component.
@@ -265,7 +265,8 @@ import "./molecules/IllustratedContent/IllustratedContent";
 If it didn't reload properly, it is because you need to restart the application
 every time you override a component in order to let the application know that
 the file location it should load has changed. But note that there is an upcoming
-improvement [#63](https://gitlab.com/front-commerce/front-commerce/issues/63)
+improvement
+[#63](https://gitlab.blackswift.cloud/front-commerce/front-commerce/issues/63)
 that should remove the need for a restart in the future.
 
 :::

--- a/docs/essentials/extend-the-graphql-schema.mdx
+++ b/docs/essentials/extend-the-graphql-schema.mdx
@@ -85,8 +85,8 @@ module.exports = {
 The `name` key must be unique across your server modules. It is a temporary name
 that is used during a code generation step and has no other usage in the
 application. _Do not worry about it, it will be deprecated in a near future: see
-[#179](https://gitlab.com/front-commerce/front-commerce/issues/179) for further
-information._
+[#179](https://gitlab.blackswift.cloud/front-commerce/front-commerce/issues/179)
+for further information._
 
 The `path` must be a path to your module definition file (created above).
 

--- a/docs/essentials/extend-the-theme.mdx
+++ b/docs/essentials/extend-the-theme.mdx
@@ -83,7 +83,7 @@ Let's add the description of a `Product` to a `ProductItem` as an example of
 overriding the base theme.
 
 The original file is:
-[`node_modules/front-commerce/src/web/theme/modules/ProductView/ProductItem/ProductItem.js`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/theme/modules/ProductView/ProductItem/ProductItem.js)
+[`node_modules/front-commerce/src/web/theme/modules/ProductView/ProductItem/ProductItem.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/theme/modules/ProductView/ProductItem/ProductItem.js)
 
 :::info
 
@@ -105,7 +105,7 @@ need to update the fragment related to `ProductItem`.
 The original fragment file is collocated with the original component at:
 
 1. copy the
-   [`original ProductItemFragment`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/theme/modules/ProductView/ProductItem/ProductItemFragment.gql)
+   [`original ProductItemFragment`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/theme/modules/ProductView/ProductItem/ProductItemFragment.gql)
    to the equivalent location in your module.
 1. add the field `description` to the fragment.
 
@@ -130,8 +130,8 @@ In development mode, you MIGHT need to restart the application for the override
 to be detected. The tools used to provide the override feature do not detect
 automatically that you're trying to override a file yet. This is an upcoming
 improvement, see
-[#63](https://gitlab.com/front-commerce/front-commerce/issues/63) for further
-information.
+[#63](https://gitlab.blackswift.cloud/front-commerce/front-commerce/issues/63)
+for further information.
 
 :::
 

--- a/docs/essentials/installation.mdx
+++ b/docs/essentials/installation.mdx
@@ -57,7 +57,7 @@ In order to install the skeleton, you need to follow these instructions:
 ```
 
 ```shell
-git clone --depth=1 git@gitlab.com:front-commerce/front-commerce-skeleton.git
+git clone --depth=1 git@gitlab.blackswift.cloud:front-commerce/front-commerce-skeleton.git
 cd front-commerce-skeleton
 npm install --legacy-peer-deps
 ```
@@ -68,7 +68,7 @@ npm install --legacy-peer-deps
 ```
 
 ```shell
-git clone --depth=1 git@gitlab.com:front-commerce/front-commerce-skeleton.git
+git clone --depth=1 git@gitlab.blackswift.cloud:front-commerce/front-commerce-skeleton.git
 cd front-commerce-skeleton
 npm install
 ```

--- a/docs/essentials/installation.mdx
+++ b/docs/essentials/installation.mdx
@@ -43,7 +43,7 @@ If you don't have the minimum requirements,
 
 **This is the recommended way to start a new Front-Commerce project.**
 
-[Front-Commerce’s skeleton repository](https://gitlab.com/front-commerce/front-commerce-skeleton)
+[Front-Commerce’s skeleton repository](https://gitlab.blackswift.cloud/front-commerce/front-commerce-skeleton)
 provides a quick way to get started with Front-Commerce with sane default
 configurations.
 

--- a/docs/magento1/installation.mdx
+++ b/docs/magento1/installation.mdx
@@ -38,7 +38,7 @@ For a community edition version:
 
 ```shell
 composer config minimum-stability dev
-composer config repositories.front-commerce git https://gitlab.com/front-commerce/magento1-module-front-commerce.git
+composer config repositories.front-commerce git https://gitlab.blackswift.cloud/front-commerce/magento1-module-front-commerce.git
 composer config repositories.front-commerce-restful git https://github.com/PH2M/Magento-Extra-RESTful
 composer config http-basic.gitlab.com token $FC_GITLAB_TOKEN
 composer require front-commerce/magento1-module:"^1.3"
@@ -48,8 +48,8 @@ For an enterprise edition version:
 
 ```shell
 composer config minimum-stability dev
-composer config repositories.front-commerce-ee git https://gitlab.com/front-commerce/magento1-module-enterprise-front-commerce
-composer config repositories.front-commerce git https://gitlab.com/front-commerce/magento1-module-front-commerce.git
+composer config repositories.front-commerce-ee git https://gitlab.blackswift.cloud/front-commerce/magento1-module-enterprise-front-commerce
+composer config repositories.front-commerce git https://gitlab.blackswift.cloud/front-commerce/magento1-module-front-commerce.git
 composer config repositories.front-commerce-restful git https://github.com/PH2M/Magento-Extra-RESTful
 composer config http-basic.gitlab.com token $FC_GITLAB_TOKEN
 composer require front-commerce/magento1-module-enterprise:"dev-master"
@@ -60,7 +60,7 @@ composer require front-commerce/magento1-module-enterprise:"dev-master"
 `front-commerce/magento1-module-enterprise` is currently in beta, requiring
 `dev-master` allows to get the last version. After this beta phase, it is
 strongly recommended to use a fixed version.
-([see available release for Enterprise Edition](https://gitlab.com/front-commerce/magento1-module-enterprise-front-commerce/-/releases))
+([see available release for Enterprise Edition](https://gitlab.blackswift.cloud/front-commerce/magento1-module-enterprise-front-commerce/-/releases))
 
 :::
 
@@ -69,7 +69,7 @@ strongly recommended to use a fixed version.
 - Community edition version:
 
   1. Clone or download
-     https://gitlab.com/front-commerce/magento1-module-front-commerce.git
+     https://gitlab.blackswift.cloud/front-commerce/magento1-module-front-commerce.git
   2. Copy `app` directory and paste it in your Magento's root directory
   3. Clone or download https://github.com/PH2M/Magento-Extra-RESTful
   4. Copy `modules/Clockworkgeek_Extrarestful.xml` file and paste it in your
@@ -82,10 +82,10 @@ strongly recommended to use a fixed version.
 - Enterprise edition version:
 
   1. Clone or download
-     https://gitlab.com/front-commerce/magento1-module-front-commerce.git
+     https://gitlab.blackswift.cloud/front-commerce/magento1-module-front-commerce.git
   2. Copy `app` directory and paste it in your Magento's root directory
   3. Clone or download
-     https://gitlab.com/front-commerce/magento1-module-enterprise-front-commerce
+     https://gitlab.blackswift.cloud/front-commerce/magento1-module-enterprise-front-commerce
   4. Copy `app` directory and paste it in your Magento's root directory
   5. Clone or download https://github.com/PH2M/Magento-Extra-RESTful
   6. Copy `modules/Clockworkgeek_Extrarestful.xml` file and paste it in your
@@ -185,7 +185,7 @@ If the OAuth Zend Patch is not valid in the installer checker, please follow
 these steps:
 
 - Copy the
-  [`fix-sort-params-core.patch`](https://gitlab.com/front-commerce/magento1-module-front-commerce/blob/master/fix-sort-params-core.patch)
+  [`fix-sort-params-core.patch`](https://gitlab.blackswift.cloud/front-commerce/magento1-module-front-commerce/blob/master/fix-sort-params-core.patch)
   file in your root directory
 - Past it on your root Magento directory
 - Apply them

--- a/docs/magento1/installation.mdx
+++ b/docs/magento1/installation.mdx
@@ -40,7 +40,7 @@ For a community edition version:
 composer config minimum-stability dev
 composer config repositories.front-commerce git https://gitlab.blackswift.cloud/front-commerce/magento1-module-front-commerce.git
 composer config repositories.front-commerce-restful git https://github.com/PH2M/Magento-Extra-RESTful
-composer config http-basic.gitlab.com token $FC_GITLAB_TOKEN
+composer config http-basic.gitlab.blackswift.cloud token $FC_GITLAB_TOKEN
 composer require front-commerce/magento1-module:"^1.3"
 ```
 
@@ -51,7 +51,7 @@ composer config minimum-stability dev
 composer config repositories.front-commerce-ee git https://gitlab.blackswift.cloud/front-commerce/magento1-module-enterprise-front-commerce
 composer config repositories.front-commerce git https://gitlab.blackswift.cloud/front-commerce/magento1-module-front-commerce.git
 composer config repositories.front-commerce-restful git https://github.com/PH2M/Magento-Extra-RESTful
-composer config http-basic.gitlab.com token $FC_GITLAB_TOKEN
+composer config http-basic.gitlab.blackswift.cloud token $FC_GITLAB_TOKEN
 composer require front-commerce/magento1-module-enterprise:"dev-master"
 ```
 

--- a/docs/magento2/b2b.mdx
+++ b/docs/magento2/b2b.mdx
@@ -35,7 +35,7 @@ On Magento2 side, you need to
 [install the Front-Commerce Magento2 Commerce module](/docs/magento2/commerce#magento2-commerce-module-installation).
 
 You must then install the
-[`front-commerce/magento2-b2b-module-front-commerce`](https://gitlab.com/front-commerce/magento2-b2b-module-front-commerce)
+[`front-commerce/magento2-b2b-module-front-commerce`](https://gitlab.blackswift.cloud/front-commerce/magento2-b2b-module-front-commerce)
 module:
 
 ```shell

--- a/docs/magento2/b2b.mdx
+++ b/docs/magento2/b2b.mdx
@@ -40,7 +40,7 @@ module:
 
 ```shell
 composer config repositories.front-commerce-magento2-b2b git \
-    git@gitlab.com:front-commerce/magento2-b2b-module-front-commerce.git
+    git@gitlab.blackswift.cloud:front-commerce/magento2-b2b-module-front-commerce.git
 composer require front-commerce/magento2-b2b-module
 
 bin/magento setup:upgrade

--- a/docs/magento2/commerce.mdx
+++ b/docs/magento2/commerce.mdx
@@ -25,7 +25,7 @@ and bring support for Adobe Commerce specific features such as
 ### Magento2 Commerce module installation
 
 You need to install the
-[`front-commerce/magento2-commerce-module` module](https://gitlab.com/front-commerce/magento2-commerce-module-front-commerce/):
+[`front-commerce/magento2-commerce-module` module](https://gitlab.blackswift.cloud/front-commerce/magento2-commerce-module-front-commerce/):
 
 ```shell
 composer config repositories.front-commerce-magento2-commerce git \
@@ -161,7 +161,7 @@ Under the hood, the following error is occurring in Magento:
 > report.ERROR: Expected a value of type "ReturnStatus" but received: (empty
 > string) (status is `null` )
 
-[We've decided](https://gitlab.com/front-commerce/front-commerce/-/merge_requests/1382/#note_1020963128)
+[We've decided](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/1382/#note_1020963128)
 to cope with this flaw, ignore the error and display an empty status for such
 returns.
 
@@ -175,7 +175,7 @@ Return.
 
 The Front-Commerce Magento2 OpenSource module contains a patch for this known
 issue
-[since its version 2.8.3](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/releases/2.8.3).
+[since its version 2.8.3](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/releases/2.8.3).
 
 Please ensure that your project is properly patched by ensuring that L42 of
 `vendor/magento/module-eav/Model/ResourceModel/Entity/Attribute/OptionValueProvider.php`

--- a/docs/magento2/commerce.mdx
+++ b/docs/magento2/commerce.mdx
@@ -29,7 +29,7 @@ You need to install the
 
 ```shell
 composer config repositories.front-commerce-magento2-commerce git \
-    git@gitlab.com:front-commerce/magento2-commerce-module-front-commerce.git
+    git@gitlab.blackswift.cloud:front-commerce/magento2-commerce-module-front-commerce.git
 
 composer require front-commerce/magento2-commerce-module
 

--- a/docs/magento2/headless-payments.mdx
+++ b/docs/magento2/headless-payments.mdx
@@ -61,7 +61,7 @@ We will explain the mechanisms available to implement your own adapter if
 supported Magento payment modules do not suit your needs.
 
 **Payment Adapters must implement the
-[`\FrontCommerce\Integration\Api\HeadlessPayment\Adapter`](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/main/app/code/FrontCommerce/Integration/Api/HeadlessPayment/Adapter.php)
+[`\FrontCommerce\Integration\Api\HeadlessPayment\Adapter`](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/blob/main/app/code/FrontCommerce/Integration/Api/HeadlessPayment/Adapter.php)
 interface no matter the [workflows](/docs/advanced/payments/payment-workflows)
 they support.**
 
@@ -83,7 +83,7 @@ Adapters must implement methods that are called at key times in order to:
 [Redirect before order](/docs/advanced/payments/payment-workflows#redirect-before-order)
 
 Converts an internal Magento response to a
-[`RedirectionInterface`](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/main/app/code/FrontCommerce/Integration/Api/Data/HeadlessPayment/RedirectionInterface.php)
+[`RedirectionInterface`](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/blob/main/app/code/FrontCommerce/Integration/Api/Data/HeadlessPayment/RedirectionInterface.php)
 value object.
 
 ```php
@@ -99,7 +99,7 @@ public function redirectionFromCheckoutRedirectActionResponse(
 [Redirect after order](/docs/advanced/payments/payment-workflows#redirect-after-order)
 
 Converts an internal Magento response to a
-[`RedirectionInterface`](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/main/app/code/FrontCommerce/Integration/Api/Data/HeadlessPayment/RedirectionInterface.php)
+[`RedirectionInterface`](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/blob/main/app/code/FrontCommerce/Integration/Api/Data/HeadlessPayment/RedirectionInterface.php)
 value object.
 
 ```php
@@ -164,7 +164,7 @@ public function changeAfterCheckoutResponseFromResult(
 [Redirect after order](/docs/advanced/payments/payment-workflows#redirect-after-order)
 
 This is a factory to build a
-[`ProxiedAction`](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/main/app/code/FrontCommerce/Integration/Api/HeadlessPayment/ProxiedAction.php)
+[`ProxiedAction`](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/blob/main/app/code/FrontCommerce/Integration/Api/HeadlessPayment/ProxiedAction.php)
 matching the next step for the Customer depending on information transmitted by
 the payment system in the return url the user was redirected to when coming back
 to the store
@@ -188,7 +188,7 @@ Example: `throw new \RuntimeException('Checkout flow not supported');`
 Wether you've implemented a new Payment Adapter or are reusing an existing one,
 adapters have to be registered so Front-Commerce's module could instantiate it
 when relevant. Using the `di.xml`, inject the adapter in the
-[`FrontCommerce\Integration\Model\HeadlessPayments\AdapterFactory` `$adapters` constructor param](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/main/app/code/FrontCommerce/Integration/Model/HeadlessPayments/AdapterFactory.php#L12).
+[`FrontCommerce\Integration\Model\HeadlessPayments\AdapterFactory` `$adapters` constructor param](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/blob/main/app/code/FrontCommerce/Integration/Model/HeadlessPayments/AdapterFactory.php#L12).
 
 Below is an example from Front-Commerce's core:
 
@@ -208,7 +208,7 @@ Below is an example from Front-Commerce's core:
 :::note
 
 We encourage you to investigate existing Adapters' source code from
-[Front-Commerce's core](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/tree/main/app/code/FrontCommerce/Integration/Model/HeadlessPayments/Adapter)
+[Front-Commerce's core](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/tree/main/app/code/FrontCommerce/Integration/Model/HeadlessPayments/Adapter)
 to learn about advanced patterns.
 
 :::
@@ -267,7 +267,7 @@ limitations and reasons of the issues:
    module (headless payments API)
 2. the REST endpoint will load the relevant headless payment adapter
 3. it then bootstraps
-   [a Magento internal Request](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/blob/64784f627064d0068ca04842317eb69f3fd143b7/app/code/FrontCommerce/Integration/Model/HeadlessPayments.php#L148)
+   [a Magento internal Request](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/blob/64784f627064d0068ca04842317eb69f3fd143b7/app/code/FrontCommerce/Integration/Model/HeadlessPayments.php#L148)
    object, and initializes it with session information (user, order, quote…) by
    delegating some initialization to the payment adapter
 4. it then dispatches the request (in an emulated `frontend` Magento area)
@@ -309,7 +309,7 @@ Possible workarounds:
 - patch the `Magento\Framework\Config\Data\Scoped` class with the patch attached
   in the related issue
 
-[Read the related issue for details](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/issues/49).
+[Read the related issue for details](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/issues/49).
 
 #### Magento 2.4.1+
 
@@ -324,4 +324,4 @@ Possible workarounds:
   reinitialize internal state properly
 - patch the `PluginList` class to handle this edge case (undefined index)
 
-[Read the related issue for details](https://gitlab.com/front-commerce/magento2-module-front-commerce/-/issues/57).
+[Read the related issue for details](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/issues/57).

--- a/docs/magento2/i18n.mdx
+++ b/docs/magento2/i18n.mdx
@@ -60,7 +60,7 @@ only returns the message received.
 Our roadmap contains an item to make it easier to support translations of these
 errors in Front-Commerce. If you are interested in this feature, learn more and
 give us your feedback on the related issue:
-[#218](https://gitlab.com/front-commerce/front-commerce/issues/218).
+[#218](https://gitlab.blackswift.cloud/front-commerce/front-commerce/issues/218).
 
 :::
 

--- a/docs/magento2/page-builder.mdx
+++ b/docs/magento2/page-builder.mdx
@@ -153,7 +153,7 @@ answer you in a timely manner.
 - override
   `theme/modules/WysiwygV2/MagentoWysiwyg/PageBuilder/appComponentsMap.js` to
   register new components (or override
-  [existing ones](https://gitlab.com/front-commerce/front-commerce/blob/main/src/web/theme/modules/WysiwygV2/MagentoWysiwyg/PageBuilder/index.js))
+  [existing ones](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/theme/modules/WysiwygV2/MagentoWysiwyg/PageBuilder/index.js))
 
 <!-- Override GraphQL fragment too (not yet externalized in a specific fragment FC code) -->
 

--- a/docs/prismic/embed-fields.mdx
+++ b/docs/prismic/embed-fields.mdx
@@ -40,7 +40,7 @@ For this example let's say we want to create an album cover from an embed field.
 ### Adding an Embed Field in your server-side
 
 First add an embed field in your schema using the
-[`oEmbedContent`](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/schema.gql)
+[`oEmbedContent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/schema.gql)
 type, for example:
 
 ```graphql
@@ -51,10 +51,10 @@ type MyAlbum {
 ```
 
 Then you can add the
-[`EmbedTransformer`](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/transformers/Embed.js)
+[`EmbedTransformer`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/transformers/Embed.js)
 to your album definition which will parse the embed response from Prismic as a
 rich
-[`oEmbedContent`](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/schema.gql)
+[`oEmbedContent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/schema.gql)
 type.
 
 ```diff
@@ -90,7 +90,7 @@ fragment AlbumFragment on Album {
 ```
 
 The fragment will expose several fields from the
-[`oEmbedContent`](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/schema.gql)
+[`oEmbedContent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/schema.gql)
 type.
 
 ```jsx
@@ -118,7 +118,7 @@ You can override the default components for each embed type in your own theme
 As mentioned above, the fragment only exposes the minimum required fields for
 the PrismicEmbed component, if you would like to create your own custom embed
 component you can refer to all the available fields on the
-[`oEmbedContent`](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/schema.gql)
+[`oEmbedContent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/schema.gql)
 type.
 
 ## Wysiwyg Embed Fields
@@ -172,7 +172,7 @@ We have added loader functions for the following embed scripts:
 - `Instagram`
 
 You can update these loading functions or add your own by overriding the
-[`theme/modules/WysiwygV2/PrismicWysiwyg/Components/EmbedScript/appEmbeds.js`](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic/web/theme/modules/WysiwygV2/PrismicWysiwyg/Components/EmbedScript/appEmbeds.js)
+[`theme/modules/WysiwygV2/PrismicWysiwyg/Components/EmbedScript/appEmbeds.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/web/theme/modules/WysiwygV2/PrismicWysiwyg/Components/EmbedScript/appEmbeds.js)
 file.
 
 - This file accepts a record with the key as the embed
@@ -226,7 +226,7 @@ export default Pre;
 ```
 
 Then you will need to register this component by overriding the
-[`theme/modules/WysiwygV2/PrismicWysiwyg/appComponentsMap.js`](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic/web/theme/modules/WysiwygV2/PrismicWysiwyg/appComponentsMap.js)
+[`theme/modules/WysiwygV2/PrismicWysiwyg/appComponentsMap.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/web/theme/modules/WysiwygV2/PrismicWysiwyg/appComponentsMap.js)
 file.
 
 ```js

--- a/docs/prismic/expose-content.mdx
+++ b/docs/prismic/expose-content.mdx
@@ -32,7 +32,7 @@ The Prismic loader has the following API to request Content from Prismic:
 ### `loadSingle(typeIdentifier)`
 
 Returns a
-[Content](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/Content.js)
+[Content](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/Content.js)
 representing a Prismic Content of
 [the corresponding type](https://prismic.io/docs/core-concepts/custom-types). If
 such Content does not exist, it throws an error.
@@ -46,7 +46,7 @@ such Content does not exist, it throws an error.
 ### `loadByID(id)`
 
 Returns a
-[Content](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/Content.js)
+[Content](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/Content.js)
 representing a Prismic Content of
 [the corresponding type](https://prismic.io/docs/core-concepts/custom-types). If
 such Content does not exist, it throws an error.
@@ -58,7 +58,7 @@ such Content does not exist, it throws an error.
 ### `loadByUID(typeIdentifier, uid)`
 
 Returns a
-[Content](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/Content.js)
+[Content](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/Content.js)
 representing a Prismic Content of
 [the corresponding type](https://prismic.io/docs/core-concepts/custom-types) and
 having [a UID field](https://prismic.io/docs/core-concepts/uid) with the given
@@ -74,15 +74,15 @@ value. If such Content does not exist, it throws an error.
 ### `loadList(query)`
 
 Returns
-[a `ContentList`](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/ContentList.js)
+[a `ContentList`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/ContentList.js)
 matching the query. `query` must be an instance of
-[`ListQuery`](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/ListQuery.js),
+[`ListQuery`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/ListQuery.js),
 it provides a way to filter, sort and paginate Prismic Content.
 
 **Arguments:**
 
 - `query`
-  ([ListQuery](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/ListQuery.js)):
+  ([ListQuery](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/ListQuery.js)):
   A query for a list of documents
 
 ### `defineContentTransformers(typeIdentifier, options)`
@@ -95,7 +95,7 @@ Defines the content transform options for a given document type.
   ([string](https://prismic.io/docs/technologies/rest-api-technical-reference#document.type)):
   The type of document.
 - `options`
-  ([ContentTransformOptions](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/index.js#L35-39)):
+  ([ContentTransformOptions](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/index.js#L35-39)):
   Content transform options
 
 ### Field Transformers
@@ -149,7 +149,7 @@ the
 :::
 
 The complete list of available Transformers can be found under
-[the `transformers` directory in Prismic module](https://gitlab.com/front-commerce/front-commerce-prismic/-/tree/main/prismic/server/modules/prismic/core/loaders/transformers).
+[the `transformers` directory in Prismic module](https://gitlab.blackswift.cloud/front-commerce/front-commerce-prismic/-/tree/main/prismic/server/modules/prismic/core/loaders/transformers).
 We will use some of them in the following examples.
 
 ## Implementation examples

--- a/docs/prismic/installation.mdx
+++ b/docs/prismic/installation.mdx
@@ -10,7 +10,7 @@ description:
 <p>{frontMatter.description}</p>
 
 This guide assumes that you are working in
-[a Front-Commerce skeleton environment](https://gitlab.com/front-commerce/front-commerce-skeleton/).
+[a Front-Commerce skeleton environment](https://gitlab.blackswift.cloud/front-commerce/front-commerce-skeleton/).
 
 ## Configure the environment for Prismic
 
@@ -133,8 +133,9 @@ domain `images.prismic.io` to `imgSrc` in
 ## Optional: Configure the PrismicWysiwyg
 
 If you are using any other Wysiwyg enabled modules, then you will need to
-override [`getWysiwygComponent.js`](https://gitlab.com/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/WysiwygV2/getWysiwygComponent.js) and map all of the
-Wysiwyg customizations, for example:
+override
+[`getWysiwygComponent.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/WysiwygV2/getWysiwygComponent.js)
+and map all of the Wysiwyg customizations, for example:
 
 ```js title="theme/modules/WysiwygV2/getWysiwygComponent.js"
 import loadable from "@loadable/component";
@@ -165,7 +166,7 @@ learn more.
 **Default transforms**
 
 - `<script>` tags with a
-  [supported embed script](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic/web/theme/modules/WysiwygV2/PrismicWysiwyg/Components/EmbedScript/embeds.js)
+  [supported embed script](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/web/theme/modules/WysiwygV2/PrismicWysiwyg/Components/EmbedScript/embeds.js)
   are transformed into
-  [`theme/web/WysiwygV2/PrismicWysiwyg/EmbedScript`](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic/web/theme/modules/WysiwygV2/PrismicWysiwyg/Components/EmbedScript/EmbedScript.js)
+  [`theme/web/WysiwygV2/PrismicWysiwyg/EmbedScript`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/web/theme/modules/WysiwygV2/PrismicWysiwyg/Components/EmbedScript/EmbedScript.js)
   components.

--- a/docs/prismic/resolver-cache.mdx
+++ b/docs/prismic/resolver-cache.mdx
@@ -11,7 +11,7 @@ descriptions:
 
 In order to create references from prismic to the cached documents, we need to
 ensure that the `PrismicCachedResolver` receives a
-[Content](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/Content.js)
+[Content](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/Content.js)
 type from your resolver. The resolver can either cache a `singleton` Content, or
 a `list` of Content.
 
@@ -29,7 +29,7 @@ Returns a resolver that caches the result of the given resolver.
 - `options` : An object with the following properties:
   - `mapParamsToId` A function that maps the resolver parameters to a unique id.
   - `contentProperty` The name of the property that contains the
-    [Content](https://gitlab.com/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/Content.js).
+    [Content](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/Content.js).
 
 ## Usage
 

--- a/docs/prismic/routable-types.mdx
+++ b/docs/prismic/routable-types.mdx
@@ -50,7 +50,7 @@ type Album implements Routable {
 
 Note that in order for the custom type to be routable it needs to implement the
 core Front-Commerce
-[Routable interface](https://gitlab.com/front-commerce/front-commerce/-/blob/2.7.1/src/server/modules/front-commerce/core/schema.gql#L87).
+[Routable interface](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2.7.1/src/server/modules/front-commerce/core/schema.gql#L87).
 That is why the GraphQL type must have a field called `path` to represent the
 URL of the routable type.
 
@@ -299,7 +299,7 @@ Prismic Route Resolver, it can also create a sitemapable route.
   redirected the base path.
 - `isSitemapable` (boolean): whether the type should be included in the sitemap
 - `postTransformer`
-  ([PostTransformerCallback](https://gitlab.com/front-commerce/front-commerce-prismic/blob/084cbb54049614259cf31045bf03de636c08c201/prismic/server/modules/prismic/core/makeRoutableTypeRegisterer.js#L114-120)):
+  ([PostTransformerCallback](https://gitlab.blackswift.cloud/front-commerce/front-commerce-prismic/blob/084cbb54049614259cf31045bf03de636c08c201/prismic/server/modules/prismic/core/makeRoutableTypeRegisterer.js#L114-120)):
   a function that will be called after the transformation is done using
   `contentTransformOptions`
 

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -12,7 +12,7 @@ These commands should be launched from your project's root directory. This can
 be done by:
 
 - Using npm scripts (just like
-  [front-commerce-skeleton/package.json](https://gitlab.com/front-commerce/front-commerce-skeleton/blob/main/package.json#L7))
+  [front-commerce-skeleton/package.json](https://gitlab.blackswift.cloud/front-commerce/front-commerce-skeleton/blob/main/package.json#L7))
 - Prefixing the commands with `npx` which will call the `front-commerce` bin in
   your project
 

--- a/docs/reference/configurations.mdx
+++ b/docs/reference/configurations.mdx
@@ -19,7 +19,7 @@ to also read these related pages.
 ## How to set your configurations
 
 Each file described below exist in
-[`node_modules/front-commerce/src/config`](https://gitlab.com/front-commerce/front-commerce/tree/main/src/config)
+[`node_modules/front-commerce/src/config`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tree/main/src/config)
 in Front-Commerce. If you want to override some, duplicate those in
 `my-module/config`.
 
@@ -72,7 +72,7 @@ your website. The term website refers to what a
 - `tax` (ex: `1.2` for 20% VAT): Used to correctly filter products within layer
   queries (this configuration should soon be deprecated with search updates in
   Front-Commerce — see
-  [#102](https://gitlab.com/front-commerce/front-commerce/issues/102))
+  [#102](https://gitlab.blackswift.cloud/front-commerce/front-commerce/issues/102))
 - `contentSecurityPolicy`: For security reasons only URLs from the store's
   domain are authorized through CSPs. However, for tracking and external
   dependencies, we may authorize more domains. Use the following config and add
@@ -164,7 +164,7 @@ module.exports = {
   ]
 
   // Headers where it's most likely to find the client IP
-  // Useful for logging the client's ip in the client logger (cf. https://gitlab.com/front-commerce/front-commerce/issues/23)
+  // Useful for logging the client's ip in the client logger (cf. https://gitlab.blackswift.cloud/front-commerce/front-commerce/issues/23)
   headers: ["x-real-ip", "x-forwarded-for"],
 };
 ```
@@ -253,7 +253,8 @@ Loaders are identified with a key. The key is the first argument passed to the
 
 Example of a recommended configuration for Magento stores.
 
-Reminder: ensure to take a look at [the redis strategy for the fully configured redis setup](/docs/advanced/graphql/dataloaders-and-cache-invalidation#redis)
+Reminder: ensure to take a look at
+[the redis strategy for the fully configured redis setup](/docs/advanced/graphql/dataloaders-and-cache-invalidation#redis)
 
 ```js
 export default {

--- a/docs/reference/front-commerce-js.mdx
+++ b/docs/reference/front-commerce-js.mdx
@@ -112,8 +112,8 @@ Each object must be composed of the properties below:
   a temporary name that is used during a code generation step and has no other
   usage in the application. _Do not worry about it, it will be deprecated in a
   near future: see
-  [#179](https://gitlab.com/front-commerce/front-commerce/issues/179) for
-  further information._
+  [#179](https://gitlab.blackswift.cloud/front-commerce/front-commerce/issues/179)
+  for further information._
 
 - `path`: must be a path to the
   [GraphQL module definition file](/docs/reference/graphql-module-definition)

--- a/docs/reference/graphql-module-definition.mdx
+++ b/docs/reference/graphql-module-definition.mdx
@@ -93,7 +93,7 @@ export default {
 
 Modules are sorted using the [toposort](https://www.npmjs.com/package/toposort)
 library. See
-[`flattenAndReorderModulesUsingDependencies`](https://gitlab.com/front-commerce/front-commerce/blob/main/src/server/core/graphql/__tests__/flattenAndReorderModulesUsingDependencies.js)
+[`flattenAndReorderModulesUsingDependencies`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/server/core/graphql/__tests__/flattenAndReorderModulesUsingDependencies.js)
 code and tests for further details.
 
 :::

--- a/docs/reference/scripts.mdx
+++ b/docs/reference/scripts.mdx
@@ -16,9 +16,9 @@ import ContactLink from "@site/src/components/ContactLink";
 We plan to improve the way scripts are created and used in the future, and allow
 developers to register custom scripts from their applications. If interested for
 more context, please see
-[#169](https://gitlab.com/front-commerce/front-commerce/issues/169) for further
-details and do note hesitate to send us feedback about this feature. You can
-also <ContactLink /> directly if you have any question.
+[#169](https://gitlab.blackswift.cloud/front-commerce/front-commerce/issues/169)
+for further details and do note hesitate to send us feedback about this feature.
+You can also <ContactLink /> directly if you have any question.
 
 :::
 

--- a/src/components/BackportList.tsx
+++ b/src/components/BackportList.tsx
@@ -7,7 +7,7 @@ interface BackportListProps {
 }
 
 const releaseUrl = (version: string) => {
-  return `https://gitlab.com/front-commerce/front-commerce/-/releases/${version}`;
+  return `https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/${version}`;
 };
 
 const stripPatchVersion = (version: string) => {


### PR DESCRIPTION
This MR updates our documentation to replace gitlab.com URLs with new gitlab.blackswift.cloud URLs.