### PR TITLE
Google Pay and Apple Pay support with Stripe

### DIFF
--- a/versioned_docs/version-2.x/advanced/payments/stripe.mdx
+++ b/versioned_docs/version-2.x/advanced/payments/stripe.mdx
@@ -83,6 +83,16 @@ In your Front-Commerce application:
    };
    ```
 
+### Optional: enable Apple Pay and/or Google Pay
+
+<SinceVersion tag="2.24" />
+
+If enabled in your Stripe account, Apple Pay and Google Pay payment methods are
+supported and can be used in your Front-Commerce store. Please refer to [the
+Google Pay with Stripe](https://stripe.com/docs/google-pay) and [the Apple Pay
+with Stripe](https://stripe.com/docs/apple-pay) documentation to learn how to
+configure those payment methods.
+
 ### Update your CSPs
 
 To allow loading stripe related remote resources:

--- a/versioned_docs/version-2.x/advanced/payments/stripe.mdx
+++ b/versioned_docs/version-2.x/advanced/payments/stripe.mdx
@@ -7,6 +7,7 @@ description:
 ---
 
 import ContactLink from "@site/src/components/ContactLink";
+import SinceVersion from "@site/src/components/SinceVersion";
 
 <p>{frontMatter.description}</p>
 
@@ -103,7 +104,7 @@ To allow loading stripe related remote resources:
 
 ### Advanced: disable automatic capture
 
-> Since 2.19.0
+<SinceVersion tag="2.19" />
 
 Optionally the environment variable `FRONT_COMMERCE_STRIPE_DISABLE_CAPTURE` can
 be set to `true` to configure the Stripe module so that the payment is not

--- a/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
@@ -12,6 +12,31 @@ import ContactLink from "@site/src/components/ContactLink";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
+## `2.23.0` -> `2.24.0`
+
+### Apple Pay and Google Pay support with Stripe
+
+In this version, we have added support for [Apple Pay and Google Pay with
+Stripe](/docs/2.x/advanced/payments/stripe#optional-enable-apple-pay-andor-google-pay).
+We have also took this as an opportunity to upgrade Stripe related dependencies.
+If your project uses Stripe, we strongly advice you to test your integration.
+
+:::note
+
+To enable support for Apple Pay and Google Pay, we have [changed the
+implementation of `StripeCheckoutForm` to use Stripe's `PaymentElement` instead
+of Stripe's
+`CardElement`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2030).
+This results in a slight user interface change. Please update your
+`theme/modules/Checkout/Payment/AdditionalPaymentInformation/StripeCheckout/*`
+overrides if any.
+
+:::
+
+### New features in `2.24.0`
+
+* [Apple Pay and Google Pay support with Stripe](/docs/2.x/advanced/payments/stripe)
+
 ## `2.22.0` -> `2.23.0`
 
 ### Adobe Commerce RMA


### PR DESCRIPTION
https://deploy-preview-662--heuristic-almeida-1a1f35.netlify.app/docs/2.x/advanced/payments/stripe#optional-enable-apple-pay-andor-google-pay

https://deploy-preview-662--heuristic-almeida-1a1f35.netlify.app/docs/2.x/appendices/migration-guides/#apple-pay-and-google-pay-support-with-stripe