### PR TITLE
fix(adyen): add more detailed explanations about configuring M2 extension

### DIFF
--- a/versioned_docs/version-2.x/advanced/payments/adyen.mdx
+++ b/versioned_docs/version-2.x/advanced/payments/adyen.mdx
@@ -383,9 +383,13 @@ currently support any version from
 [7.2.0](https://github.com/Adyen/adyen-magento2/releases/tag/7.2.0) to
 [8.x](https://github.com/Adyen/adyen-magento2/releases/tag/8.0.0).
 
-You must configure the "Payment Origin URL" in the `Advanced: PWA` section
-(version 7.0+) or `Advance settings > Headless Integration` (version 8.0+) with
-your Front-Commerce URL **for each of your stores**.
+You must configure the extension's Headless/PWA settings with your Front-Commerce URL **for each of your stores**.
+Settings [changed in version 8.0.0](https://github.com/Adyen/adyen-magento2/releases/tag/8.0.0), so it will be slightly different depending on your version.
+- `< 8`: configure "Payment Origin URL" in the `Advanced: PWA` section
+- `>= 8`: configure  `Advanced settings > Headless Integration` with
+  - Payment Origin URL: your Front-Commerce URL (e.g: [http://localhost:4000/](http://localhost:4000/))
+  - Payment Return URL: the `/adyen/process/result` path (e.g: [http://localhost:4000/adyen/process/result](http://localhost:4000/adyen/process/result))
+  - Custom Success Redirect Path: same value as Payment Return URL
 
 :::info important
 

--- a/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
@@ -492,6 +492,8 @@ In this release, we added support for version 8 of Magento2 Adyen module. If you
 have a Front-Commerce setup where the module `Magento2/Adyen` is used,
 [the `FRONT_COMMERCE_ADYEN_MAGENTO_MODULE_VERSION` environment variable is now required and it must contain the Magento2 module version](/docs/2.x/advanced/payments/adyen#add-the-required-environment-variables-1).
 
+New configurations were added in the Adyen Magento module regarding headless storefronts. Please [ensure you've configured the "Headless Integration" as per our docs](/docs/2.x/advanced/payments/adyen#install-and-configure-the-adyen_payment-magento2-extension-72--90).
+
 ### DomainEvent implementations reworked
 
 The `PaymentDetails` attribute was removed from the payment DomainEvents. A


### PR DESCRIPTION
This MR updates the M2 Adyen installation procedure to explain more clearly how to configure URLs for headless use cases.

It also adds a word about this for existing projects migrating to 2.18 (and upgrading their Adyen module).

Preview:
- [Adyen install section](https://deploy-preview-683--heuristic-almeida-1a1f35.netlify.app/docs/2.x/advanced/payments/adyen#install-and-configure-the-adyen_payment-magento2-extension-72--90)
- [Migration guide](https://deploy-preview-683--heuristic-almeida-1a1f35.netlify.app/docs/2.x/appendices/migration-guides/#magento2-adyen-module-update)