### PR TITLE
fix(attraqt): remove double return keyword

### DIFF
--- a/docs/magento2/search-engine.mdx
+++ b/docs/magento2/search-engine.mdx
@@ -459,8 +459,8 @@ export default {
   	products: async (recommendation, _, { loaders }) => {
       // Note: the shape of recommendation.recommendations will vary
       // depending on your data indexed in Attraqt. Adapt this example to your use case.
-  		const skus = recommendation.recommendations.map(({ id }) => id).filter(Boolean);
-      return return loaders.Product.loadBySkus(skus);
+      const skus = recommendation.recommendations.map(({ id }) => id).filter(Boolean);
+      return loaders.Product.loadBySkus(skus);
   	},
   },
 };


### PR DESCRIPTION
… and reindented the code block properly.

[Before](https://developers.front-commerce.com/docs/magento2/search-engine#using-attraqt-orchestrator-chrome-extension) / [After](https://deploy-preview-606--heuristic-almeida-1a1f35.netlify.app/docs/magento2/search-engine#using-attraqt-orchestrator-chrome-extension)

![2023-03-09_16-21](https://user-images.githubusercontent.com/75968/224070070-8a1d64a5-ac17-44fd-b987-e9772779e950.png)
