### PR TITLE
fix: use correct syntax in copy/pastable GTM setup snippet

### DIFF
--- a/docs/advanced/analytics/plugins.mdx
+++ b/docs/advanced/analytics/plugins.mdx
@@ -305,11 +305,11 @@ Configuration example in `src/config/analytics.js`
 {
   name: "google-tag-manager",
   needConsent: true,
-  settings: (authorization, otherAuthorizations) => {
+  settings: (authorization, otherAuthorizations) => ({
     containerId: "GTM-123xyz",
     // the userConsents option is a specific key that the plugin will use and expose in the GTM dataLayer
     userConsents: otherAuthorizations
-  }
+  }),
   script: () => import("@segment/analytics.js-integration-google-tag-manager"),
 }
 ```

--- a/docs/advanced/analytics/plugins.mdx
+++ b/docs/advanced/analytics/plugins.mdx
@@ -310,7 +310,7 @@ Configuration example in `src/config/analytics.js`
     // the userConsents option is a specific key that the plugin will use and expose in the GTM dataLayer
     userConsents: otherAuthorizations
   }),
-  script: () => import("@segment/analytics.js-integration-google-tag-manager"),
+  script: () => import("@analytics/google-tag-manager"),
 }
 ```
 


### PR DESCRIPTION
As seen today during support, the snippet is incorrect. This MR fixes the syntax.

**Preview:** https://deploy-preview-543--heuristic-almeida-1a1f35.netlify.app/docs/advanced/analytics/plugins#google-tag-manager