### PR TITLE
refactor: consolidate Magento 1 / OpenMage LTS branding across the doc

### DIFF
--- a/docs/advanced/features/external-logins/index.mdx
+++ b/docs/advanced/features/external-logins/index.mdx
@@ -20,7 +20,7 @@ comes in 2 parts:
 - The `LoginProvider` which implements the login with the external systems (such
   as Facebook or Google)
 - The `ExternalLoginHandler` which implements the login with your platform (such
-  as Magento1, Magento2, Proximis or BigCommerce).
+  as Magento1 (OpenMage LTS), Magento2, Proximis or BigCommerce).
 
 Out of the box we ship two `LoginProvider`s -the `FacebookProvider` and the
 `GoogleProvider`- and two `ExternalLoginHandler`s -the
@@ -64,7 +64,7 @@ module.exports = {
 };
 ```
 
-## Magento1 Requirements
+## Magento1 (OpenMage LTS) Requirements
 
 For the external logins to work with the Magento1 module in addition to
 [Adding the necessary modules](#adding-the-necessary-modules) you need to ensure

--- a/docs/advanced/features/in-stock-alert.mdx
+++ b/docs/advanced/features/in-stock-alert.mdx
@@ -17,7 +17,7 @@ import SinceVersion from "@site/src/components/SinceVersion";
 
 <p>{frontMatter.description}</p>
 
-Currently supoported for Magento 1 and Magento 2, enabling this feature will add
+Currently supported for Magento 1 (OpenMage LTS) and Magento 2, enabling this feature will add
 a button on a product's detail page for every product that is out of stock.
 
 <Figure>
@@ -31,7 +31,7 @@ a button on a product's detail page for every product that is out of stock.
 To use in-stock alerts in your project, you must first make sure the feature is
 enabled in your backend configuration.
 
-### Magento 1
+### Magento 1 (OpenMage LTS)
 
 Navigate to `System > Configuration > Catalog > Catalog`. Within the
 `Product Alerts` menu, make sure `Allow Alert When Product Comes Back in-Stock`

--- a/docs/advanced/graphql/dataloaders-and-cache-invalidation.mdx
+++ b/docs/advanced/graphql/dataloaders-and-cache-invalidation.mdx
@@ -123,7 +123,7 @@ resolve data.
 Clearing the cache manually is possible on some of the supported platforms. Read
 dedicated pages for details:
 
-- [Magento 1](/docs/magento1/advanced#clearing-front-commerce-cache)
+- [Magento 1 (OpenMage LTS)](/docs/magento1/advanced#clearing-front-commerce-cache)
 - [Magento 2](/docs/magento2/advanced#clearing-front-commerce-cache)
 <!-- TODO - add BigCommerce and Prismic manual cache clearing backlinks -->
 

--- a/docs/advanced/payments/adyen.mdx
+++ b/docs/advanced/payments/adyen.mdx
@@ -73,7 +73,7 @@ FRONT_COMMERCE_ADYEN_STORE_PAYMENT_DETAILS=true
 
 In your Front-Commerce application:
 
-For Magento1:
+For Magento1 (OpenMage LTS):
 
 ```js title=".front-commerce.js"
 module.exports = {

--- a/docs/advanced/payments/buybox.mdx
+++ b/docs/advanced/payments/buybox.mdx
@@ -54,7 +54,7 @@ In your Front-Commerce application:
    ]
 ```
 
-#### Magento1
+#### Magento1 (OpenMage LTS)
 
 BuyBox is not yet supported for Magento 1. Please <ContactLink /> if you need
 this integration.

--- a/docs/advanced/payments/payline.mdx
+++ b/docs/advanced/payments/payline.mdx
@@ -14,7 +14,7 @@ There is only one way to accept payments with
 [Monext Online (Payline)](https://www.monext.fr/online) in your Front-Commerce
 application for now.
 
-## Magento1 module
+## Magento1 (OpenMage LTS) module
 
 > _This feature has been added in versions: Front-Commerce `2.5.0`_
 

--- a/docs/advanced/payments/paypal.mdx
+++ b/docs/advanced/payments/paypal.mdx
@@ -18,12 +18,12 @@ There are different ways for you to accept payments with
   - [Configure your environment](#configure-your-environment)
   - [Register the Paypal payment module](#register-the-paypal-payment-module)
     - [Magento2](#magento2)
-    - [Magento1](#magento1)
+    - [Magento1 (OpenMage LTS)](#magento1-openmage-lts)
   - [Register your Paypal payment component](#register-your-paypal-payment-component)
   - [Update your CSPs](#update-your-csps)
   - [Advanced: customize data sent to Paypal](#advanced-customize-data-sent-to-paypal)
 - [Magento2 module](#magento2-module)
-- [Magento1 module](#magento1-module)
+- [Magento1 (OpenMage LTS) module](#magento1-openmage-lts-module)
 
 :::note
 
@@ -73,7 +73,7 @@ In your Front-Commerce application:
    ]
 ```
 
-#### Magento1
+#### Magento1 (OpenMage LTS)
 
 ```diff title=".front-commerce.js"
    modules: [],
@@ -183,7 +183,7 @@ Express** payment method.
 The Paypal module must be configured in a normal way, as for a non-headless
 Magento store.
 
-## Magento1 module
+## Magento1 (OpenMage LTS) module
 
 :::caution WIP
 

--- a/docs/advanced/payments/payzen.mdx
+++ b/docs/advanced/payments/payzen.mdx
@@ -20,7 +20,7 @@ application.
   - [Configure your environment](#configure-your-environment)
   - [Register the PayZen payment module](#register-the-payzen-payment-module)
     - [Magento2](#magento2)
-    - [Magento1](#magento1)
+    - [Magento1 (OpenMage LTS)](#magento1-openmage-lts)
   - [Register your PayZen payment component](#register-your-payzen-payment-component)
   - [Update your CSPs](#update-your-csps)
   - [Advanced: customize data sent to PayZen](#advanced-customize-data-sent-to-payzen)
@@ -87,7 +87,7 @@ In your Front-Commerce application:
    ]
 ```
 
-#### Magento1
+#### Magento1 (OpenMage LTS)
 
 ```diff title='.front-commerce.js'
    modules: [],

--- a/docs/advanced/payments/stripe.mdx
+++ b/docs/advanced/payments/stripe.mdx
@@ -50,7 +50,7 @@ In your Front-Commerce application:
    ]
 ```
 
-#### Magento1
+#### Magento1 (OpenMage LTS)
 
 ```diff title=".front-commerce.js"
    modules: [],

--- a/docs/advanced/shipping/mondial-relay.mdx
+++ b/docs/advanced/shipping/mondial-relay.mdx
@@ -77,7 +77,7 @@ Then, within your Front-Commerce project, you have to:
   };
   ```
 
-## Integrate with Magento1
+## Integrate with Magento1 (OpenMage LTS)
 
 <SinceVersion tag="2.5" />
 

--- a/docs/appendices/release-notes.mdx
+++ b/docs/appendices/release-notes.mdx
@@ -18,7 +18,7 @@ Compatible with:
   - Note: Magento 2.4.3 requires
     [this Adobe official patch](https://support.magento.com/hc/en-us/articles/4406893342093).
 - **Magento1**: CE 1.7+, EE 1.12+,
-  [OpenMageLTS](https://www.openmage.org/supported-versions.html) 19.4+
+  [OpenMage LTS](https://www.openmage.org/supported-versions.html) 19.4+
 
 ## 2.20.0 (2022-12-08)
 
@@ -329,7 +329,7 @@ Requirements:
   [magento module version 2.2.0+](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/releases/2.2.0) -
   (Open Source & Commerce)
 - or Magento1: CE 1.7+, EE 1.12+,
-  [OpenMageLTS](https://www.openmage.org/supported-versions.html) 19.4+
+  [OpenMage LTS](https://www.openmage.org/supported-versions.html) 19.4+
 - Reverse Proxy : Nginx 1.16 or more
 - NodeJS: 12.22+
 - Redis: 3.2+
@@ -452,7 +452,7 @@ Requirements:
   [magento module version 2.2.0+](https://gitlab.blackswift.cloud/front-commerce/magento2-module-front-commerce/-/releases/2.2.0) -
   (Open Source & Commerce)
 - or Magento1: CE 1.7+, EE 1.12+,
-  [OpenMageLTS](https://www.openmage.org/supported-versions.html) 19.4+
+  [OpenMage LTS](https://www.openmage.org/supported-versions.html) 19.4+
 - Reverse Proxy : Nginx 1.10 or more
 - NodeJS: 10.15+
 - Redis: 3.2+
@@ -500,7 +500,7 @@ Requirements:
 
 - Magento2: 2.3.2+ -> 2.4.0 (Open Source & Commerce)
 - or Magento1: CE 1.7+, EE 1.12+,
-  [OpenMageLTS](https://www.openmage.org/supported-versions.html) 19.4+
+  [OpenMage LTS](https://www.openmage.org/supported-versions.html) 19.4+
 - Reverse Proxy : Nginx 1.10 or more
 - NodeJS: 10.15+
 - Redis: 3.2+
@@ -571,7 +571,7 @@ Requirements:
   - analysis-icu
 - Magento2: 2.3.1+ (Open Source & Commerce)
 - Magento1: CE 1.7+, EE 1.12+,
-  [OpenMageLTS](https://www.openmage.org/supported-versions.html) 19.4+
+  [OpenMage LTS](https://www.openmage.org/supported-versions.html) 19.4+
 
 ## 2.0.0 (2020-07-09)
 
@@ -590,7 +590,7 @@ Requirements:
   - analysis-icu
 - Magento2: 2.3.1+ (Open Source & Commerce)
 - Magento1: CE 1.7+, EE 1.12+,
-  [OpenMageLTS](https://www.openmage.org/supported-versions.html) 19.4+
+  [OpenMage LTS](https://www.openmage.org/supported-versions.html) 19.4+
 
 ## 1.0.0-beta.4 (2019-06-25)
 

--- a/docs/magento1/_category_.yml
+++ b/docs/magento1/_category_.yml
@@ -1,8 +1,8 @@
-label: Magento 1
+label: Magento 1 (OpenMage LTS)
 position: 5
 link:
   slug: "/category/magento1"
   type: generated-index
   description:
     We currently support the main features of Magento. You can consider that if
-    it works in Magento 1, it will work with Front-Commerce!
+    it works in Magento 1 (now OpenMage LTS), it will work with Front-Commerce!

--- a/docs/magento1/generate-api-doc.mdx
+++ b/docs/magento1/generate-api-doc.mdx
@@ -2,7 +2,7 @@
 sidebar_position: 6
 title: Generate API doc
 description:
-  Magento 1 doesn't have an official API Documentation, but you can generate
+  Magento 1 (or OpenMage LTS) doesn't have an official API Documentation, but you can generate
   your own API doc with a PHP open source script. This guide explains the
   process in detail.
 ---

--- a/docs/magento1/headless-payments.mdx
+++ b/docs/magento1/headless-payments.mdx
@@ -1,10 +1,10 @@
 ---
 sidebar_position: 7
-title: Magento1 headless payments
+title: Magento1 (OpenMage LTS) headless payments
 description:
-  Historically, Magento1 does not support headless payments. Even though some
-  payment providers are using APIs from their module, most of them often rely on
-  the user's session to persist meaningful information across checkout steps.
+  Historically, Magento1 (now OpenMage LTS) does not support headless payments.
+  Even though some payment providers are using APIs from their module, most of them
+  often rely on the user's session to persist meaningful information across checkout steps.
   This guide explains how to expose an existing Magento payment method for
   headless usage in Front-Commerce.
 ---

--- a/docs/magento1/installation.mdx
+++ b/docs/magento1/installation.mdx
@@ -16,7 +16,7 @@ description:
 
 ### Recommendation
 
-- [Magento LTS](https://github.com/OpenMage/magento-lts) (1.9.4.x)
+- [OpenMage LTS](https://github.com/OpenMage/magento-lts) (1.9.4.x - v19.x)
 - `php` 7.3 with OpenSSL
 - `MySQL` 8.0+
 

--- a/docs/magento1/search-engine.mdx
+++ b/docs/magento1/search-engine.mdx
@@ -2,7 +2,7 @@
 sidebar_position: 2
 title: Search engine
 description:
-  When configured with Magento1, Front-Commerce provides search capabilities for
+  When configured with Magento1 , Front-Commerce provides search capabilities for
   your website using different technologies. This guide shows you the different
   options available to you.
 ---
@@ -14,9 +14,13 @@ import ContactLink from "@site/src/components/ContactLink";
 You can configure search and product lists with filters using the following
 platforms:
 
-- [Native Magento feature](#native-search)
-- [ElasticSearch - direct access](#elasticsearch) (using our ElasticSuite fork)
+- [Native search](#native-search)
+- [Elasticsearch](#elasticsearch)
+  - [Requirements](#requirements)
+  - [Front-Commerce configuration](#front-commerce-configuration)
 - [Algolia](#algolia)
+  - [Requirements](#requirements-1)
+  - [Front-Commerce configuration](#front-commerce-configuration-1)
 
 ## Native search
 


### PR DESCRIPTION
This PR goes over the main parts of the documentation mentioning OpenMage or Magento 1 to ensure we mention both as much as possible… and with the correct "branded name" for OpenMage: **OpenMage LTS** (see [suggestion from Colin Mollenhour](https://github.com/OpenMage/OpenMage.github.io/pull/110#pullrequestreview-1234819332))