### PR TITLE
fix: do not document deprecated URL property on custom url matcher

### DIFF
--- a/versioned_docs/version-2.x/advanced/theme/route-dispatcher.mdx
+++ b/versioned_docs/version-2.x/advanced/theme/route-dispatcher.mdx
@@ -106,8 +106,7 @@ const myCustomUrlMatcher = (loader) => async (url, match) => {
   }
   return {
     // return your custom routable entity
-    path: myMatch.canonical_url || url, // depending on your use case, it can be same as the url
-    url,
+    path: myMatch.canonical_url || url,
     __typename: "MyCustomType", // the GraphQL type of your custom type (should be added in schema.gql),
     ...myMatch, // or some adaptation of it. this will be available to your component defined bellow on a prop called `matched`
   };


### PR DESCRIPTION
Goes hand in hand with https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/1932