### PR TITLE
refactor(docs): Removed FrontCommerceCore references from docs

### DIFF
--- a/docs/advanced/graphql/meta-modules.mdx
+++ b/docs/advanced/graphql/meta-modules.mdx
@@ -39,7 +39,7 @@ module.exports = {
   url: "https://www.front-commerce.test",
   modules: [],
   serverModules: [
-    { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+    { name: "FrontCommerce", path: "server/modules/front-commerce" },
     // highlight-next-line
     { name: "Magento2", path: "server/modules/magento2" },
   ],

--- a/docs/advanced/graphql/remote-schemas.mdx
+++ b/docs/advanced/graphql/remote-schemas.mdx
@@ -51,7 +51,7 @@ module.exports = {
   url: "https://www.front-commerce.test",
   modules: [],
   serverModules: [
-    { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+    { name: "FrontCommerce", path: "server/modules/front-commerce" },
     { name: "Magento2", path: "server/modules/magento2" },
     // highlight-next-line
     { name: "Pokemon", path: "./my-module/server/modules/pokemon" },

--- a/docs/advanced/payments/adyen.mdx
+++ b/docs/advanced/payments/adyen.mdx
@@ -79,7 +79,7 @@ module.exports = {
   // highlight-next-line
   modules: ["./node_modules/front-commerce/modules/payment-adyen"],
   serverModules: [
-    { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+    { name: "FrontCommerce", path: "server/modules/front-commerce" },
     { name: "Magento1", path: "server/modules/magento1" },
     // highlight-start
     {
@@ -107,7 +107,7 @@ module.exports = {
   // highlight-next-line
   modules: ["./node_modules/front-commerce/modules/payment-adyen"],
   serverModules: [
-    { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+    { name: "FrontCommerce", path: "server/modules/front-commerce" },
     { name: "Magento2", path: "server/modules/magento2" },
     // highlight-start
     {
@@ -248,7 +248,8 @@ To allow loading Adyen related remote resources:
 The `reportOnlyDirectives` block allows all iframes on you application, this is
 required to allow 3DS2 authentication iframes to load in your site.
 
-If you are not using the credit card payments consider removing this code block (for FC < 2.19, please remove the `"*"` rule instead).
+If you are not using the credit card payments consider removing this code block
+(for FC < 2.19, please remove the `"*"` rule instead).
 
 :::
 
@@ -398,7 +399,7 @@ FRONT_COMMERCE_ADYEN_STORE_PAYMENT_DETAILS=true
 -  modules: [],
 +  modules: ["./node_modules/front-commerce/modules/payment-adyen"],
    serverModules: [
-     { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
 -    { name: "Magento2", path: "server/modules/magento2" }
 +    { name: "Magento2", path: "server/modules/magento2" },
 +    {

--- a/docs/advanced/payments/affirm.mdx
+++ b/docs/advanced/payments/affirm.mdx
@@ -80,7 +80,7 @@ In your Front-Commerce application:
 ```diff title=".front-commerce.js"
    modules: [],
    serverModules: [
-     { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
 -    { name: "Magento2", path: "server/modules/magento2" }
 +    { name: "Magento2", path: "server/modules/magento2" },
 +    { name: "Magento2Affirm", path: "server/modules/payment-magento2-affirm" },

--- a/docs/advanced/payments/buybox.mdx
+++ b/docs/advanced/payments/buybox.mdx
@@ -45,7 +45,7 @@ In your Front-Commerce application:
 -   modules: [],
 +   modules: ["./node_modules/front-commerce/modules/payment-buybox"],
    serverModules: [
-     { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
 -    { name: "Magento2", path: "server/modules/magento2" }
 +    { name: "Magento2", path: "server/modules/magento2" },
 +    { name: "BuyBox", path: "payment-buybox/server/modules/payment-buybox" }

--- a/docs/advanced/payments/ingenico.mdx
+++ b/docs/advanced/payments/ingenico.mdx
@@ -54,7 +54,7 @@ In your Front-Commerce application:
 ```diff title='.front-commerce.js'
    modules: [],
    serverModules: [
-     { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
 -    { name: "Magento2", path: "server/modules/magento2" }
 +    { name: "Magento2", path: "server/modules/magento2" },
 +    { name: "Ogone", path: "server/modules/payment-ogone" }

--- a/docs/advanced/payments/payline.mdx
+++ b/docs/advanced/payments/payline.mdx
@@ -78,7 +78,7 @@ In your Front-Commerce application:
 -  modules: [],
 +  modules: ["./node_modules/front-commerce/modules/payment-payline-magento1"],
    serverModules: [
-     { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
 -    { name: "Magento1", path: "server/modules/magento1" }
 +    { name: "Magento1", path: "server/modules/magento1" },
 +    {

--- a/docs/advanced/payments/paypal.mdx
+++ b/docs/advanced/payments/paypal.mdx
@@ -66,7 +66,7 @@ In your Front-Commerce application:
 ```diff title=".front-commerce.js"
    modules: [],
    serverModules: [
-     { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
 -    { name: "Magento2", path: "server/modules/magento2" }
 +    { name: "Magento2", path: "server/modules/magento2" },
 +    { name: "Paypal", path: "server/modules/payment-paypal" }
@@ -78,7 +78,7 @@ In your Front-Commerce application:
 ```diff title=".front-commerce.js"
    modules: [],
    serverModules: [
-     { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
 -    { name: "Magento1", path: "server/modules/magento1" }
 +    { name: "Magento1", path: "server/modules/magento1" },
 +    { name: "Paypal", path: "server/modules/payment-paypal/index.magento1.js" }

--- a/docs/advanced/payments/payzen.mdx
+++ b/docs/advanced/payments/payzen.mdx
@@ -75,7 +75,7 @@ In your Front-Commerce application:
 ```diff title='.front-commerce.js'
    modules: [],
    serverModules: [
-     { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
 -    { name: "Magento2", path: "server/modules/magento2" }
 +    { name: "Magento2", path: "server/modules/magento2" },
 +    { name: "PayZen", path: "server/modules/payment-payzen" }
@@ -87,7 +87,7 @@ In your Front-Commerce application:
 ```diff title='.front-commerce.js'
    modules: [],
    serverModules: [
-     { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
 -    { name: "Magento1", path: "server/modules/magento1" }
 +    { name: "Magento1", path: "server/modules/magento1" },
 +    { name: "PayZen", path: "server/modules/payment-payzen/index.magento1.js" }

--- a/docs/advanced/payments/stripe.mdx
+++ b/docs/advanced/payments/stripe.mdx
@@ -43,7 +43,7 @@ In your Front-Commerce application:
 ```diff title=".front-commerce.js"
    modules: [],
    serverModules: [
-     { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
 -    { name: "Magento2", path: "server/modules/magento2" }
 +    { name: "Magento2", path: "server/modules/magento2" },
 +    { name: "Stripe", path: "server/modules/payment-stripe" }
@@ -55,7 +55,7 @@ In your Front-Commerce application:
 ```diff title=".front-commerce.js"
    modules: [],
    serverModules: [
-     { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
 -    { name: "Magento1", path: "server/modules/magento1" }
 +    { name: "Magento1", path: "server/modules/magento1" },
 +    { name: "Stripe", path: "server/modules/payment-stripe/index.magento1.js" }

--- a/docs/appendices/migration-guides/archives.mdx
+++ b/docs/appendices/migration-guides/archives.mdx
@@ -735,7 +735,7 @@ For a Magento2 based Front-Commerce setup:
 -  modules: [],
 +  modules: ["./node_modules/front-commerce/modules/datasource-elasticsearch"],
    serverModules: [
-     { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
 +    {
 +      name: "Magento2Elasticsearch",
 +      path: "datasource-elasticsearch/server/modules/magento2-elasticsearch",
@@ -750,7 +750,7 @@ For a Magento1 based Front-Commerce setup:
 -  modules: [],
 +  modules: ["./node_modules/front-commerce/modules/datasource-elasticsearch"],
    serverModules: [
-     { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
 +    {
 +      name: "Magento1Elasticsearch",
 +      path: "datasource-elasticsearch/server/modules/magento1-elasticsearch",

--- a/docs/essentials/add-component-to-storybook.mdx
+++ b/docs/essentials/add-component-to-storybook.mdx
@@ -206,7 +206,7 @@ module.exports = {
   url: "https://demo.front-commerce.com",
   modules: ["./my-module"],
   serverModules: [
-    { name: "FrontCommerceCore", path: "./modules/front-commerce-core" },
+    { name: "FrontCommerce", path: "./modules/front-commerce" },
     { name: "Magento2", path: "./modules/magento2" },
     { name: "SampleBlog", path: "./model/blog" },
   ],

--- a/docs/essentials/extend-the-graphql-schema.mdx
+++ b/docs/essentials/extend-the-graphql-schema.mdx
@@ -70,7 +70,7 @@ module.exports = {
     // highlight-end
   ],
   serverModules: [
-    { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+    { name: "FrontCommerce", path: "server/modules/front-commerce" },
     { name: "Magento2", path: "server/modules/magento2" },
     // highlight-start
     {

--- a/docs/magento1/search-engine.mdx
+++ b/docs/magento1/search-engine.mdx
@@ -62,7 +62,7 @@ making the changes in your `.front-commerce.js` file similar to:
 -  modules: [],
 +  modules: ["./node_modules/front-commerce/modules/datasource-elasticsearch"],
    serverModules: [
-     { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
 +    {
 +      name: "Magento1Elasticsearch",
 +      path: "datasource-elasticsearch/server/modules/magento1-elasticsearch",
@@ -151,7 +151,7 @@ changes in your `.front-commerce.js` file similar to:
 -  modules: [],
 +  modules: ["./node_modules/front-commerce/modules/datasource-algolia"],
    serverModules: [
-     { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
 +    {
 +      name: "Magento1Algolia",
 +      path: "datasource-algolia/server/modules/magento1-algolia",

--- a/docs/magento2/graphql.mdx
+++ b/docs/magento2/graphql.mdx
@@ -49,7 +49,7 @@ module.exports = {
   url: "https://www.front-commerce.test",
   modules: [],
   serverModules: [
-    { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+    { name: "FrontCommerce", path: "server/modules/front-commerce" },
     { name: "Magento2", path: "server/modules/magento2" },
     // highlight-next-line
     { name: "Magento2GraphQL", path: "server/modules/magento2-graphql" },

--- a/docs/magento2/search-engine.mdx
+++ b/docs/magento2/search-engine.mdx
@@ -78,7 +78,7 @@ module.exports = {
   // highlight-next-line
   modules: ["./node_modules/front-commerce/modules/datasource-elasticsearch"],
   serverModules: [
-    { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+    { name: "FrontCommerce", path: "server/modules/front-commerce" },
     // highlight-start
     {
       name: "Magento2Elasticsearch",
@@ -186,7 +186,7 @@ module.exports = {
   // highlight-next-line
   modules: ["./node_modules/front-commerce/modules/datasource-algolia"],
   serverModules: [
-    { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+    { name: "FrontCommerce", path: "server/modules/front-commerce" },
     // highlight-start
     {
       name: "Magento2Algolia",
@@ -309,7 +309,7 @@ module.exports = {
   // highlight-next-line
   modules: ["./node_modules/front-commerce/modules/datasource-attraqt"],
   serverModules: [
-    { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+    { name: "FrontCommerce", path: "server/modules/front-commerce" },
     // highlight-start
     {
       name: "Magento2Attraqt",

--- a/docs/reference/front-commerce-js.mdx
+++ b/docs/reference/front-commerce-js.mdx
@@ -99,7 +99,7 @@ GraphQL modules allows you to
 module.exports = {
   // […]
   serverModules: [
-    { name: "FrontCommerceCore", path: "server/modules/front-commerce-core" },
+    { name: "FrontCommerce", path: "server/modules/front-commerce" },
     { name: "Magento2", path: "server/modules/magento2" },
   ],
   // […]
@@ -130,7 +130,7 @@ management.
 As of the latest release, Front-Commerce’s provides the following GraphQL
 modules (or [meta-modules](/docs/advanced/graphql/meta-modules)):
 
-- `server/modules/front-commerce-core`: core features of Front-Commerce.
+- `server/modules/front-commerce`: core features of Front-Commerce.
 - `server/modules/magento2` _(meta module)_: Magento2 GraphQL modules to
   [use Front-Commerce with all Magento2 supported features](/docs/category/magento2).
   Register single sub-modules explicitly if you only need a subset of features.


### PR DESCRIPTION
Docs contained references of `FrontCommerceCore` module, which has been deprecated for a long time. this MR replaces every occurences of this module to the "new" `FrontCommerce`.