### PR TITLE
Complete migration guide related to Magic Button implementation

### DIFF
--- a/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
@@ -107,7 +107,10 @@ from the theme:
     commit](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/8234c24547b3a22a737f9279ebafddb697135a5e))
 - `theme/pages/CmsPage/CmsPage.js` ([see the corresponding commit](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/61fddb8f9c68278a818a3875fb29c3c4294df4eb#0910701e610443ed0dabb3fb9b053e2b3b9e4ad7_22_13))
 - `theme/pages/Category/Category.js` ([see the corresponding commit](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/8234c24547b3a22a737f9279ebafddb697135a5e#f73633265fb675f84c088c5b3d38749242fe36f8))
-- `theme/modules/_modules.scss` ([see the corresponding commit](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/5d803de8a30d9429cf4c085c3b3da91285c22ae1#f9a39a6723f4100486c2658dff702698421eae41))
+- `theme/components/atoms/Colors/_colors.scss` ([see the corresponding commit](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/d34b4bf4819fc2c8e4275d28aa62d94608aa418e#cb2e530ac7e57d50b7a4e6773fd6b24b86b0a982))
+- `theme/modules/_modules.scss` (see [this first commit](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/d34b4bf4819fc2c8e4275d28aa62d94608aa418e?page=2#f9a39a6723f4100486c2658dff702698421eae41) and [this second commit](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/5d803de8a30d9429cf4c085c3b3da91285c22ae1#f9a39a6723f4100486c2658dff702698421eae41))
+- `theme/components/_components.scss` ([see the
+    corresponding changes](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2084/diffs#diff-content-1ff60716b8b194110c074a70473544b96850f2ac))
 
 If you have an override of `template/index.html`, you need to apply the
 following changes:


### PR DESCRIPTION
The migration guide related to the Magic Button is incomplete. This patch adds some missing instructions.