### PR TITLE
Akamai Image Manager: add additional configuration + mention in migration guide

### DIFF
--- a/versioned_docs/version-2.x/advanced/images-adapters/akamai-image-manager.mdx
+++ b/versioned_docs/version-2.x/advanced/images-adapters/akamai-image-manager.mdx
@@ -2,12 +2,14 @@
 sidebar_position: 1
 title: Akamai Image Manager
 description:
-  Automatically optimize and enhance visual media for every user, on any device.
+  Automatically optimize and enhance visual media for every user, on any device, at edge with Akamai.
 ---
 
 import SinceVersion from "@site/src/components/SinceVersion";
+import ContactLink from "@site/src/components/ContactLink";
 
 <SinceVersion tag="2.24" />
+<p>{frontMatter.description}</p>
 
 ## Installation
 
@@ -25,6 +27,31 @@ module.exports = {
 };
 ```
 
+## Configuration
+
+The `akamai-image-manager` module works out-of-the-box without requiring any changes to your existing image configuration. It however supports additional configurations for specific use cases.
+
+Configuration is available under the `akamai` key of the [`src/config/images.js`](/docs/2.x/reference/configurations#configimagesjs)
+config.
+
+### Using Image Manager for a subset of images
+
+You can customize the `akamai.paths` value to limit images handled by image manager to only a subset of paths. This option accepts an array of paths. Only images under this path will be handled by the image manager adapter. Default value is `["/"]` (all images).
+
+Example:
+
+```js title="src/config/images.js"
+module.exports = {
+  // […]
+  akamai: {
+    paths: [
+      "/media",
+      "/cms/images/",
+    ],
+  },
+};
+```
+
 ## Akamai configuration
 
 The adapter uses
@@ -33,7 +60,6 @@ transformation on images, with the default `im` as variable name.
 
 :::info
 
-In Front-Commerce Cloud Akamai Image Manager configuration, all IMQuery image
-transformations are enabled by default.
+In Front-Commerce Cloud, Akamai Image Manager isn't enabled by default. Please <ContactLink>contact us</ContactLink> if you plan to use this feature.
 
 :::

--- a/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
@@ -42,6 +42,7 @@ overrides if any.
   - [worker-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/worker-src)
   - [manifest-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/manifest-src)
   - [child-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/child-src)
+- [Akamai Image Manager adapter](/docs/2.x/advanced/images-adapters/akamai-image-manager) for the `<Image>` component
 
 ## `2.22.0` -> `2.23.0`
 


### PR DESCRIPTION
This PR ensures that the Akamai Image Manager documented feature is up-to-date with the latest version and consistent with other.

It:
- adds a note about it in the migration guide's new features
- adds the description in the page
- documents the `akamai.paths` configuration
- rewords the FC Cloud related block with a CTA to contact us

Preview:
- [Akamai image manager](https://deploy-preview-666--heuristic-almeida-1a1f35.netlify.app/docs/2.x/advanced/images-adapters/akamai-image-manager)
- [Migration guide](https://deploy-preview-666--heuristic-almeida-1a1f35.netlify.app/docs/2.x/appendices/migration-guides/#new-features-in-2240)