### PR TITLE
Initialize front-commerce-wordpress module documentation

### DIFF
--- a/versioned_docs/version-2.x/advanced/_category_.yml
+++ b/versioned_docs/version-2.x/advanced/_category_.yml
@@ -1,5 +1,5 @@
 label: Advanced
-position: 3
+position: 30
 link:
   type: generated-index
   description:

--- a/versioned_docs/version-2.x/bigcommerce/_category_.yml
+++ b/versioned_docs/version-2.x/bigcommerce/_category_.yml
@@ -1,5 +1,5 @@
 label: BigCommerce
-position: 6
+position: 70
 link:
   type: generated-index
   description:

--- a/versioned_docs/version-2.x/concepts/_category_.yml
+++ b/versioned_docs/version-2.x/concepts/_category_.yml
@@ -1,5 +1,5 @@
 label: Concepts
-position: 4
+position: 40
 link:
   type: generated-index
   description:

--- a/versioned_docs/version-2.x/essentials/_category_.yml
+++ b/versioned_docs/version-2.x/essentials/_category_.yml
@@ -1,5 +1,5 @@
 label: Essentials
-position: 2
+position: 20
 link:
   type: generated-index
   description: 5 minutes to learn the most important Front-Commerce concepts.

--- a/versioned_docs/version-2.x/magento1/_category_.yml
+++ b/versioned_docs/version-2.x/magento1/_category_.yml
@@ -1,5 +1,5 @@
 label: Magento 1 (OpenMage LTS)
-position: 5
+position: 60
 link:
   slug: "/category/magento1"
   type: generated-index

--- a/versioned_docs/version-2.x/magento2/_category_.yml
+++ b/versioned_docs/version-2.x/magento2/_category_.yml
@@ -1,5 +1,5 @@
 label: Magento 2
-position: 4
+position: 50
 link:
   slug: "/category/magento2"
   type: generated-index

--- a/versioned_docs/version-2.x/prismic/_category_.yml
+++ b/versioned_docs/version-2.x/prismic/_category_.yml
@@ -1,5 +1,5 @@
 label: Prismic
-position: 6
+position: 80
 link:
   type: generated-index
   description:

--- a/versioned_docs/version-2.x/reference/_category_.yml
+++ b/versioned_docs/version-2.x/reference/_category_.yml
@@ -1,4 +1,4 @@
 label: Reference
-position: 6
+position: 9
 link:
   type: generated-index

--- a/versioned_docs/version-2.x/reference/_category_.yml
+++ b/versioned_docs/version-2.x/reference/_category_.yml
@@ -1,4 +1,4 @@
 label: Reference
-position: 9
+position: 90
 link:
   type: generated-index

--- a/versioned_docs/version-2.x/reference/environment-variables.mdx
+++ b/versioned_docs/version-2.x/reference/environment-variables.mdx
@@ -347,6 +347,11 @@ See [our related documentation](/docs/2.x/category/prismic) for details.
 - `FRONT_COMMERCE_PRISMIC_WEBHOOK_SECRET`
 - `#FRONT_COMMERCE_PRISMIC_API_CACHE_TTL_IN_SECONDS`
 
+### Wordpress
+
+- `FRONT_COMMERCE_WORDPRESS_ENDPOINT`: the URL of the Wordpress instance. [See
+Front-Commerce Wordpress module documentation](/docs/2.x/wordpress/installation).
+
 ## Build related variables
 
 - `NODE_ENV`: `"development"` or `"production"` a variable heavily used in the

--- a/versioned_docs/version-2.x/wordpress/_category_.yml
+++ b/versioned_docs/version-2.x/wordpress/_category_.yml
@@ -1,0 +1,7 @@
+label: Wordpress
+position: 7
+link:
+  type: generated-index
+  description:
+    The Front-Commerce Wordpress module brings support for Wordpress as a headless
+    CMS and allows you to quickly add a blog to your Front-Commerce project.

--- a/versioned_docs/version-2.x/wordpress/_category_.yml
+++ b/versioned_docs/version-2.x/wordpress/_category_.yml
@@ -1,5 +1,5 @@
 label: Wordpress
-position: 7
+position: 90
 link:
   type: generated-index
   description:

--- a/versioned_docs/version-2.x/wordpress/installation.mdx
+++ b/versioned_docs/version-2.x/wordpress/installation.mdx
@@ -1,0 +1,96 @@
+---
+sidebar_position: 1
+title: Installation
+description:
+  This page explains how to install the Front-Commerce Wordpress module.
+---
+
+<p>{frontMatter.description}</p>
+
+## Install
+
+The Front-Commerce Wordpress module lives [in a dedicated
+repository](https://gitlab.blackswift.cloud/front-commerce/front-commerce-wordpress).
+As a result, you first need to install it with npm:
+
+```shell
+npm install git+ssh://git@gitlab.blackswift.cloud/front-commerce/front-commerce-wordpress.git
+```
+
+:::tip
+
+We recommend to use a specific version of this module and not to rely on the
+latest blindly.
+
+:::
+
+## Configure
+
+This module requires the `FRONT_COMMERCE_WORDPRESS_ENDPOINT` environment
+variable to be set with the URL of your WordPress instance (without a
+trailing slash):
+
+```shell title=.env
+FRONT_COMMERCE_WORDPRESS_ENDPOINT=https://wordpress.example.com
+```
+
+Then the module must be enabled in your `.front-commerce.js`. The Front-Commerce
+Wordpress module comes with two main GraphQL modules:
+
+* `WordPress/Blog` brings a blog to your Front-Commerce project
+* `WordPress/Cms` exposes the CMS pages from Wordpress.
+
+Depending on your project you can use both or only one of these GraphQL modules.
+
+:::note
+
+In any case, you also need to enable the `WordPress/Core` module.
+
+:::
+
+```javascript title=.front-commerce.js
+module.exports = {
+  name: "Front Commerce Skeleton",
+  url: "http://localhost:4000",
+  modules: [
+    // highlight-next-line
+    "./node_modules/front-commerce-wordpress/front-commerce-wordpress",
+    "./src",
+  ],
+  serverModules: [
+    { name: "FrontCommerce", path: "server/modules/front-commerce" },
+    { name: "Magento2", path: "server/modules/magento2" },
+    // highlight-start
+    {
+      name: "WordPressCore",
+      path: "front-commerce-wordpress/server/modules/wordpress/core",
+    },
+    // if you want a blog
+    {
+      name: "WordPressBlog",
+      path: "front-commerce-wordpress/server/modules/wordpress/blog",
+    },
+    // if you want to expose Cms Pages from Wordpress
+    {
+      name: "WordPressCms",
+      path: "front-commerce-wordpress/server/modules/wordpress/cms",
+      // if your Front-Commerce project is connected to a Magento1 instance, you
+      // need to use the following path instead
+      // path: "front-commerce-wordpress/server/modules/wordpress/cms/index.magento1.js",
+    },
+    // highlight-end
+  ],
+  webModules: [
+    { name: "FrontCommerce", path: "front-commerce/src/web" },
+    // highlight-start
+    {
+      name: "Wordpress",
+      path: "front-commerce-wordpress/front-commerce-wordpress/web",
+    },
+    // highlight-end
+    { name: "YourProject", path: "./src/web" },
+  ],
+};
+```
+
+After these changes, you need to restart Front-Commerce.


### PR DESCRIPTION
See also https://gitlab.blackswift.cloud/front-commerce/front-commerce-wordpress/-/merge_requests/20

Preview:
* https://deploy-preview-639--heuristic-almeida-1a1f35.netlify.app/docs/2.x/wordpress/installation
* https://deploy-preview-639--heuristic-almeida-1a1f35.netlify.app/docs/2.x/reference/environment-variables#wordpress