### PR TITLE
Update release calendar with 2023 dates

### DIFF
--- a/docs/appendices/release-process.mdx
+++ b/docs/appendices/release-process.mdx
@@ -41,15 +41,10 @@ seamless as possible.
 
 ### When to expect a new release?
 
-At Front-Commerce, the team has been growing a lot! _(as part of
-[our fundraising](https://www.usine-digitale.fr/article/front-commerce-leve-1-5-million-d-euros-pour-sa-solution-d-optimisation-des-boutiques-en-ligne.N1163477)
-notably_ 👀*)*
-
-We are now able to implement a lot of new elements between two minor releases,
-**every 6 weeks** (new features, tech improvements, bug fixes ...)
+We release a minor version of Front-Commerce **every 6 weeks** with new features, tech improvements, bug fixes…
 
 In order to follow the pace of our users, we have decided to release 2
-intermediate pre-releases between 2 minor releases, to allow our early-adopters
+intermediate pre-releases between 2 minor releases, to allow early-adopters
 to integrate the features as soon as possible and to give us feedback.
 
 Therefore, here is the theoretical rhythm of a cycle (Front-Commerce is
@@ -57,35 +52,70 @@ currently in MAJOR version 2):
 
 ![Front-Commerce’s release pace and cycles](./assets/release-pace.jpg)
 
-### The 2022 release calendar
+### Our release calendar
 
-- **[2.12.0](/docs/appendices/release-notes#2-12-0-2022-01-06)**: 6 january
-- **[2.13.0](/docs/appendices/migration-guides#2-12-0-gt-2-13-0)**: 17 february
-- 2.14:
-  - 4 march: _2.14.0-beta.0_
-  - 18 march: _2.14.0-beta.1_
-  - **31 march: 2.14.0**
-- 2.15:
-  - 15 april: _2.15.0-beta.0_
-  - 29 april: _2.15.0-beta.1_
-  - **12 may: 2.15.0**
-- 2.16:
-  - 27 may: _2.16.0-beta.0_
-  - 10 june: _2.16.0-beta.1_
-  - **23 june: 2.16.0**
-- 2.17:
-  - 8 july: _2.17.0-beta.0_
-  - 22 july: _2.17.0-beta.1: 22-07-2022_
-  - **4 august: 2.17.0**
-- 2.18:
-  - 19 august: _2.18.0-beta.0_
-  - 2 september: _2.18.0-beta.1_
-  - **15 september: 2.18.0**
-- 2.19:
-  - 30 september: _2.19.0-beta.0_
-  - 14 october: _2.19.0-beta.1_
-  - **27 october: 2.19.0**
-- 2.20:
-  - 10 november: _2.20.0-beta.0_
-  - 25 november: _2.20.0-beta.1_
-  - **8 december: 2.20.0**
+
+```mdx-code-block
+<details open>
+  <summary><h3 className="mb-0">2023 releases</h3></summary>
+```
+- 2.21:
+  - 23 december (2022): _2.21.0-beta.0_
+  - 6 january: _2.21.0-beta.1_
+  - **19 january: 2.21.0**
+- 2.22:
+  - 3 february: _2.22.0-beta.0_
+  - 17 february: _2.22.0-beta.1_
+  - **2 march: 2.22.0**
+- 2.23:
+  - 17 march: _2.23.0-beta.0_
+  - 31 march: _2.23.0-beta.1_
+  - **13 april: 2.23.0**
+- 2.24:
+  - 28 april: _2.24.0-beta.0_
+  - 12 may: _2.24.0-beta.1_
+  - **25 may: 2.24.0**
+- 2.25:
+  - 9 june: _2.25.0-beta.0_
+  - 23 june: _2.25.0-beta.1_
+  - **6 july: 2.25.0**
+- 2.26:
+  - 21 july: _2.26.0-beta.0_
+  - 4 august: _2.26.0-beta.1_
+  - **17 august: 2.26.0**
+- 2.27:
+  - 1 september: _2.27.0-beta.0_
+  - 15 september: _2.27.0-beta.1_
+  - **28 september: 2.27.0**
+- 2.28:
+  - 13 october: _2.28.0-beta.0_
+  - 27 october: _2.28.0-beta.1_
+  - **9 november: 2.28.0**
+- 2.29:
+  - 24 november: _2.29.0-beta.0_
+  - 8 december: _2.29.0-beta.1_
+  - **21 december: 2.29.0**
+
+*Note: in order to follow Semantic Versioning, we'll very likely switch to a 3.x major version during the year. We'll update the versions accordingly and of course communicate as soon as we'll have more details.*
+
+```mdx-code-block
+</details>
+```
+
+```mdx-code-block
+<details>
+  <summary><h3 className="mb-0">2022 releases</h3></summary>
+```
+- **[2.12.0](/changelog/front-commerce-2.12)**: 6 january
+- **[2.13.0](/changelog/front-commerce-2.13)**: 17 february
+- **[2.14.0](/changelog/front-commerce-2.14)**: 31 march
+- **[2.15.0](/changelog/front-commerce-2.15)**: 12 may
+- **[2.16.0](/changelog/front-commerce-2.16)**: 23 june
+- **[2.17.0](/changelog/front-commerce-2.17)**: 4 august
+- **[2.18.0](/changelog/front-commerce-2.18)**: 15 september
+- **[2.19.0](/changelog/front-commerce-2.19)**: 27 october
+- **[2.20.0](/changelog/front-commerce-2.20)**: 8 december
+
+```mdx-code-block
+</details>
+```


### PR DESCRIPTION
This PR updates the release pace page by:

- rewording the introduction
- updating the 2022 releases with links to the changelog
- adding the 2023 calendar

It allows us to communicate date estimates to integrators or potential customers.

➡️ **[Preview](https://deploy-preview-568--heuristic-almeida-1a1f35.netlify.app/docs/appendices/release-process#when-to-expect-a-new-release)**