### PR TITLE
feat: add an ESLint disable instruction when reusing component

### DIFF
--- a/docs/essentials/extend-the-theme.mdx
+++ b/docs/essentials/extend-the-theme.mdx
@@ -158,6 +158,8 @@ original source file you could set it up like this:
 
 ```jsx title="my-module/web/theme/modules/ProductView/ProductItem/ProductItem.js"
 import React from "react";
+
+// eslint-disable-next-line no-restricted-imports (ESLint rule added in 2.19.0)
 import BaseProductItem from "front-commerce/src/web/theme/modules/ProductView/ProductItem/ProductItem.js";
 
 const ProductItem = (props) => (


### PR DESCRIPTION
This PR ensures that the example showing how to reuse an existing component from FC in an override works.

In 2.19.0, we've introduced [a new ESLint rule](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/1495) to warn in case the editor imports a component with FC core shortcut.\
Indeed, in this case we prefer developers to manually fix the import (to use `theme/xxx`) which is the most common case.

If developers really want to reuse FC component, they'll add an ESLint disable rule to express that they know what they're doing!

- [Preview](https://deploy-preview-593--heuristic-almeida-1a1f35.netlify.app/docs/essentials/extend-the-theme#reuse-the-original-component)