### PR TITLE
Fixes docosaurus types

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.4.1",
+    "@docusaurus/types": "2.4.1",
     "@tsconfig/docusaurus": "1.0.7",
     "@types/react": "18.0.27",
     "@types/react-slick": "0.23.10",
@@ -69,7 +70,7 @@
   },
   "engines": {
     "node": ">=18.16",
-    "pnpm": ">=7.20"
+    "pnpm": ">=8.6"
   },
-  "packageManager": "pnpm@7.26.3"
+  "packageManager": "pnpm@8.6.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 dependencies:
   '@algolia/client-search':
@@ -9,7 +13,7 @@ dependencies:
     version: 2.4.1(@docusaurus/types@2.4.1)(@types/node@18.15.11)(react-dom@18.2.0)(react@18.2.0)(ts-node@10.9.1)(typescript@4.9.4)
   '@docusaurus/plugin-client-redirects':
     specifier: 2.4.1
-    version: 2.4.1(@types/node@18.15.11)(react-dom@18.2.0)(react@18.2.0)(ts-node@10.9.1)(typescript@4.9.4)
+    version: 2.4.1(@docusaurus/types@2.4.1)(@types/node@18.15.11)(react-dom@18.2.0)(react@18.2.0)(ts-node@10.9.1)(typescript@4.9.4)
   '@docusaurus/plugin-content-blog':
     specifier: 2.4.1
     version: 2.4.1(@types/node@18.15.11)(react-dom@18.2.0)(react@18.2.0)(ts-node@10.9.1)(typescript@4.9.4)
@@ -79,6 +83,9 @@ dependencies:
 
 devDependencies:
   '@docusaurus/module-type-aliases':
+    specifier: 2.4.1
+    version: 2.4.1(react-dom@18.2.0)(react@18.2.0)
+  '@docusaurus/types':
     specifier: 2.4.1
     version: 2.4.1(react-dom@18.2.0)(react@18.2.0)
   '@tsconfig/docusaurus':
@@ -1859,7 +1866,7 @@ packages:
       - uglify-js
       - webpack-cli
 
-  /@docusaurus/plugin-client-redirects@2.4.1(@types/node@18.15.11)(react-dom@18.2.0)(react@18.2.0)(ts-node@10.9.1)(typescript@4.9.4):
+  /@docusaurus/plugin-client-redirects@2.4.1(@docusaurus/types@2.4.1)(@types/node@18.15.11)(react-dom@18.2.0)(react@18.2.0)(ts-node@10.9.1)(typescript@4.9.4):
     resolution: {integrity: sha512-tp0j16gaLIJ4p+IR0P6KDOFsTOGGMY54MNPnmM61Vaqqt5omLqsuKUO8UlCGU1oW/4EIQOhXYy99XYY5MjE+7A==}
     engines: {node: '>=16.14'}
     peerDependencies:


### PR DESCRIPTION
Fixes the following error logs when running in development
```
[ERROR] TSError: ⨯ Unable to compile TypeScript:
docusaurus.config.js:19:19 - error TS2307: Cannot find module '@docusaurus/types' or its corresponding type declarations.

19 /** @type {import('@docusaurus/types').Config} */
                     ~~~~~~~~~~~~~~~~~~~

    at createTSError (/home/paul/Projects/developers.front-commerce.com/node_modules/.pnpm/ts-node@10.9.1_@types+node@18.15.11_typescript@4.9.4/node_modules/ts-node/src/index.ts:859:12)
    at reportTSError (/home/paul/Projects/developers.front-commerce.com/node_modules/.pnpm/ts-node@10.9.1_@types+node@18.15.11_typescript@4.9.4/node_modules/ts-node/src/index.ts:863:19)
    at getOutput (/home/paul/Projects/developers.front-commerce.com/node_modules/.pnpm/ts-node@10.9.1_@types+node@18.15.11_typescript@4.9.4/node_modules/ts-node/src/index.ts:1077:36)
    at Object.compile (/home/paul/Projects/developers.front-commerce.com/node_modules/.pnpm/ts-node@10.9.1_@types+node@18.15.11_typescript@4.9.4/node_modules/ts-node/src/index.ts:1433:41)
    at Module.m._compile (/home/paul/Projects/developers.front-commerce.com/node_modules/.pnpm/ts-node@10.9.1_@types+node@18.15.11_typescript@4.9.4/node_modules/ts-node/src/index.ts:1617:30)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Object.require.extensions.<computed> [as .js] (/home/paul/Projects/developers.front-commerce.com/node_modules/.pnpm/ts-node@10.9.1_@types+node@18.15.11_typescript@4.9.4/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Function.Module._load (node:internal/modules/cjs/loader:958:12)
    at Module.require (node:internal/modules/cjs/loader:1141:19)
    at module.exports (/home/paul/Projects/developers.front-commerce.com/node_modules/.pnpm/import-fresh@3.3.0/node_modules/import-fresh/index.js:32:59)
    at loadSiteConfig (/home/paul/Projects/developers.front-commerce.com/node_modules/.pnpm/@docusaurus+core@2.4.1_@docusaurus+types@2.4.1_@types+node@18.15.11_react-dom@18.2.0_react@18_4n5yuih3fespsdjiv3n5fb3jze/node_modules/@docusaurus/core/lib/server/config.js:36:55)
    at async loadContext (/home/paul/Projects/developers.front-commerce.com/node_modules/.pnpm/@docusaurus+core@2.4.1_@docusaurus+types@2.4.1_@types+node@18.15.11_react-dom@18.2.0_react@18_4n5yuih3fespsdjiv3n5fb3jze/node_modules/@docusaurus/core/lib/server/index.js:31:63)
    at async load (/home/paul/Projects/developers.front-commerce.com/node_modules/.pnpm/@docusaurus+core@2.4.1_@docusaurus+types@2.4.1_@types+node@18.15.11_react-dom@18.2.0_react@18_4n5yuih3fespsdjiv3n5fb3jze/node_modules/@docusaurus/core/lib/server/index.js:74:21)

✔ Client
  Compiled successfully in 386.26ms
  ```

This is used in the [docosaurus.config.js](https://github.com/front-commerce/developers.front-commerce.com/blob/e383c565320ee2ca79d803402201f977808cffff/docusaurus.config.js#L19)