### PR TITLE
fix: properly state GA4 non support in legacy analytics module

### DIFF
--- a/docs/advanced/analytics/legacy.mdx
+++ b/docs/advanced/analytics/legacy.mdx
@@ -361,7 +361,9 @@ Here is a list of integrations frequently used across e-commerce shops
 
 ### Google Analytics 4
 
-Coming soon, <ContactLink /> for more details.
+Google Analytics 4 is not supported by the legacy analytics module. If you need
+Google Analytics 4, please use [the analytics module based on
+analytics](/docs/advanced/analytics/getting-started).
 
 ### Universal Analytics (Google Analytics)
 


### PR DESCRIPTION
Related a recent support request:
https://deploy-preview-573--heuristic-almeida-1a1f35.netlify.app/docs/advanced/analytics/legacy#google-analytics-4