### PR TITLE
chore: Document workaround for sending cookies services to datalayer

### DIFF
--- a/versioned_docs/version-2.x/advanced/analytics/getting-started.mdx
+++ b/versioned_docs/version-2.x/advanced/analytics/getting-started.mdx
@@ -94,6 +94,31 @@ module.exports = {
 };
 ```
 
+### Retrieve authorized cookie services in analytics
+
+In Front-Commerce, to allow authorized cookie services to be injected in
+analytics services `settings(authorization, otherAuthorizations)` callback (as
+its 2nd parameter), those services also need to be defined in
+`config/analytics.js`.
+
+This can be done by declaring "dummy" modules in `config/analytics.js` such as:
+
+```diff title="src/config/analytics.js"
+       // ...
++      {
++        name: "my-service",
++        needConsent: true,
++        script: () => () => {
++          return {
++            name: "my-service",
++          };
++        },
++      },
+     ],
+   },
+ };
+```
+
 ## The GDPR consent
 
 If your plugins need consent of the user before running, you need to setup the

--- a/versioned_docs/version-2.x/advanced/analytics/plugins.mdx
+++ b/versioned_docs/version-2.x/advanced/analytics/plugins.mdx
@@ -344,6 +344,10 @@ load / remove (depending on the `userConsents` value). Here is an example:
 
 </Figure>
 
+Please note that to retrieve the authorized cookies services in GTM's datalayer,
+services must be
+[declared in your `analytics.js`](./getting-started#retrieve-authorized-cookie-services-in-analytics).
+
 ### Meta Pixel
 
 You can use our


### PR DESCRIPTION
This MR document an issue about sending cookie services to the datalayer.

[Analytics page](https://deploy-preview-681--heuristic-almeida-1a1f35.netlify.app/docs/2.x/advanced/analytics/getting-started#retrieve-authorized-cookie-services-in-analytics)\
[GTM mention](https://deploy-preview-681--heuristic-almeida-1a1f35.netlify.app/docs/2.x/advanced/analytics/plugins#retrieve-authorized-cookie-services-in-gtms-datalayer)