### PR TITLE
chore(remix): add FrontCommerceApp documentation

### DIFF
--- a/docs/api-reference/_category_.yml
+++ b/docs/api-reference/_category_.yml
@@ -1,0 +1,3 @@
+label: API Reference
+position: 2
+collapsible: false

--- a/docs/api-reference/front-commerce-remix.mdx
+++ b/docs/api-reference/front-commerce-remix.mdx
@@ -1,0 +1,164 @@
+---
+title: "@front-commerce/remix"
+sidebar_position: 2
+description:
+  "This package contains Front-Commerce implementations related to Remix."
+---
+
+<p>{frontMatter.description}</p>
+
+## Installation
+
+First ensure you have installed the package:
+
+```bash
+$ pnpm install @front-commerce/remix@latest
+```
+
+## Type Safety
+
+You can get type safety over the network for your loaders with
+[LoaderArgs](https://remix.run/docs/en/1.16.0/route/loader#type-safety) and for
+your actions with
+[ActionArgs](https://remix.run/docs/en/1.16.0/route/action#action). To ensure
+that the typed frontCommerce context is in the arguments, you can add the
+`@front-commerce/remix` reference to your `remix.env.d.ts` file.
+
+```ts
+/// <reference types="@remix-run/dev" />
+/// <reference types="@remix-run/node" />
+// highlight-next-line
+/// <reference types="@front-commerce/remix" />
+```
+
+## Front-Commerce Context
+
+To ensure the Front-Commerce Context is available in your loaders and actions,
+you need to add it to your server via the
+[`getLoadContext`](https://remix.run/docs/en/1.16.0/route/loader#context), to do
+this, update your
+[`server.ts`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/b99f0475ce494591a54fdc2b904e956a083e9b51/skeleton/server.ts)
+
+```ts
+// add-start
+import { createFrontCommerceContext } from "@front-commerce/remix";
+import { createRemixRequest } from "@remix-run/express/dist/server";
+// add-end
+
+app.all(
+  "*",
+  createRequestHandler({
+    build: require(BUILD_DIR),
+    mode: process.env.NODE_ENV,
+    // add-start
+    getLoadContext(request, response) {
+      const remixRequest = createRemixRequest(request, response);
+      return {
+        frontCommerce: createFrontCommerceContext(remixRequest),
+      };
+    },
+    // add-end
+  })
+);
+```
+
+## FrontCommerceApp
+
+The `FrontCommerceApp` instance uses the `frontCommerce` context to expose
+different API's which can be used in your Application.
+
+To create the `FrontCommerceApp` Instance you can add it to your loaders or
+actions.
+
+```ts
+import type { LoaderArgs, ActionArgs } from "@remix-run/node";
+import { FrontCommerceApp } from "@front-commerce/remix";
+
+export const loader = ({ context }: LoaderArgs) => {
+  const app = new FrontCommerceApp(context.frontCommerce);
+  // your loader logic here
+};
+
+export const action = ({ context }: ActionArgs) => {
+  const app = new FrontCommerceApp(context.frontCommerce);
+  // your action logic here
+};
+```
+
+### API Reference
+
+### `app.user`
+
+Exposes the current user information.
+
+```ts
+interface User {
+  clientIp: string;
+}
+```
+
+### `app.env`
+
+Exposes the current environment information. If the `FRONT_COMMERCE_ENV` has
+been set, it will use that, otherwise fallback to `process.env.NODE_ENV`.
+
+```ts
+type Environment = "production" | "development" | "test";
+```
+
+### `app.request`
+
+Exposes the
+[Remix NodeRequest](https://github.com/remix-run/remix/blob/410e9d8aac044b3453c1dddbeb0bcc1d53cdec68/packages/remix-node/fetch.ts#LL34C1-L46C2)
+request.
+
+This is essentially the same request which you will find in your `loader` or
+`action` functions.
+
+### `app.graphql`
+
+Exposes the graphql client.
+
+- `query` - Executes a graphql query.
+- `mutate` - Executes a graphql mutation.
+
+```ts
+export const loader = ({ context }: LoaderArgs) => {
+  const app = new FrontCommerceApp(context.frontCommerce);
+
+  const result = app.graphql.query(/* GraphQL */ `
+    query {
+      products {
+        items {
+          id
+          name
+        }
+      }
+    }
+  `);
+
+  // your loader logic here
+};
+
+export const action = ({ context }: ActionArgs) => {
+  const app = new FrontCommerceApp(context.frontCommerce);
+
+  const result = app.graphql.mutate(
+    /* GraphQL */ `
+    mutation AddToCart($input: AddToCartInput!)) {
+      addToCart(input: $input) {
+        cart {
+          items {
+            id
+            name
+          }
+        }
+      }
+    }
+  `,
+    { sku: "123", quantity: 1 }
+  );
+
+  // your action logic here
+};
+```

--- a/docs/migration/_category_.yml
+++ b/docs/migration/_category_.yml
@@ -1,5 +1,6 @@
 label: Migrating from v2
 position: 3
+collapsible: false
 link:
   type: generated-index
   description:

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -44,7 +44,7 @@
 .code-block-error-line {
   background-color: #ff000020;
   display: block;
-  margin: 0 calc(-1 * var(--ifm-pre-padding));
+  margin: 0 calc(-1.2 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
   border-left: 3px solid #ff000080;
 }
@@ -52,13 +52,13 @@
 .code-block-removed-line {
   background-color: #ff000020;
   display: block;
-  margin: 0 calc(-1 * var(--ifm-pre-padding));
+  margin: 0 calc(-1.2 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
   border-left: 3px solid transparent;
 }
 
 .code-block-removed-line::before {
-  content: " -";
+  content: "-";
   position: absolute;
   left: 0;
   color: #ff000080;
@@ -68,13 +68,13 @@
 .code-block-added-line {
   background-color: rgb(54, 172, 170, 0.13);
   display: block;
-  margin: 0 calc(-1 * var(--ifm-pre-padding));
+  margin: 0 calc(-1.2 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
   border-left: 3px solid transparent;
 }
 
 .code-block-added-line::before {
-  content: " +";
+  content: "+";
   position: absolute;
   left: 0;
   color: rgb(54, 172, 170);


### PR DESCRIPTION
## What?

This adds the documentation and API reference for the `@front-commerce/remix` package.

## Preview

https://deploy-preview-654--heuristic-almeida-1a1f35.netlify.app/docs/remixed/api-reference/front-commerce-remix