### PR TITLE
feat: add blog comments with giscus

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@docusaurus/plugin-google-gtag": "2.2.0",
     "@docusaurus/plugin-ideal-image": "2.2.0",
     "@docusaurus/preset-classic": "2.2.0",
+    "@giscus/react": "^2.2.8",
     "@heroicons/react": "2.0.13",
     "@mdx-js/react": "1.6.22",
     "autoprefixer": "10.4.13",

--- a/src/theme/BlogPostItem/Footer/index.tsx
+++ b/src/theme/BlogPostItem/Footer/index.tsx
@@ -1,0 +1,70 @@
+import { useColorMode } from "@docusaurus/theme-common";
+import { useBlogPost } from "@docusaurus/theme-common/internal";
+import Giscus from "@giscus/react";
+import ReadMoreLink from "@theme/BlogPostItem/Footer/ReadMoreLink";
+import EditThisPage from "@theme/EditThisPage";
+import TagsListInline from "@theme/TagsListInline";
+import clsx from "clsx";
+import React from "react";
+import styles from "./styles.module.css";
+
+export default function BlogPostItemFooter() {
+  const { colorMode } = useColorMode();
+  const { metadata, isBlogPostPage } = useBlogPost();
+  const { tags, title, editUrl, hasTruncateMarker } = metadata;
+  // A post is truncated if it's in the "list view" and it has a truncate marker
+  const truncatedPost = !isBlogPostPage && hasTruncateMarker;
+  const tagsExists = tags.length > 0;
+  const renderFooter = tagsExists || truncatedPost || editUrl;
+  if (!renderFooter) {
+    return null;
+  }
+  return (
+    <footer
+      className={clsx(
+        "row docusaurus-mt-lg",
+        isBlogPostPage && styles.blogPostFooterDetailsFull
+      )}
+    >
+      {isBlogPostPage && (
+        <Giscus
+          id="comments"
+          repo="front-commerce/developers.front-commerce.com"
+          repoId="MDEwOlJlcG9zaXRvcnkxMjUwNDY0NjE="
+          category="Comments"
+          categoryId="DIC_kwDOB3QOvc4CUxxg"
+          mapping="title"
+          term="Comments"
+          reactionsEnabled="1"
+          emitMetadata="0"
+          inputPosition="top"
+          theme={colorMode}
+          lang="en"
+          loading="lazy"
+        />
+      )}
+
+      {tagsExists && (
+        <div className={clsx("col", { "col--9": truncatedPost })}>
+          <TagsListInline tags={tags} />
+        </div>
+      )}
+
+      {isBlogPostPage && editUrl && (
+        <div className="col margin-top--sm">
+          <EditThisPage editUrl={editUrl} />
+        </div>
+      )}
+
+      {truncatedPost && (
+        <div
+          className={clsx("col text--right", {
+            "col--3": tagsExists,
+          })}
+        >
+          <ReadMoreLink blogPostTitle={title} to={metadata.permalink} />
+        </div>
+      )}
+    </footer>
+  );
+}

--- a/src/theme/BlogPostItem/Footer/styles.module.css
+++ b/src/theme/BlogPostItem/Footer/styles.module.css
@@ -1,0 +1,3 @@
+.blogPostFooterDetailsFull {
+  flex-direction: column;
+}


### PR DESCRIPTION
### Why?
This allows us to communicate with the readers on comments/questions they might have in the blog post.

### What?
It adds this comments section at the bottom which is driven through the GitHub Discissions api

### Example
https://deploy-preview-608--heuristic-almeida-1a1f35.netlify.app/blog/wsl-development-environment#conclusion

![image](https://user-images.githubusercontent.com/39598117/224299518-674399a3-7100-49bd-af4d-39b0ba026831.png)

