### PR TITLE
Links to source code

### DIFF
--- a/changelog/front-commerce-2.9.mdx
+++ b/changelog/front-commerce-2.9.mdx
@@ -96,7 +96,7 @@ More details on the
   (Chocolatine theme)
 - added JSDoc type checking as part of our CI pipeline. To know more about our
   typing strategy, please read
-  [the related <abbr title="Architecture Decision Record">ADR</abbr> (customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/docs/adr/0003-jsdoc-typing.md)
+  [the related <abbr title="Architecture Decision Record">ADR</abbr> (customers only)](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2.9.x/docs/adr/0003-jsdoc-typing.md)
 
 <hr />
 

--- a/docs/advanced/analytics/getting-started.mdx
+++ b/docs/advanced/analytics/getting-started.mdx
@@ -47,7 +47,7 @@ within a Front-Commerce app.
 :::
 
 First you will need to configure your analytics by updating the
-[configuration file](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/config/analytics.sample.js):
+[configuration file](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2.x/src/config/analytics.sample.js):
 
 ```js title="src/config/analytics.js"
 module.exports = {

--- a/docs/advanced/analytics/plugins.mdx
+++ b/docs/advanced/analytics/plugins.mdx
@@ -104,7 +104,7 @@ you to create an interface to map
 [e-commerce events and properties](https://developers.google.com/analytics/devguides/collection/ga4/ecommerce)
 to the relevant events and properties for your `acme` provider, you can find a
 full list of events in the
-[EcommercePlugin.js](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/core/analytics/plugins/e-commerce/domain/e-commerce-plugin.js)
+[EcommercePlugin.js](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/core/analytics/plugins/e-commerce/domain/e-commerce-plugin.js)
 
 Below is an example of how to extend the `acme` plugin to handle e-commerce
 events.
@@ -168,7 +168,7 @@ export default function providerPluginExample(settings) {
 :::info
 
 We handle this internally for
-[known plugins](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/core/analytics/plugins/e-commerce/e-commerce.js#L6-11)
+[known plugins](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/core/analytics/plugins/e-commerce/e-commerce.js#L6-11)
 like the [`google-analytics`](https://getanalytics.io/plugins/google-analytics/)
 plugin.
 

--- a/docs/advanced/features/display-a-map.mdx
+++ b/docs/advanced/features/display-a-map.mdx
@@ -30,19 +30,19 @@ consistent across different components.
 
 | Property        | Description                              | Type                                                                                                                                                          |
 | --------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| locations       | A list of locations used for the markers | [`LocationInputShape[]`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/components/organisms/Map/location.js#L65-74) |
+| locations       | A list of locations used for the markers | [`LocationInputShape[]`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/components/organisms/Map/location.js#L65-74) |
 | getMarker       | The marker node for locations            | `(location) => ReactNode`                                                                                                                                     |
 | zoom            | Default zoom level                       | `number`                                                                                                                                                      |
-| defaultBounds   | The default map bounds                   | [`CoordinatesShape[]`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/components/organisms/Map/location.js#L59-62)   |
-| defaultCenter   | The default center for the map.          | [`CoordinatesShape` ](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/components/organisms/Map/location.js#L59-62)    |
+| defaultBounds   | The default map bounds                   | [`CoordinatesShape[]`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/components/organisms/Map/location.js#L59-62) |
+| defaultCenter   | The default center for the map.          | [`CoordinatesShape` ](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/components/organisms/Map/location.js#L59-62) |
 | onBoundsChanged | Event handler for bound changes          | `(event) => void`                                                                                                                                             |
 
 #### Marker Component
 
 | Property      | Description                            | Type                                                                                                                                                         |
 | ------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| location      | Location for the marker                | [`LocationInputShape` ](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/components/organisms/Map/location.js#L65-74) |
-| icon          | Allows you to override the marker icon | [`object`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/components/organisms/Map/index.js#L25-31)                 |
+| location      | Location for the marker                | [`LocationInputShape` ](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/components/organisms/Map/location.js#L65-74) |
+| icon          | Allows you to override the marker icon | [`object`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/components/organisms/Map/index.js#L25-31) |
 | isPopupOpened | Controlled method for marker popup     | `boolean`                                                                                                                                                    |
 | onClick       | Event handler on marker click          | `(event) => void`                                                                                                                                            |
 
@@ -95,7 +95,7 @@ consistent across different components.
 Once that has been added you can restart your application, that should be it. 🎉
 
 You should be able to use the Map component. See
-[Map.story.js](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/modules/map-leaflet/web/theme/components/organisms/Map/Map.story.js)
+[Map.story.js](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/map-leaflet/web/theme/components/organisms/Map/Map.story.js)
 for details. _Please keep in mind, that the Map component should be used in an
 element with a fixed height._
 
@@ -177,7 +177,7 @@ If you don't, you can create one by following
 Once that has been added you can restart your application, that should be it. 🎉
 
 You should be able to use the Map component. See
-[Map.story.js](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/modules/map-googlemap/web/theme/components/organisms/Map/Map.story.js)
+[Map.story.js](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/map-googlemap/web/theme/components/organisms/Map/Map.story.js)
 for details.
 
 :::note

--- a/docs/advanced/features/feature-flags.mdx
+++ b/docs/advanced/features/feature-flags.mdx
@@ -9,12 +9,12 @@ features.
 ## Enabling or Disabling a feature
 
 Feature flags are resolved by the
-[FeatureFlagLoader](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/front-commerce/core/loaders.js#L7)
+[FeatureFlagLoader](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/server/modules/front-commerce/core/loaders.js)
 which is typically overridden in the
 [`contextEnhancer`](/docs/reference/graphql-module-definition#contextenhancer-optional)
 of each module supporting a feature flag (e.g.
-[wishlist](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/magento2/wishlist/index.js#L21),
-[search](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/front-commerce/search/index.js#L41)).
+[wishlist](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/server/modules/magento2/wishlist/index.js#L19),
+[search](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/server/modules/front-commerce/search/index.js#L41)).
 
 To enable or disable a feature one must update the overridden `FeatureFlag`
 loader in the `contexEnhancer` of the module and ensure `isActive` returns

--- a/docs/advanced/features/feature-flags.mdx
+++ b/docs/advanced/features/feature-flags.mdx
@@ -10,7 +10,7 @@ features.
 
 Feature flags are resolved by the
 [FeatureFlagLoader](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/front-commerce/core/loaders.js#L7)
-which is typically overrided in the
+which is typically overridden in the
 [`contextEnhancer`](/docs/reference/graphql-module-definition#contextenhancer-optional)
 of each module supporting a feature flag (e.g.
 [wishlist](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/magento2/wishlist/index.js#L21),

--- a/docs/advanced/features/smart-forms.mdx
+++ b/docs/advanced/features/smart-forms.mdx
@@ -368,7 +368,7 @@ const MyAwesomeForm = ({ email }) => {
 
 With this code, when the user submits the form, the hook will call the GraphQL
 API to validate the email. The GraphQL email validation API is designed
-[to return different validation statuses](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/front-commerce/smart-forms/schema.gql#L22)
+[to return different validation statuses](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/server/modules/front-commerce/smart-forms/schema.gql#L22)
 (not only valid/invalid) and by default, the `onSubmit` handler returned by
 `useEmailServerValidation` has the following behaviour:
 
@@ -444,7 +444,7 @@ context object that contains the following properties:
 - `formModel`: an object with the value of fields in the form
 - `emailField`: the name of the email field passed to `useEmailServerValidation`
 - `validationResult`:
-  [the validation result](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/front-commerce/smart-forms/schema.gql#L29)
+  [the validation result](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/server/modules/front-commerce/smart-forms/schema.gql#L29)
   returned by the server
 - `updateInputsWithError`: a function to
   [update a field with an error message](https://github.com/formsy/formsy-react/blob/master/API.md#updateInputsWithError)

--- a/docs/advanced/graphql/change-resolver-behavior.mdx
+++ b/docs/advanced/graphql/change-resolver-behavior.mdx
@@ -31,7 +31,7 @@ export default {
 Before being able to inject you custom resolver logic, you first need to find
 the module that defines the resolver for the field. In our example, the Product
 `meta_description` is resolved
-[by the resolver provided by the `Magento2/Catalog/Products` module](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/magento2/catalog/products/resolvers.js#L245-248).
+[by the resolver provided by the `Magento2/Catalog/Products` module](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/server/modules/magento2/catalog/products/resolvers.js#L267-270).
 As a result, the `Magento2/Catalog/Products` module must be added as a
 dependency of our custom module:
 

--- a/docs/advanced/graphql/dataloaders-and-cache-invalidation.mdx
+++ b/docs/advanced/graphql/dataloaders-and-cache-invalidation.mdx
@@ -318,7 +318,7 @@ Writing batching functions and loaders could lead to reusing the same patterns.
 We have extracted some utility functions to help you in this task.
 
 You can find them in the
-[`server/core/graphql/dataloaderHelpers`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/server/core/graphql/dataloaderHelpers.js)
+[`server/core/graphql/dataloaderHelpers`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/server/core/graphql/dataloaderHelpers.js)
 module.
 
 ### `reorderForIds`

--- a/docs/advanced/production-ready/checklist-before-production.mdx
+++ b/docs/advanced/production-ready/checklist-before-production.mdx
@@ -81,7 +81,7 @@ detect whether it's a Progressive Web Application. See
 :::info
 
 It instructs bots what they can access. By default,
-[it forbids crawling to prevent unexpectedly exposing dev applications](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/public/robots.txt).
+[it forbids crawling to prevent unexpectedly exposing dev applications](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/public/robots.txt).
 
 :::
 

--- a/docs/advanced/production-ready/media-middleware.mdx
+++ b/docs/advanced/production-ready/media-middleware.mdx
@@ -458,7 +458,7 @@ This pattern will be matched against the file full URL without the query string
 
 Setting `FRONT_COMMERCE_BACKEND_IGNORE_CACHE_REGEX` will set the
 `ignoreCacheRegex` config of the
-[`expressConfigProvider`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/cf83e8bac722295403cc89c66fa39758eeaa25c6/src/server/express/config/expressConfigProvider.js#L53).
+[`expressConfigProvider`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/server/express/config/expressConfigProvider.js#L49).
 Consequently it will be available on
 `staticConfigFromProviders.express.ignoreCacheRegex` should you ever need it.
 
@@ -475,7 +475,7 @@ In case you want to prevent caching build time compiled files, you can set the
 `FRONT_COMMERCE_BACKEND_IGNORE_BUILD_CACHE_REGEX` variable instead.
 
 This will set the `ignoreBuildCacheRegex` config of the
-[`expressConfigProvider`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/express/config/expressConfigProvider.js#L55).
+[`expressConfigProvider`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/server/express/config/expressConfigProvider.js#L55).
 Consequently it will be available on
 `staticConfigFromProviders.express.ignoreBuildCacheRegex` should you ever need
 it.

--- a/docs/advanced/server/add-http-endpoint.mdx
+++ b/docs/advanced/server/add-http-endpoint.mdx
@@ -51,7 +51,7 @@ information.
 In the case of the WYSIWYG preview, let's say that when a user visits the
 `wysiwyg-preview` URL, we want to display static files that will let anyone
 preview how an html string will be transformed by
-[Front-Commerce's Wysiwyg component](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tree/main/src/web/theme/modules/Wysiwyg).
+[Front-Commerce's Wysiwyg component](/docs/advanced/theme/wysiwyg/).
 
 To do so, we need to create our server config file, and configure its
 `entrypoint` key.

--- a/docs/advanced/server/customize-response-http-headers.mdx
+++ b/docs/advanced/server/customize-response-http-headers.mdx
@@ -55,7 +55,7 @@ from origin 'https://other.example.org' has been blocked by CORS policy: No
 
 **In Front-Commerce, the content of this header can be controlled by customizing
 the `cors.origin` configuration** from the
-[`corsConfigProvider`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/express/withGlobalHeaders.js#L13).
+[`corsConfigProvider`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/server/express/withGlobalHeaders.js#L10).
 
 You must do it from a custom configuration provider. See the
 [Register a configuration provider](/docs/advanced/server/configurations#register-a-configuration-provider)

--- a/docs/advanced/shipping/chronorelais.mdx
+++ b/docs/advanced/shipping/chronorelais.mdx
@@ -71,7 +71,7 @@ Then, within your Front-Commerce project, you have to:
   ```
 
 - Import `ChronoRelais` component in by overriding the
-  [`getAdditionalDataComponent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js)
+  [`getAdditionalDataComponent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js)
   used for Shipping methods
 
   ```jsx title='src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js'

--- a/docs/advanced/shipping/colissimo.mdx
+++ b/docs/advanced/shipping/colissimo.mdx
@@ -63,7 +63,7 @@ module.exports = {
 ```
 
 - Import Colissimo component in by overriding the
-  [`getAdditionalDataComponent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js)
+  [`getAdditionalDataComponent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js)
   used for Shipping methods
 
 ```diff title="src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js"

--- a/docs/advanced/shipping/custom-shipping-information.mdx
+++ b/docs/advanced/shipping/custom-shipping-information.mdx
@@ -48,7 +48,7 @@ GraphQL query should return your method's codes.
 Once you've done this request, you will be able to get the `carrier_code` and
 the `method_code` of your shipping method. You should use those to register a
 new component by overriding the
-[`getAdditionalDataComponent.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js)
+[`getAdditionalDataComponent.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js)
 by following this template:
 
 ```js title="theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js"
@@ -115,9 +115,9 @@ export default CustomMethod;
 
 You can reference one of our implementations to get you started
 
-- [`<ModialRelay />`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/modules/shipping-mondialrelay/web/theme/modules/MondialRelay/MondialRelay.js)
-- [`<Colissimo />`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/modules/shipping-colissimo-magento2/web/theme/modules/Colissimo/Colissimo.js)
-- [`<ChronoRelais />`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/modules/shipping-chronorelais/web/theme/modules/ChronoRelais/ChronoRelais.js)
+- [`<ModialRelay />`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/shipping-mondialrelay/web/theme/modules/MondialRelay/MondialRelay.js)
+- [`<Colissimo />`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/shipping-colissimo-magento2/web/theme/modules/Colissimo/Colissimo.js)
+- [`<ChronoRelais />`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/shipping-chronorelais/web/theme/modules/ChronoRelais/ChronoRelais.js)
 
 :::
 

--- a/docs/advanced/shipping/mondial-relay.mdx
+++ b/docs/advanced/shipping/mondial-relay.mdx
@@ -64,7 +64,7 @@ Then, within your Front-Commerce project, you have to:
   ```
 
 - Import MondialRelay component in by overriding the
-  [`getAdditionalDataComponent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js)
+  [`getAdditionalDataComponent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js)
   used for Shipping methods
 
   ```diff title='src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js'
@@ -122,7 +122,7 @@ Then, within your Front-Commerce project, you have to:
   ```
 
 - Import MondialRelay component in by overriding the
-  [`getAdditionalDataComponent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js)
+  [`getAdditionalDataComponent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js)
   used for Shipping methods
 
   ```diff title="src/web/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js"

--- a/docs/advanced/theme/form.mdx
+++ b/docs/advanced/theme/form.mdx
@@ -332,7 +332,7 @@ and transformed into either a datepicker or multiple input fields without
 impacting the external API.
 
 You can look at
-[`node_modules/front-commerce/src/web/theme/components/atoms/Form/Input/Checkbox/Checkbox.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/components/atoms/Form/Input/Checkbox/Checkbox.js)
+[`node_modules/front-commerce/src/web/theme/components/atoms/Form/Input/Checkbox/Checkbox.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/components/atoms/Form/Input/Checkbox/Checkbox.js)
 to better understand how the form input api works.
 
 ### Use another form library than Formsy

--- a/docs/advanced/theme/server-side-rendering.mdx
+++ b/docs/advanced/theme/server-side-rendering.mdx
@@ -177,7 +177,7 @@ key with the following information that you can use to if needed:
 ```
 
 If you want to tweak this behavior, we invite you to browse the
-[`deviceConfigProvider`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/express/ssr/deviceConfigProvider.js)
+[`deviceConfigProvider`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/server/express/ssr/deviceConfigProvider.js)
 for implementation details and <ContactLink /> if you think of any improvements.
 
 ## SSR Fallback when things go wrong

--- a/docs/advanced/theme/translations.mdx
+++ b/docs/advanced/theme/translations.mdx
@@ -66,7 +66,7 @@ import { FormattedNumber } from "react-intl";
 
 However, for this particular use case we have abstracted this in Front-Commerce
 with the
-[`theme/components/atoms/Price`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tree/main/src/web/theme/components/atoms/Typography/Price)
+[`theme/components/atoms/Price`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/components/atoms/Typography/Price/index.js)
 component (and its variants: `ProductPrice`, `PriceOrFree`). We recommend you to
 use it instead, so you could benefit from better integration with its related
 GraphQL Type.

--- a/docs/advanced/theme/wysiwyg/README.mdx
+++ b/docs/advanced/theme/wysiwyg/README.mdx
@@ -53,9 +53,9 @@ export default (props) => <WysiwygV2 content={props.cms.contentWysiwyg} />;
 
 The `contentWysiwyg` property must come from a GraphQL field of type `Wysiwyg`,
 you should add the `WysiwygFragment` available at
-[`theme/modules/WysiwygV2/WysiwygFragment.gql`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/theme/modules/WysiwygV2/WysiwygFragment.gql),
+[`theme/modules/WysiwygV2/WysiwygFragment.gql`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/modules/WysiwygV2/WysiwygFragment.gql),
 to the `CmsPageFragment` available at
-[`theme/pages/CmsPage/CmsPageFragment.gql`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/theme/pages/CmsPage/CmsPageFragment.gql).
+[`theme/pages/CmsPage/CmsPageFragment.gql`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/pages/CmsPage/CmsPageFragment.gql).
 
 ```diff title="my-module/modules/CmsPage/CmsPageFragment.gql"
 #import "theme/modules/CmsPage/CmsPageSeo/CmsPageSeoFragment.gql"
@@ -182,12 +182,10 @@ If you want to customize `MagentoWysiwyg` instead, please refer to
     };
     ```
 
-#### Map this new type to a specific React component that will apply the needed
-
-transformations before displaying the content
+#### Map this new type to a specific React component that will apply the needed transformations before displaying the content
 
 1.  Duplicate the
-    [`DefaultWysiwyg.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/WysiwygV2/DefaultWysiwyg.js)
+    [`DefaultWysiwyg.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/modules/WysiwygV2/DefaultWysiwyg.js)
     component to `theme/modules/WysiwygV2/CustomWysiwyg`.
 1.  Override `theme/modules/WysiwygV2/appWysiwygComponents.js` and map your new
     `CustomWysiwyg` typename (the one used in your GraphQL schema) to

--- a/docs/appendices/migration-guides/archives.mdx
+++ b/docs/appendices/migration-guides/archives.mdx
@@ -582,7 +582,7 @@ to illustrate this.
 ### Updated dependencies
 
 In this release we have updated
-[several dependencies](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commits/main/package.json).
+[several dependencies](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commits/2.6.x/package.json).
 For most of them, the upgrade will be transparent. However, the following
 dependency updates require some attention though:
 

--- a/docs/appendices/migration-guides/index.mdx
+++ b/docs/appendices/migration-guides/index.mdx
@@ -69,7 +69,7 @@ code is compatible with this new behavior.
 
 In this release, we updated how the `"Use as default billing address"` and
 `"Use as default shipping address"` checkboxes are displayed in the
-[`AddressForm`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/User/Address/AddressForm/AddressForm.js)
+[`AddressForm`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2.20.x/src/web/theme/modules/User/Address/AddressForm/AddressForm.js)
 component. It now can be controlled globally using a configuration in the
 [`src/config/website.js`](/docs/reference/configurations#configwebsitejs)
 configuration file.
@@ -149,10 +149,10 @@ module.exports = {
 
 We have improved the way you can add custom icons to your theme. Before you had
 to override the
-[`theme/components/atoms/Icon/Icon.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/components/atoms/Icon/Icon.js)
+[`theme/components/atoms/Icon/Icon.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2.20.x/src/web/theme/components/atoms/Icon/Icon.js)
 file to add your custom icons. Now you can simply extend or override the core
 icons with your custom icons by adding them to the
-[`theme/components/atoms/Icon/icons/app-icons.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/components/atoms/Icon/icons/app-icons.js)
+[`theme/components/atoms/Icon/icons/app-icons.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2.20.x/src/web/theme/components/atoms/Icon/icons/app-icons.js)
 file.
 
 ```js title="theme/components/atoms/Icon/icons/app-icons.js"
@@ -265,7 +265,7 @@ We have tagged the last version of the Prismic module in the
 `v1` 🥳
 
 Since this version we have moved the Prismic module
-[into the core repository](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic)
+[into the core repository](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/2.18.x/modules/prismic)
 of Front-Commerce, moving forward any new features will be made available and
 follow the same
 [semantic versioning](/docs/appendices/release-process#semantic-versioning) as
@@ -465,7 +465,7 @@ const EnhancePlaceOrder = ({
 The DomainEvent class was reworked.
 
 If you handled payment events on orders (backend operation) using
-[DomainEvent implementations](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/src/server/modules/front-commerce/payment/domain/events),
+[DomainEvent implementations](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/2.17.x/src/server/modules/front-commerce/payment/domain/events),
 these implementations now base on a `PurchaseIdentifier` instead of a direct
 `orderId` (this allows to update order events based on a cartId)
 
@@ -1084,7 +1084,7 @@ const isCompanyUser = (user) => {
   - Support for [trailing slashes](/docs/prismic/routable-types#trailing-slash)
   - Support for [path rewrites](/docs/prismic/routable-types#path-rewrites)
   - Exposed the `url` to the
-    [Content type](https://gitlab.blackswift.cloud/front-commerce/front-commerce-prismic/-/blob/main/prismic/server/modules/prismic/core/loaders/Content.js)
+    [Content type](https://gitlab.blackswift.cloud/front-commerce/front-commerce-prismic/-/blob/2.14.x/prismic/server/modules/prismic/core/loaders/Content.js)
 
 :::note
 
@@ -1093,7 +1093,7 @@ When a Prismic document has been registered using the
 method or the
 [`registerPrismicRoute`](/docs/prismic/routable-types#registerprismicroute-options)
 method, A `url` property is exposed in the
-[Content type object](https://gitlab.blackswift.cloud/front-commerce/front-commerce-prismic/-/blob/main/prismic/server/modules/prismic/core/loaders/Content.js).
+[Content type object](https://gitlab.blackswift.cloud/front-commerce/front-commerce-prismic/-/blob/2.14.x/prismic/server/modules/prismic/core/loaders/Content.js).
 This property contains the resolved url of the document.
 
 :::
@@ -1992,7 +1992,7 @@ to
 ### New icons required
 
 In this release, two new icons (`warn` and `users`) were added to
-[the `<Icon>` component](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/components/atoms/Icon/Icon.js).
+[the `<Icon>` component](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2.11.x/src/web/theme/components/atoms/Icon/Icon.js).
 
 If you have overridden the `<Icon>` component, you need to add both icons as
 follows to the list of icons to avoid any error messages at page loading:
@@ -2066,7 +2066,7 @@ new components to the
 [default `MagentoWysiwyg` transforms](/docs/advanced/theme/wysiwyg-platform#magentowysiwyg).
 
 See
-[the Page Builder ones](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/WysiwygV2/MagentoWysiwyg/PageBuilder/index.js)
+[the Page Builder ones](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2.11.x/src/web/theme/modules/WysiwygV2/MagentoWysiwyg/PageBuilder/index.js)
 and ensure there is no collision with your custom WYSIWYG components. While very
 unlikely, it could be possible. For instance, if you may have overridden the
 `theme/modules/WysiwygV2/MagentoWysiwyg/MagentoWysiwyg.js` to add a custom

--- a/docs/essentials/adapt-theme-to-your-brand.mdx
+++ b/docs/essentials/adapt-theme-to-your-brand.mdx
@@ -47,7 +47,7 @@ theme.
 
 Since we use the Atomic Design principles, the tokens are within atoms of our
 base theme. From your application, you will find the base theme in the
-[`node_modules/front-commerce/src/web/`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tree/main/src/web)
+[`node_modules/front-commerce/src/web/`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tree/2.x/src/web)
 directory and atoms under its `theme/components/atoms` subdirectory.
 
 In this guide, we'll focus on the colors and the typography settings. But feel
@@ -152,7 +152,7 @@ Follow the same steps than for colors:
 ### Icons
 
 To introduce new icons or
-[override existing](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/components/atoms/Icon/icons/core-icons.js)
+[override existing](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/components/atoms/Icon/icons/core-icons.js)
 icons you can add an `app-icons` file including your icons, for example:
 
 ```js title="theme/components/atoms/Icon/icons/app-icons.js"

--- a/docs/essentials/add-component-to-storybook.mdx
+++ b/docs/essentials/add-component-to-storybook.mdx
@@ -143,7 +143,7 @@ add a new type of button: `tertiary`.
 To add this story, you will need to override the `Button.story.js` in the same
 way you overrode the `Button.js`. This means that you should copy the existing
 story from
-[`node_modules/front-commerce/src/web/theme/components/atoms/Button/Button.story.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/theme/components/atoms/Button/Button.story.js)
+[`node_modules/front-commerce/src/web/theme/components/atoms/Button/Button.story.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/components/atoms/Button/Button.story.js)
 to `my-module/web/theme/components/atoms/Button/Button.story.js`.
 
 Once you have copied the file, you need to restart the Storybook with
@@ -174,17 +174,15 @@ issues and have created helpers that should make your life easier when
 documenting those complex components.
 
 These helpers are located in
-[`node_modules/front-commerce/src/web/storybook/addons`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tree/main/src/web/storybook/addons)
+[`node_modules/front-commerce/src/web/storybook/addons`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tree/2.x/src/web/storybook/addons)
 and you can import them by using the alias `web/storybook/addons/...`. For now,
 we have four of them:
 
-- [`web/storybook/addons/apollo/ApolloDecorator`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/storybook/addons/apollo/ApolloDecorator.js):
+- [`web/storybook/addons/apollo/ApolloDecorator`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/storybook/addons/apollo/ApolloDecorator.js):
   mocks the data fetched by your components
-- [`web/storybook/addons/form/formDecorator`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/storybook/addons/form/formDecorator.js):
-  mocks a Form surounding the input component you are documenting
-- [`web/storybook/addons/intl/IntlDecorator`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/storybook/addons/intl/IntlDecorator.js):
-  allows you to switch between the languages of your shop
-- [`web/storybook/addons/router/routerDecorator`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/storybook/addons/router/routerDecorator.js):
+- [`web/storybook/addons/form/formDecorator`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/storybook/addons/form/formDecorator.js):
+  mocks a Form surrounding the input component you are documenting
+- [`web/storybook/addons/router/routerDecorator`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/storybook/addons/router/routerDecorator.js):
   mocks the routing and the URLs of your application
 
 <!-- TODO document usage of each of these helpers -->

--- a/docs/essentials/create-a-business-component.mdx
+++ b/docs/essentials/create-a-business-component.mdx
@@ -103,7 +103,7 @@ Before starting to edit the Home page, you first need to extend the theme. If
 you don't have a module yet, please refer to
 [Extend the theme](./extend-the-theme#configure-your-custom-theme-and-use-it-in-your-application).
 Once you have one, the goal will be to override the Home component from
-[`node_modules/front-commerce/src/web/theme/pages/Home/Home.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/theme/pages/Home/Home.js)
+[`node_modules/front-commerce/src/web/theme/pages/Home/Home.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/pages/Home/Home.js)
 to `my-module/web/theme/pages/Home/Home.js`.
 
 :::warning

--- a/docs/essentials/create-a-ui-component.mdx
+++ b/docs/essentials/create-a-ui-component.mdx
@@ -31,7 +31,7 @@ your stories later, feel free to leave the parts mentioning Storybook later.
 
 Front-Commerce’s core UI components follow the same principles and you could
 dive into the
-[`node_modules/front-commerce/src/web/theme/components`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tree/main/src/web/theme/components)
+[`node_modules/front-commerce/src/web/theme/components`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tree/2.x/src/web/theme/components)
 folder to find examples into our source code.
 
 But first, let's define what is an ideal UI Component.

--- a/docs/essentials/extend-the-theme.mdx
+++ b/docs/essentials/extend-the-theme.mdx
@@ -83,7 +83,7 @@ Let's add the description of a `Product` to a `ProductItem` as an example of
 overriding the base theme.
 
 The original file is:
-[`node_modules/front-commerce/src/web/theme/modules/ProductView/ProductItem/ProductItem.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/theme/modules/ProductView/ProductItem/ProductItem.js)
+[`node_modules/front-commerce/src/web/theme/modules/ProductView/ProductItem/ProductItem.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/modules/ProductView/ProductItem/ProductItem.js)
 
 :::info
 
@@ -105,7 +105,7 @@ need to update the fragment related to `ProductItem`.
 The original fragment file is collocated with the original component at:
 
 1. copy the
-   [`original ProductItemFragment`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/theme/modules/ProductView/ProductItem/ProductItemFragment.gql)
+   [`original ProductItemFragment`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/modules/ProductView/ProductItem/ProductItemFragment.gql)
    to the equivalent location in your module.
 1. add the field `description` to the fragment.
 

--- a/docs/magento2/advanced.mdx
+++ b/docs/magento2/advanced.mdx
@@ -45,7 +45,7 @@ Front-Commerce takes care of expiring the cart cache when an operation can have
 an effect on the cart representation (for instance when adding an item to the
 cart). If you use an API that changes the cart, you will also have to expire the
 cart cache. To do that, you can use
-[`decorateWithCartCacheExpire`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/magento2/cart/cache/decorateWithCartCacheExpire.js)
+[`decorateWithCartCacheExpire`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/server/modules/magento2/cart/cache/decorateWithCartCacheExpire.js)
 in the loader where this API is used. You can have a look at how it is used in
 [`CachedCartLoader`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/d8d74295d36455419f5e80c4d28e69987976b59c/src/server/modules/magento2/cart/loaders/CachedCartLoader.js#L20-24)
 or
@@ -107,10 +107,10 @@ to the account). If you use an API that updates customer information, you will
 also have to expire the cart cache.
 
 To do that, you can use
-[`makeCurrentCustomerCache`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/magento2/customer/cache/makeCurrentCustomerCache.js)
+[`makeCurrentCustomerCache`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/server/modules/magento2/customer/cache/makeCurrentCustomerCache.js)
 factory to create an instance of this cache, and `expire()` it. You can have a
 look at how it is used in
-[`CustomerLoader`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/server/modules/magento2/customer/loaders/CustomerLoader.js)
+[`CustomerLoader`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/server/modules/magento2/customer/loaders/CustomerLoader.js)
 where the customer cache is expired after some operations.
 
 ## Additional headers in Magento API calls

--- a/docs/magento2/page-builder.mdx
+++ b/docs/magento2/page-builder.mdx
@@ -154,7 +154,7 @@ answer you in a timely manner.
 - override
   `theme/modules/WysiwygV2/MagentoWysiwyg/PageBuilder/appComponentsMap.js` to
   register new components (or override
-  [existing ones](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/web/theme/modules/WysiwygV2/MagentoWysiwyg/PageBuilder/index.js))
+  [existing ones](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/modules/WysiwygV2/MagentoWysiwyg/PageBuilder/index.js))
 
 <!-- Override GraphQL fragment too (not yet externalized in a specific fragment FC code) -->
 

--- a/docs/prismic/embed-fields.mdx
+++ b/docs/prismic/embed-fields.mdx
@@ -40,7 +40,7 @@ For this example let's say we want to create an album cover from an embed field.
 ### Adding an Embed Field in your server-side
 
 First add an embed field in your schema using the
-[`oEmbedContent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/schema.gql)
+[`oEmbedContent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/prismic/server/modules/prismic/core/schema.gql)
 type, for example:
 
 ```graphql
@@ -51,10 +51,10 @@ type MyAlbum {
 ```
 
 Then you can add the
-[`EmbedTransformer`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/transformers/Embed.js)
+[`EmbedTransformer`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/prismic/server/modules/prismic/core/loaders/transformers/Embed.js)
 to your album definition which will parse the embed response from Prismic as a
 rich
-[`oEmbedContent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/schema.gql)
+[`oEmbedContent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/prismic/server/modules/prismic/core/schema.gql)
 type.
 
 ```diff
@@ -90,7 +90,7 @@ fragment AlbumFragment on Album {
 ```
 
 The fragment will expose several fields from the
-[`oEmbedContent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/schema.gql)
+[`oEmbedContent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/prismic/server/modules/prismic/core/schema.gql)
 type.
 
 ```jsx
@@ -118,7 +118,7 @@ You can override the default components for each embed type in your own theme
 As mentioned above, the fragment only exposes the minimum required fields for
 the PrismicEmbed component, if you would like to create your own custom embed
 component you can refer to all the available fields on the
-[`oEmbedContent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/schema.gql)
+[`oEmbedContent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/prismic/server/modules/prismic/core/schema.gql)
 type.
 
 ## Wysiwyg Embed Fields
@@ -172,7 +172,7 @@ We have added loader functions for the following embed scripts:
 - `Instagram`
 
 You can update these loading functions or add your own by overriding the
-[`theme/modules/WysiwygV2/PrismicWysiwyg/Components/EmbedScript/appEmbeds.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/web/theme/modules/WysiwygV2/PrismicWysiwyg/Components/EmbedScript/appEmbeds.js)
+[`theme/modules/WysiwygV2/PrismicWysiwyg/Components/EmbedScript/appEmbeds.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/prismic/web/theme/modules/WysiwygV2/PrismicWysiwyg/Components/EmbedScript/appEmbeds.js)
 file.
 
 - This file accepts a record with the key as the embed
@@ -226,7 +226,7 @@ export default Pre;
 ```
 
 Then you will need to register this component by overriding the
-[`theme/modules/WysiwygV2/PrismicWysiwyg/appComponentsMap.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/web/theme/modules/WysiwygV2/PrismicWysiwyg/appComponentsMap.js)
+[`theme/modules/WysiwygV2/PrismicWysiwyg/appComponentsMap.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/prismic/web/theme/modules/WysiwygV2/PrismicWysiwyg/appComponentsMap.js)
 file.
 
 ```js

--- a/docs/prismic/expose-content.mdx
+++ b/docs/prismic/expose-content.mdx
@@ -32,7 +32,7 @@ The Prismic loader has the following API to request Content from Prismic:
 ### `loadSingle(typeIdentifier)`
 
 Returns a
-[Content](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/Content.js)
+[Content](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/prismic/server/modules/prismic/core/loaders/Content.js)
 representing a Prismic Content of
 [the corresponding type](https://prismic.io/docs/core-concepts/custom-types). If
 such Content does not exist, it throws an error.
@@ -46,7 +46,7 @@ such Content does not exist, it throws an error.
 ### `loadByID(id)`
 
 Returns a
-[Content](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/Content.js)
+[Content](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/prismic/server/modules/prismic/core/loaders/Content.js)
 representing a Prismic Content of
 [the corresponding type](https://prismic.io/docs/core-concepts/custom-types). If
 such Content does not exist, it throws an error.
@@ -58,7 +58,7 @@ such Content does not exist, it throws an error.
 ### `loadByUID(typeIdentifier, uid)`
 
 Returns a
-[Content](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/Content.js)
+[Content](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/prismic/server/modules/prismic/core/loaders/Content.js)
 representing a Prismic Content of
 [the corresponding type](https://prismic.io/docs/core-concepts/custom-types) and
 having [a UID field](https://prismic.io/docs/core-concepts/uid) with the given
@@ -74,15 +74,15 @@ value. If such Content does not exist, it throws an error.
 ### `loadList(query)`
 
 Returns
-[a `ContentList`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/ContentList.js)
+[a `ContentList`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/prismic/server/modules/prismic/core/loaders/ContentList.js)
 matching the query. `query` must be an instance of
-[`ListQuery`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/ListQuery.js),
+[`ListQuery`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/prismic/server/modules/prismic/core/loaders/ListQuery.js),
 it provides a way to filter, sort and paginate Prismic Content.
 
 **Arguments:**
 
 - `query`
-  ([ListQuery](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/ListQuery.js)):
+  ([ListQuery](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/prismic/server/modules/prismic/core/loaders/ListQuery.js)):
   A query for a list of documents
 
 ### `defineContentTransformers(typeIdentifier, options)`
@@ -95,7 +95,7 @@ Defines the content transform options for a given document type.
   ([string](https://prismic.io/docs/technologies/rest-api-technical-reference#document.type)):
   The type of document.
 - `options`
-  ([ContentTransformOptions](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/index.js#L35-39)):
+  ([ContentTransformOptions](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/prismic/server/modules/prismic/core/loaders/index.js#L38-40)):
   Content transform options
 
 ### Field Transformers
@@ -149,7 +149,7 @@ the
 :::
 
 The complete list of available Transformers can be found under
-[the `transformers` directory in Prismic module](https://gitlab.blackswift.cloud/front-commerce/front-commerce-prismic/-/tree/main/prismic/server/modules/prismic/core/loaders/transformers).
+[the `transformers` directory in Prismic module](https://gitlab.blackswift.cloud/front-commerce/front-commerce-prismic/-/tree/2.x/prismic/server/modules/prismic/core/loaders/transformers).
 We will use some of them in the following examples.
 
 ## Implementation examples

--- a/docs/prismic/installation.mdx
+++ b/docs/prismic/installation.mdx
@@ -128,7 +128,7 @@ domain `images.prismic.io` to `imgSrc` in
 
 If you are using any other Wysiwyg enabled modules, then you will need to
 override
-[`getWysiwygComponent.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/src/web/theme/modules/WysiwygV2/getWysiwygComponent.js)
+[`getWysiwygComponent.js`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/web/theme/modules/WysiwygV2/getWysiwygComponent.js)
 and map all of the Wysiwyg customizations, for example:
 
 ```js title="theme/modules/WysiwygV2/getWysiwygComponent.js"
@@ -160,7 +160,7 @@ learn more.
 **Default transforms**
 
 - `<script>` tags with a
-  [supported embed script](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/web/theme/modules/WysiwygV2/PrismicWysiwyg/Components/EmbedScript/embeds.js)
+  [supported embed script](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/prismic/web/theme/modules/WysiwygV2/PrismicWysiwyg/Components/EmbedScript/embeds.js)
   are transformed into
-  [`theme/web/WysiwygV2/PrismicWysiwyg/EmbedScript`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/web/theme/modules/WysiwygV2/PrismicWysiwyg/Components/EmbedScript/EmbedScript.js)
+  [`theme/web/WysiwygV2/PrismicWysiwyg/EmbedScript`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/prismic/web/theme/modules/WysiwygV2/PrismicWysiwyg/Components/EmbedScript/EmbedScript.js)
   components.

--- a/docs/prismic/resolver-cache.mdx
+++ b/docs/prismic/resolver-cache.mdx
@@ -11,7 +11,7 @@ descriptions:
 
 In order to create references from prismic to the cached documents, we need to
 ensure that the `PrismicCachedResolver` receives a
-[Content](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/Content.js)
+[Content](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/prismic/server/modules/prismic/core/loaders/Content.js)
 type from your resolver. The resolver can either cache a `singleton` Content, or
 a `list` of Content.
 
@@ -29,7 +29,7 @@ Returns a resolver that caches the result of the given resolver.
 - `options` : An object with the following properties:
   - `mapParamsToId` A function that maps the resolver parameters to a unique id.
   - `contentProperty` The name of the property that contains the
-    [Content](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/modules/prismic/server/modules/prismic/core/loaders/Content.js).
+    [Content](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/modules/prismic/server/modules/prismic/core/loaders/Content.js).
 
 ## Usage
 

--- a/docs/reference/configurations.mdx
+++ b/docs/reference/configurations.mdx
@@ -19,7 +19,7 @@ to also read these related pages.
 ## How to set your configurations
 
 Each file described below exist in
-[`node_modules/front-commerce/src/config`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tree/main/src/config)
+[`node_modules/front-commerce/src/config`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/tree/2.x/src/config)
 in Front-Commerce. If you want to override some, duplicate those in
 `my-module/config`.
 

--- a/docs/reference/graphql-module-definition.mdx
+++ b/docs/reference/graphql-module-definition.mdx
@@ -95,7 +95,7 @@ export default {
 
 Modules are sorted using the [toposort](https://www.npmjs.com/package/toposort)
 library. See
-[`flattenAndReorderModulesUsingDependencies`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/main/src/server/core/graphql/__tests__/flattenAndReorderModulesUsingDependencies.js)
+[`flattenAndReorderModulesUsingDependencies`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/784684ce56cca69ca5c2e42d5d421a8c0b4bb9c3/src/server/core/graphql/__tests__/flattenAndReorderModulesUsingDependencies.js)
 code and tests for further details.
 
 :::


### PR DESCRIPTION
Summary:

* when the link targets a specific version (changelog, migration guide, …) the link is updated to lead to the file in the `2.n.x` branch
* when the link targets a directory, the link is updated to the `2.x` branch
* in other case, the link is the permalink to the file in the current `2.x` branch ie the commit that configure the CI for `2.x`

along the way, I fixed some hash to target the right lines and removed the link IntlDecorator that was removed like 3 years ago.