### PR TITLE
Document current customer's information cache for Magento2

### DIFF
--- a/docs/appendices/migration-guides/index.mdx
+++ b/docs/appendices/migration-guides/index.mdx
@@ -187,7 +187,9 @@ or
 
 - [The Stripe module can be configured to not automatically capture the payment](/docs/advanced/payments/stripe#advanced-disable-automatic-capture)
 - [Report-Only <abbr title="Content Security Policy">CSP</abbr> are now configurable](/docs/reference/content-security-policy.mdx)
-- [Ability to cache customers' cart with Magento2](/docs/magento2/advanced#caching-customers-cart)
+- Magento2 performance improvements (opt-in)
+  - [Ability to cache customers' cart](/docs/magento2/advanced#caching-customers-cart)
+  - [Ability to cache current customers' information](/docs/magento2/advanced#caching-current-customers-information)
 - [ChronoRelais shipping method support](/docs/advanced/shipping/chronorelais)
 
 ## `2.17.0` -> `2.18.0`

--- a/docs/magento2/advanced.mdx
+++ b/docs/magento2/advanced.mdx
@@ -49,6 +49,35 @@ or
 [`CartCacheAwareStoreCreditLoader`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/d29c30a0c6a513472b66f10441bd2c620903b11c/src/server/modules/magento2-commerce/store-credit/loaders/CartCacheAwareStoreCreditLoader.js#L43-51)
 where the cart cache is expired after some operations.
 
+## Caching current customers' information
+
+> _Since version 2.19.0_
+
+By default, any GraphQL query fetching data under the `Query.me` field (`Customer` type) systematically leads to customer data being fetched from Magento. While this ensure the freshness of current customer's information, it has several drawbacks:
+- Magento is hit more often than needed
+- child resolvers are resolved after this initial query is received (waterfall effect)
+
+Considering that customer's information are likely not updated without user interaction on the application, we've added a way to cache customer's information in their user session in 2.19.0. It allows to greatly improve the perceived performance of transactional user journeys, but should be adopted with care.
+
+For now, this feature is considered as **experimental** and must be explicitly enabled by defining the `FRONT_COMMERCE_CURRENT_CUSTOMER_CACHE_ENABLE` environment variable.
+
+```shell title=.env
+FRONT_COMMERCE_CURRENT_CUSTOMER_CACHE_ENABLE=true
+```
+
+:::caution
+
+If you enable current customer's cache, we strongly advice to fully test your project before going live with it. You can use the `DEBUG=front-commerce:customer:cache` flag to monitor what happens in your process output.
+
+:::
+
+When the current customer cache is enabled, Front-Commerce will cache customer's information in its own session. As with any cache mechanism, at some point, the cache needs to be expired.
+
+Front-Commerce takes care of expiring these information when an operation can have an effect on the customer information (for instance when adding an address to the account). If you use an API that updates customer information, you will also have to expire the
+cart cache.
+
+To do that, you can use [`makeCurrentCustomerCache`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/magento2/customer/cache/makeCurrentCustomerCache.js) factory to create an instance of this cache, and `expire()` it. You can have a look at how it is used in [`CustomerLoader`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/magento2/customer/loaders/CustomerLoader.js) where the cart cache is expired after some operations.
+
 ## Additional headers in Magento API calls
 
 > _Since version 2.7.0_

--- a/docs/magento2/advanced.mdx
+++ b/docs/magento2/advanced.mdx
@@ -76,7 +76,7 @@ When the current customer cache is enabled, Front-Commerce will cache customer's
 Front-Commerce takes care of expiring these information when an operation can have an effect on the customer information (for instance when adding an address to the account). If you use an API that updates customer information, you will also have to expire the
 cart cache.
 
-To do that, you can use [`makeCurrentCustomerCache`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/magento2/customer/cache/makeCurrentCustomerCache.js) factory to create an instance of this cache, and `expire()` it. You can have a look at how it is used in [`CustomerLoader`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/magento2/customer/loaders/CustomerLoader.js) where the cart cache is expired after some operations.
+To do that, you can use [`makeCurrentCustomerCache`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/magento2/customer/cache/makeCurrentCustomerCache.js) factory to create an instance of this cache, and `expire()` it. You can have a look at how it is used in [`CustomerLoader`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/magento2/customer/loaders/CustomerLoader.js) where the customer cache is expired after some operations.
 
 ## Additional headers in Magento API calls
 

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -390,6 +390,7 @@ Here is a list of available debug namespaces:
   information and [HTTP Cache
   deactivation](/docs/advanced/performance/cache-control-and-cdn/).
 - `front-commerce:cart`: debugs cart corrupted data received from remote sources
+- `front-commerce:cart:cache`: debugs cache information for customer's cart (see [Caching customers' cart](/docs/magento2/advanced#caching-customers-cart))
 - `front-commerce:cluster`: debugs the node process id and other information to
   help configuring cluster mode
 - `front-commerce:config`: dumps the configuration for a typical request at the

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -91,7 +91,9 @@ redirects user to the HTTPS version of a page in this case. Use the
   [Invalidating the cache](/docs/advanced/graphql/dataloaders-and-cache-invalidation#invalidating-the-cache)
   for more details.
 - `FRONT_COMMERCE_CART_CACHE_ENABLE`: allows to enable [the cart cache (only
-    available when running Front-Commerce with Magento2)](/docs/magento2/advanced##caching-customers-cart)
+    available when running Front-Commerce with Magento2)](/docs/magento2/advanced#caching-customers-cart)
+- `FRONT_COMMERCE_CURRENT_CUSTOMER_CACHE_ENABLE`: allows to enable [the current customer cache (only
+    available when running Front-Commerce with Magento2)](/docs/magento2/advanced#caching-current-customers-information)
 
 ### Performance
 
@@ -391,6 +393,7 @@ Here is a list of available debug namespaces:
   deactivation](/docs/advanced/performance/cache-control-and-cdn/).
 - `front-commerce:cart`: debugs cart corrupted data received from remote sources
 - `front-commerce:cart:cache`: debugs cache information for customer's cart (see [Caching customers' cart](/docs/magento2/advanced#caching-customers-cart))
+- `front-commerce:customer:cache`: debugs cache information for current user's information (see [Caching current customers' information for Magento2](/docs/magento2/advanced#caching-current-customers-information))
 - `front-commerce:cluster`: debugs the node process id and other information to
   help configuring cluster mode
 - `front-commerce:config`: dumps the configuration for a typical request at the


### PR DESCRIPTION
This MR documents the new customer cache feature for Magento2

Preview:
- https://deploy-preview-517--heuristic-almeida-1a1f35.netlify.app/docs/magento2/advanced#caching-current-customers-information
- https://deploy-preview-517--heuristic-almeida-1a1f35.netlify.app/docs/appendices/migration-guides/#new-features-in-2190
- https://deploy-preview-517--heuristic-almeida-1a1f35.netlify.app/docs/reference/environment-variables#cache