### PR TITLE
Document the new import to use when using a custom media proxy

### DIFF
--- a/docs/advanced/features/invoices.mdx
+++ b/docs/advanced/features/invoices.mdx
@@ -95,7 +95,7 @@ Here is an example of a custom router that proxy a Magento remote url with
 additional checks:
 
 ```js
-import proxy from "express-http-proxy";
+import proxy from "server/core/proxy";
 import config from "server/express/config";
 import withMagentoProxyHeaders from "server/express/withMagentoProxyHeaders";
 import makeProtectedProxyRouter from "server/core/makeProtectedProxyRouter";

--- a/docs/advanced/production-ready/media-middleware.mdx
+++ b/docs/advanced/production-ready/media-middleware.mdx
@@ -355,7 +355,7 @@ could be implemented:
 
 ```js
 import { Router } from "express";
-import proxy from "express-http-proxy";
+import proxy from "server/core/proxy";
 import makeImageProxyRouter from "server/core/image/makeImageProxyRouter";
 
 // this middleware will be mounted at the path provided in

--- a/docs/appendices/migration-guides/index.mdx
+++ b/docs/appendices/migration-guides/index.mdx
@@ -12,6 +12,21 @@ import ContactLink from "@site/src/components/ContactLink";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
+## `2.20.0` -> `2.21.0`
+
+### Media proxy updated to send a custom user agent
+
+If you have added a [custom media proxy endpoint](/docs/advanced/production-ready/media-middleware#add-your-own-media-proxy-endpoint) in your application, we recommend to update the code as follows:
+
+```diff
+- import proxy from "express-http-proxy";
++ import proxy from "server/core/proxy";
+```
+
+We detected an issue with some remote services that were blocking Front-Commerce due to firewall rules detecting a *weird behavior* caused by the media proxy: many requests from the same IP address with different `User-Agent` values was considered as a suspicious activity. It could ultimately lead to a blacklisting.
+
+This behavior [has been fixed](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/1776) in this version and backported to all support branches. Front-Commerce will now send a custom `User-Agent` value to the remote services: `Front-Commerce media proxy/<version>` (where `<version>` is the version of Front-Commerce). Please update your codebase as described above to ensure your code is compatible with this new behavior.
+
 ## `2.19.0` -> `2.20.0`
 
 ### Default shipping and billing address support


### PR DESCRIPTION
and add a section to the migration guide

This PR documents the change introduced [in this MR](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/1776)

:arrow_right: **[Preview](https://deploy-preview-569--heuristic-almeida-1a1f35.netlify.app/docs/appendices/migration-guides/#media-proxy-updated-to-send-a-custom-user-agent)**