### PR TITLE
Document Stripe for Negotiable Quote

### DIFF
--- a/versioned_docs/version-2.x/advanced/payments/stripe.mdx
+++ b/versioned_docs/version-2.x/advanced/payments/stripe.mdx
@@ -51,6 +51,27 @@ In your Front-Commerce application:
    ]
 ```
 
+#### Adobe Commerce B2B
+
+<SinceVersion tag="2.25" />
+
+The Stripe payment module supports the [Negotiable Quote](/docs/2.x/magento2/b2b#negotiable-quotes) checkout and allows customers to pay a negotiated quote with Stripe.
+
+To enable this feature, you must have the Magento2 B2B module enabled and register an additional `serverModule`:
+
+
+```diff title=".front-commerce.js"
+   modules: [],
+   serverModules: [
+     { name: "FrontCommerce", path: "server/modules/front-commerce" },
+     { name: "Magento2", path: "server/modules/magento2" },
+-    { name: "Stripe", path: "server/modules/payment-stripe" }
++    { name: "Stripe", path: "server/modules/payment-stripe" },
++    { name: "StripeM2B2B", path: "server/modules/payment-stripe/magento2-b2b" },
+   ]
+```
+
+
 #### Magento1 (OpenMage LTS)
 
 ```diff title=".front-commerce.js"

--- a/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
@@ -130,9 +130,38 @@ following changes:
 We strongly advice you to synchronize any override you may have done in your
 project.
 
+### Negotiable Quotes: online payments
+
+In this release, we've added support for a first online payment method ([Stripe](/docs/2.x/advanced/payments/stripe#adobe-commerce-b2b)) to the negotiable quote checkout.
+
+To achieve this feature, we had to perform a minor but potentially impactful Breaking Change to the negotiable checkout. The payment method selection step now only performs a single mutation instead of two.
+
+The `setNegotiableQuotePaymentMethod` and `placeNegotiableQuoteOrder` mutations have been merged into `setNegotiableQuotePaymentInformationAndPlaceOrder`.
+Here is [the merge request containing the diff](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2104), so that you can check whether or not your overrides are affected by this change.
+
+To use this feature you need to:
+- update your Magento2 B2B Front-Commerce module to [version 1.2.0+](https://gitlab.blackswift.cloud/front-commerce/magento2-b2b-module-front-commerce/-/releases/1.2.0)
+- ensure you haven't overriden theme files impacted with this breaking change
+
+Impacted files:
+- `theme/modules/Checkout/NegotiableQuotes/Payment/ChoosePayment.js`
+- `theme/modules/Checkout/NegotiableQuotes/Payment/EnhanceChoosePayment.js`
+- `theme/modules/Checkout/NegotiableQuotes/Payment/SetNegotiableQuotePaymentMethod.gql`
+- `theme/modules/Checkout/NegotiableQuotes/PlaceOrder/EnhancePlaceOrder.js`
+- `theme/modules/Checkout/NegotiableQuotes/PlaceOrder/PlaceNegotiableQuoteOrderMutation.gql`
+- `theme/modules/Checkout/NegotiableQuotes/PlaceOrder/PlaceOrder.js`
+- `theme/modules/Checkout/NegotiableQuotes/PlaceOrder/SetNegotiableQuotePaymentInformationAndPlaceOrderMutation.gql`
+
+:::note
+
+We usually try hard to avoid Breaking Changes. In this context, we decided to remain pragmatic as we knew that this relatively new feature wasn't used by many projects. For this reason, we chose the simplest solution instead of adding complexity with deprecated GraphQL mutations and conditional paths in the checkout. **Please contact us if you need help with this upgrade.**
+
+:::
+
 ### New features in `2.25.0`
 
 - [Magic Button](/docs/2.x/category/magic-button)
+- [Stripe: Negotiable Quote checkout support](/docs/2.x/advanced/payments/stripe#adobe-commerce-b2b)
 
 ## `2.23.0` -> `2.24.0`
 

--- a/versioned_docs/version-2.x/magento2/b2b.mdx
+++ b/versioned_docs/version-2.x/magento2/b2b.mdx
@@ -6,6 +6,7 @@ description:
   to configure and use the B2B module.
 ---
 
+import ContactLink from "@site/src/components/ContactLink";
 import SinceVersion from "@site/src/components/SinceVersion";
 
 <SinceVersion tag="2.11" />
@@ -148,6 +149,14 @@ This module has been fully implemented with Adobe Commerce's GraphQL API
 exposes, thus some of the features available in Adobe Commerce's native frontend
 could not be tackled yet:
 
+#### Advanced shipping methods and online payments aren't fully supported
+
+In its current state, Front-Commerce's module only supports shipping methods without additional information to provide for customers.
+
+The negotiable quote checkout fully supports offline payments such as payment on account, check/money or bank transfer. It only has a partial support for online payments and requires the Magento 2 B2B Front-Commerce module in version [>= 1.2.0](https://gitlab.blackswift.cloud/front-commerce/magento2-b2b-module-front-commerce/-/releases/1.2.0). Stripe is the only supported payment method (since version 2.25.0): please refer to [Stripe's documentation page](/docs/2.x/advanced/payments/stripe#adobe-commerce-b2b) to enable this feature.
+
+Please <ContactLink /> if you have a specific requirement.
+
 #### Negotiable quotes minimum price is not enforced nor exposed in the GraphQL API
 
 Front-Commerce's module allow the creation of negotiable quotes from _any
@@ -178,8 +187,3 @@ However, Front-Commerce doesn't support the per-company feature deactivation.
 The reason is because the information isn't exposed in Magento's API, and company ACLs don't change depending on this option.
 
 As a consequence, it is possible that some users belonging to a company with negotiable quote deactivated (on a shop with the feature globally active) will view some negotiable quotes UI.
-
-#### Advanced shipping methods and online payments aren't supported
-
-In its current state, Front-Commerce's module only supports shipping methods without additional information to provide for customers.
-It also doesn't support online payments, but fully supports offline payments such as: payment on account, bank transfer, etc.


### PR DESCRIPTION
This PR documents Stripe's support for Negotiable Quote implemented in the 2.25 version.

Impacted pages (preview):
- [Migration guide section](https://deploy-preview-688--heuristic-almeida-1a1f35.netlify.app/docs/2.x/appendices/migration-guides/#negotiable-quotes-online-payments)
- [Negotiable quotes "Known issues" section update](https://deploy-preview-688--heuristic-almeida-1a1f35.netlify.app/docs/2.x/magento2/b2b#advanced-shipping-methods-and-online-payments-arent-fully-supported) (I also moved this part first, since it's a quite important limitation to be aware of)
- [Stripe installation update for Adobe B2B use](https://deploy-preview-688--heuristic-almeida-1a1f35.netlify.app/docs/2.x/advanced/payments/stripe#adobe-commerce-b2b)