### PR TITLE
feat(image-adapters): allow custom image sources (FC-1256)

### DIFF
--- a/versioned_docs/version-2.x/advanced/images-adapters/custom-adapter.mdx
+++ b/versioned_docs/version-2.x/advanced/images-adapters/custom-adapter.mdx
@@ -90,3 +90,65 @@ imageAdapters.register(LoremPicsumAdapter);
 
 All the built-in image components use the ImageAdapters by default to deliver
 images enhanced and optimized images.
+
+### Changing the generated sources for srcSet
+
+The ImageAdapter has two optional methods:
+
+- `getSupportedExtensions` this allows you to change how the `srcSet` is
+  generated.
+- `getDefaultExtension` this allows you to change the default format used for
+  the `srcSet`.
+
+For example, if we want to change the supported formats for the UnsplashAdapter:
+
+```js title="src/web/adapters/unsplash.js"
+import { ImageAdapter } from "theme/components/atoms/Image/ImageAdapter";
+
+class UnsplashAdapter extends ImageAdapter {
+  supportSrc(src) {
+    return src.includes("unsplash.com");
+  }
+
+  makeImageSrc(src) {
+    return src;
+  }
+
+  // add-start
+  getSupportedExtensions(transparent) {
+    if (transparent) {
+      return ["webp", "png"];
+    }
+
+    return ["webp", "jpeg"];
+  }
+
+  getDefaultExtension() {
+    return "jpeg";
+  }
+  // add-end
+}
+```
+
+You can also opt-out of multiple sources for the `srcSet` by either returning a
+single format or a null if you don't want to specify a format.
+
+```js title="src/web/adapters/unsplash.js"
+  // add-start
+  getSupportedExtensions(transparent) {
+    if (transparent) {
+      return "webp" // return a single format
+    }
+
+    return null // generate one source without a format specification
+  }
+  // add-end
+```
+
+:::note
+
+Not specifing the `getSupportedExtensions` and `getDefaultExtension` methods
+will fallback to the
+[default implementation](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/7b41c06087c621b172b91270465a79c4d1aa2713/src/web/theme/components/atoms/Image/ImageAdapter.js#L17-33).
+
+:::

--- a/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
@@ -31,6 +31,69 @@ overrides if any.
 
 :::
 
+### ImageAdapters without multiple sources
+
+In the version we extended the `ImageAdapters` feature allow an adapter to
+change how sources are generated for the srcSet, to allow this, we had to
+[make changes to the `makeImagesProps`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2037)
+If you have overriden this file, you will need to update it to match the new
+implementation.
+
+```js title="src/web/theme/components/atoms/Image/makeImagesProps.js"
+// add-next-line
+import imageAdapters from "./adapters";
+
+const makeImgProps = (baseUrl, src, format, bg, cover, fluid) => {
+  // [..]
+
+  // add-start
+  const sourcesExtensions = imageAdapters.getSupportedExtensions(
+    src,
+    bg === "transparent"
+  );
+  const defaultExtension = imageAdapters.getDefaultExtension(src);
+  // add-end
+
+  return {
+    // remove-next-line
+    src: makeImgSrc(src, format, sizes[0], bg, extension, cover, baseUrl),
+    // add-next-line
+    src: makeImgSrc(src, format, sizes[0], bg, defaultFormat, cover, baseUrl),
+    sources: sourcesExtensions.map((extension) => ({
+      // remove-next-line
+      type: `image/${extension}`,
+      // add-next-line
+      ...(extension ? { type: `image/${extension}` } : {}),
+      srcSet: makeImageSrcset(
+        baseUrl,
+        src,
+        format,
+        sizes,
+        bg,
+        extension,
+        cover,
+        fluid
+      ),
+    })),
+  };
+};
+```
+
+We also added two optional methods `getSupportedExtensions` and
+`getDefaultExtension` to adapters, see
+[Custom ImageAdapters documentation](/docs/2.x/advanced/images-adapters/custom-adapter#changing-the-generated-sources-for-srcset)
+for more information.
+
+:::info
+
+This change removed the responsibility of the
+[exported `transparentExtensions`, `extensions` and `defaultExtension`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/8369167c12d4c655fab8998723b54332dc6a5274/src/web/theme/components/atoms/Image/ImageComponent.js#L8-20)
+consts from the `ImageComponent` so we have marked them for deprecation in v3,
+they are currently re-exporting the methods from the default Front-Commerce
+image adapter
+
+:::
+
 ### New features in `2.24.0`
 
 - [Apple Pay and Google Pay support with Stripe](/docs/2.x/advanced/payments/stripe)


### PR DESCRIPTION
## What?
see https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2037

## Previews
- [Migration Guide](https://deploy-preview-661--heuristic-almeida-1a1f35.netlify.app/docs/2.x/appendices/migration-guides/#imageadapters-without-multiple-sources)
- [Custom ImageAdapter](https://deploy-preview-661--heuristic-almeida-1a1f35.netlify.app/docs/2.x/advanced/images-adapters/custom-adapter#changing-the-generated-sources-for-srcset)