### PR TITLE
chore(prismic): remove web module

### DIFF
--- a/docs/prismic/installation.mdx
+++ b/docs/prismic/installation.mdx
@@ -74,12 +74,6 @@ module.exports = {
   ],
   webModules: [
     { name: "FrontCommerce", path: "front-commerce/src/web" },
-    // highlight-start
-    {
-      name: "Prismic",
-      path: "./node_modules/front-commerce/modules/prismic/web",
-    },
-    // highlight-end
   ],
 };
 ```


### PR DESCRIPTION
Since the module doesn't register routes, it shouldn't be added to `webModules` in `.front-commerce.js` 

See https://developers.front-commerce.com/docs/essentials/add-a-page-client-side#declare-your-module-as-a-web-module