### PR TITLE
fix(build): add explicit pnpm version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     ]
   },
   "engines": {
-    "node": ">=16.14"
-  }
+    "node": ">=18.16",
+    "pnpm": ">=7.20"
+  },
+  "packageManager": "pnpm@7.26.3"
 }


### PR DESCRIPTION
This PR fixes Netlify builds by providing a `pnpm` version explicitely, as per https://docs.netlify.com/configure-builds/manage-dependencies/#pnpm

## Why?

Builds had the following error:

> Found pnpm version (7.13.4) that doesn't match expected ()
> Usage Error: Invalid package manager specification in CLI arguments; expected a semver version, range, or tag

It ignored the pnpm lockfile and led to peerdependencies errors, breaking the build.