### PR TITLE
fix(negotiable-quote): fix commit links in migration guide

### DIFF
--- a/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
@@ -35,21 +35,20 @@ the following files:
 - `theme/components/atoms/Icon/icons/core-icons.js`
   ([1f324c8a](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/1f324c8a2002fe41aa5600dfdaf57a235868ffcd))
 - `theme/modules/Cart/CartFooter.js`
-  ([7613b30d](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/7613b30d89f3be7074ad6561d816d90728987b37))
+  ([a4ae74ac](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/a4ae74ac75b5e8aa6e30b4c709d81841aaeafa17))
 - `theme/modules/User/AccountNavigation/AccountNavigation.js`
-  ([1f324c8a](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/1f324c8a2002fe41aa5600dfdaf57a235868ffcd))
+  ([a4ae74ac](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/a4ae74ac75b5e8aa6e30b4c709d81841aaeafa17))
 - `theme/layouts/Header/Navigation/AccountNavigation/AccountSubNavigation.js`
-  ([6c1bfd3a](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/6c1bfd3aa96ea6d961c5040807a6ca921f7c21d4))
+  ([a4ae74ac](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/a4ae74ac75b5e8aa6e30b4c709d81841aaeafa17))
 - `theme/pages/Account/AccountLayout.js`
-  ([1f324c8a](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/1f324c8a2002fe41aa5600dfdaf57a235868ffcd))
-- `theme/pages/Account/EnhanceAccount.js`
   ([1f324c8a](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/1f324c8a2002fe41aa5600dfdaf57a235868ffcd))
 - `theme/_b2b.scss`
   ([ddc9b581](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/ddc9b5814cd33815a31865c4d75365a44094972d))
 
 ### New features in `2.23.0`
 
-- [Use Magento's `storeConfig` GraphQL query](/docs/2.x/magento2/using-magento-configuration#use-magentos-storeconfig-graphql-query) to access configurations with the `MagentoGraphQLConfig` loader
+- [Use Magento's `storeConfig` GraphQL query](/docs/2.x/magento2/using-magento-configuration#use-magentos-storeconfig-graphql-query)
+  to access configurations with the `MagentoGraphQLConfig` loader
 - [Attraqt: add contextual information to your queries](/docs/2.x/magento2/search-engine#add-contextual-information-to-your-queries)
 
 ## `2.21.0` -> `2.22.0`


### PR DESCRIPTION
This MR fixes changes on the migration guide that are outdated, notably commit links that were superseded.

https://deploy-preview-646--heuristic-almeida-1a1f35.netlify.app/docs/2.x/appendices/migration-guides/#adobe-commerce-negotiable-quotes