### PR TITLE
Fix install step in BigCommerce doc

### DIFF
--- a/docs/bigcommerce/installation.mdx
+++ b/docs/bigcommerce/installation.mdx
@@ -19,8 +19,10 @@ module.exports = {
   url: "http://localhost:4000",
   modules: [
     "./node_modules/front-commerce/theme-chocolatine",
-    // highlight-next-line
+    // highlight-start
     "./node_modules/front-commerce/modules/big-commerce",
+    "./node_modules/front-commerce/modules/big-commerce-web",
+    // highlight-end
     "./src",
   ],
   serverModules: [


### PR DESCRIPTION
`big-commerce-web` module was missing from the `front-commerce.js` diff.