### PR TITLE
chore(accessibility): update darkmode primary color

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -27,13 +27,13 @@
 * see https://docusaurus.io/docs/styling-layout#styling-your-site-with-infima
 */
 [data-theme="dark"] {
-  --ifm-color-primary: #ff2a6a;
-  --ifm-color-primary-dark: #ff0c55;
-  --ifm-color-primary-darker: #fc004c;
-  --ifm-color-primary-darkest: #d0003e;
-  --ifm-color-primary-light: #ff487f;
-  --ifm-color-primary-lighter: #ff5789;
-  --ifm-color-primary-lightest: #ff83a8;
+  --ifm-color-primary: #ff8aab;
+  --ifm-color-primary-dark: #ff638f;
+  --ifm-color-primary-darker: #ff4f81;
+  --ifm-color-primary-darkest: #ff1456;
+  --ifm-color-primary-light: #ffb1c7;
+  --ifm-color-primary-lighter: #ffc5d5;
+  --ifm-color-primary-lightest: #ffffff;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 


### PR DESCRIPTION
While reading the release notes in dark mode I noticed that the primary colors really hard to read. I used the [docosaurus palette](https://docusaurus.io/docs/styling-layout#styling-your-site-with-infima) tool to find the closes accessible color to our original primary color.

![image](https://user-images.githubusercontent.com/39598117/198337947-b0577e58-35f2-4a6b-b69f-7e1722dda129.png)


# Screenshots

| Before | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/39598117/198337630-efd9b329-5ab3-4517-9727-a35c5e1ce2cb.png) | ![image](https://user-images.githubusercontent.com/39598117/198337670-7932578f-3ac5-4804-b8e2-d5e3063299cc.png) |