### PR TITLE
Fixed GTM plugin example settings

### DIFF
--- a/versioned_docs/version-2.x/advanced/analytics/plugins.mdx
+++ b/versioned_docs/version-2.x/advanced/analytics/plugins.mdx
@@ -307,11 +307,18 @@ Configuration example in `src/config/analytics.js`
 {
   name: "google-tag-manager",
   needConsent: true,
-  settings: (authorization, otherAuthorizations) => ({
-    containerId: "GTM-123xyz",
-    // the userConsents option is a specific key that the plugin will use and expose in the GTM dataLayer
-    userConsents: otherAuthorizations
-  }),
+  settings: (authorization, otherAuthorizations) => {
+    // This ensure an event is pushed with current authorizations
+    // right after the plugin's initilization.
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      event: "initConsents",
+      userConsents: otherAuthorizations,
+    });
+    return {
+      containerId: "GTM-ABC123",
+    };
+  },
   script: () => import("@analytics/google-tag-manager"),
 }
 ```
@@ -324,9 +331,9 @@ for more details)
 In GTM, you will then be able to leverage several specific things configured in
 your plugins.
 
-First, the `userConsents` configuration option will be pushed to your dataLayer
-as the `userConsents` value. You can reference it from a Variable in GTM. Here
-is an example:
+First, pushing the `initConsents` event will push the current customer's
+authorization to your dataLayer as `userConsents` value. You can reference it
+from a Variable in GTM. Here is an example:
 
 <Figure>
 


### PR DESCRIPTION
Our current documentation features a setting (`userConsents`) we implemented in our legacy analytics module but that isn't available in `@analytics/google-tag-manager`.

This MR fixes this example with another example that provides the same effect.

[GTM documentation](https://deploy-preview-684--heuristic-almeida-1a1f35.netlify.app/docs/2.x/advanced/analytics/plugins#google-tag-manager)