### PR TITLE
fix(buybox): define a clean title to BuyBox page

### DIFF
--- a/docs/advanced/payments/buybox.mdx
+++ b/docs/advanced/payments/buybox.mdx
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+title: BuyBox integration
 description:
   This guide explains how Front-Commerce allows using BuyBox in a headless
   commerce project.


### PR DESCRIPTION
This PR adds a consistent title to [the BuyBox page](https://developers.front-commerce.com/docs/advanced/payments/buybox).

It seems it was never defined!

## Screenshot

Before/After

![2023-03-02_16-54](https://user-images.githubusercontent.com/75968/222481221-9cfc317c-cbd9-4f13-a04f-33141822c03d.png)
