### PR TITLE
fix: broken image in 2.6 post

### DIFF
--- a/changelog/front-commerce-2.6.mdx
+++ b/changelog/front-commerce-2.6.mdx
@@ -29,8 +29,9 @@ fully) pay for their order**. They can view their credits history and the
 current balance from their account dashboard.
 
 <div className="center">
-  ![The Store Credits recap page in the Customer
-  area](./assets/2.6-store-credits.png)
+
+![The Store Credits recap page in the Customer area](./assets/2.6-store-credits.png)
+
 </div>
 
 While the UI is platform agnostic, we implemented the supporting server


### PR DESCRIPTION
https://developers.front-commerce.com/changelog/front-commerce-2.6/#new-feature-store-credits

vs.

https://deploy-preview-603--heuristic-almeida-1a1f35.netlify.app/changelog/front-commerce-2.6#new-feature-store-credits