### PR TITLE
Added documention on default address support changes

### DIFF
--- a/docs/appendices/migration-guides/index.mdx
+++ b/docs/appendices/migration-guides/index.mdx
@@ -12,6 +12,21 @@ import ContactLink from "@site/src/components/ContactLink";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
+## `2.19.0` -> `2.20.0`
+
+### Default shipping and billing address support
+
+In this release, we updated how the `"Use as default billing address"` and
+`"Use as default shipping address"` checkboxes are displayed in the
+[`AddressForm`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/User/Address/AddressForm/AddressForm.js)
+component. It now can be controlled globally using a configuration in the
+[`src/config/website.js`](/docs/reference/configurations#configwebsitejs)
+configuration file.
+
+Please check if you have overriden the `AddressForm` component
+([commit](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/fd27e93d3e345157251ac6d3ace5e5e56c528ce6))
+if you're interested in using this feature.
+
 ## `2.18.0` -> `2.19.0`
 
 ### Replaced `mkdirp` package with `make-dir`

--- a/docs/reference/configurations.mdx
+++ b/docs/reference/configurations.mdx
@@ -114,6 +114,8 @@ your website. The term website refers to what a
   - `intersectionObserverDevices`: the type of devices where intersection
     observers should be used for preload. We usually don't want it on desktop to
     avoid triggering too many requests. (default: `["phone", "tablet"]`)
+- `hasDefaultAddressSupport`: a boolean that controls if the customer can set
+  addresses as default for billing and shipping (default: `true`)
 
 You could find many other configurations in such a file because some
 configurations could come from optional modules. Some of these are:


### PR DESCRIPTION
Following the change on how default address checkboxes are displayed, and the new `website.js` configuration.

[Migration guide](https://deploy-preview-540--heuristic-almeida-1a1f35.netlify.app/docs/appendices/migration-guides/#default-shipping-and-billing-address-support)

[website.js update](https://deploy-preview-540--heuristic-almeida-1a1f35.netlify.app/docs/reference/configurations#configwebsitejs)