### PR TITLE
fix(migration): remove custom payment method as a feature

### DIFF
--- a/docs/appendices/migration-guides/index.mdx
+++ b/docs/appendices/migration-guides/index.mdx
@@ -171,7 +171,6 @@ or
 ### New features in `2.19.0`
 
 - [The Stripe module can be configured to not automatically capture the payment](/docs/advanced/payments/stripe#advanced-disable-automatic-capture)
-- [Implement a custom payment method](/docs/advanced/payments/custom-payment-method)
 - [Report-Only <abbr title="Content Security Policy">CSP</abbr> are now configurable](/docs/reference/content-security-policy.mdx)
 - [Ability to cache customers' cart with Magento2](/docs/magento2/advanced##caching-customers-cart)
 - [ChronoRelais shipping method support](/docs/advanced/shipping/chronorelais)


### PR DESCRIPTION
Removing the custom payment method feature announcement following the discussion https://github.com/front-commerce/developers.front-commerce.com/pull/487#discussion_r1001997562