### PR TITLE
fix(docs): Removed wrong file title in snipet

### DIFF
--- a/docs/advanced/features/smart-forms.mdx
+++ b/docs/advanced/features/smart-forms.mdx
@@ -288,7 +288,7 @@ needs to be setup at the `<Form>` level.
 To properly setup phone number validation using the `usePhoneNumberValidation`
 hook you need to update your `<Form>` as noted below:
 
-```jsx title="my-module/web/theme/modules/SmartForms/Field/PhoneNumber/usePhoneNumberValidation.js"
+```jsx
 import Form from "theme/components/atoms/Form/Form";
 
 const MyAwesomeForm = ({ onSubmit }) => {


### PR DESCRIPTION
There was a file name in a snippet title that was unrelated to this file.

[URL](https://deploy-preview-554--heuristic-almeida-1a1f35.netlify.app/docs/advanced/features/smart-forms#usephonenumbervalidation)

Before:
![image](https://user-images.githubusercontent.com/4162177/205304961-a459d481-2d7a-41c7-a0e9-3b4c0e48d215.png)

After:
![image](https://user-images.githubusercontent.com/4162177/205304991-e2b2ae12-54c5-4636-847a-56d438e261b0.png)
