### PR TITLE
fix: make sure Wordpress is before Reference

### DIFF
--- a/versioned_docs/version-2.x/reference/_category_.yml
+++ b/versioned_docs/version-2.x/reference/_category_.yml
@@ -1,4 +1,4 @@
 label: Reference
-position: 90
+position: 98
 link:
   type: generated-index


### PR DESCRIPTION
to avoid

![image](https://github.com/front-commerce/developers.front-commerce.com/assets/305563/f546a3cf-76b4-44ac-95da-5d7fc0d02757)
