### PR TITLE
fix: properly document how to enable Payment on account for a company user

### DIFF
--- a/versioned_docs/version-2.x/advanced/payments/payment-on-account.mdx
+++ b/versioned_docs/version-2.x/advanced/payments/payment-on-account.mdx
@@ -28,6 +28,17 @@ This feature is directly provided by Adobe Commerce. Please refer to
 
 :::
 
+In addition, this feature is also controlled by the roles and the associated
+permissions assigned to a user within the company. For now, those roles can only
+be set through the Magento frontend. So to make sure a company user can use the
+_Payment on account_ method you need to:
+
+1. login as the administrator of the company or as a user having the _Manage
+   roles and permissions_ permission.
+1. go to `https://magento-front.example.com/company/role/`
+1. for the role assigned to the user, check the permissions _Sales / Allow
+   Checkout / Use Pay On Account method_ and _Company Credit / View_
+
 #### Enable the B2B module
 
 First, you need to


### PR DESCRIPTION
Being able to use the Payment on Account payment method requires some
permissions within the company. This PR adds a description of those (haven't
found the corresponding documentation in Magento's doc)