### PR TITLE
Akamai Image Manager: rename module

### DIFF
--- a/versioned_docs/version-2.x/advanced/images-adapters/akamai-image-manager.mdx
+++ b/versioned_docs/version-2.x/advanced/images-adapters/akamai-image-manager.mdx
@@ -11,7 +11,7 @@ import SinceVersion from "@site/src/components/SinceVersion";
 
 ## Installation
 
-Add the `image-adapter-akamai` module to your config file:
+Add the `akamai-image-manager` module to your config file:
 
 ```js title=".front-commerce.js"
 module.exports = {
@@ -19,7 +19,7 @@ module.exports = {
   modules: [
     "./node_modules/front-commerce/theme-chocolatine",
     // highlight-next-line
-    "./node_modules/front-commerce/modules/image-adapter-akamai",
+    "./node_modules/front-commerce/modules/akamai-image-manager",
     "./src",
   ],
 };


### PR DESCRIPTION
This PR updates the upcoming documentation to ensure the module renaming tackled in https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2051 is reflected in the documentation.