### PR TITLE
feat(migration): add M2 Commerce module minimal requirements to the migration guide

### DIFF
--- a/docs/appendices/migration-guides/index.mdx
+++ b/docs/appendices/migration-guides/index.mdx
@@ -12,6 +12,16 @@ import ContactLink from "@site/src/components/ContactLink";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
+## `2.22.0` -> `2.23.0`
+
+### Adobe Commerce RMA
+
+This version contains improvements to RMA functionality. When updating your project, you must also update the [Magento2 Commerce - Module Front Commerce to version `2.1.0+`](https://gitlab.blackswift.cloud/front-commerce/magento2-commerce-module-front-commerce/-/releases/2.1.0)
+
+```shell
+composer require front-commerce/magento2-commerce-module@2.1.0
+```
+
 ## `2.21.0` -> `2.22.0`
 
 ### Fix sort params in `QueryHelper`'s `getFacetsParams`


### PR DESCRIPTION
Because it is needed to honor GraphQL queries now made by FC in 2.23.

- [**Preview**](https://deploy-preview-607--heuristic-almeida-1a1f35.netlify.app/docs/appendices/migration-guides/#2220---2230)