### PR TITLE
feat: add CORS headers to allow RSS inclusion everywhere

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -1,0 +1,2 @@
+/*.xml
+  Access-Control-Allow-Origin: *


### PR DESCRIPTION
This PR allows our RSS feeds to be accessed by other websites client sides.

Example: https://developers.front-commerce.com/changelog/rss.xml