### PR TITLE
docs: use attribute labels as values

### DIFF
--- a/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
@@ -14,6 +14,32 @@ import TabItem from "@theme/TabItem";
 
 ## `2.24.0` -> `2.25.0`
 
+### Use facet labels as values
+
+To opt-in to using facet labels as values, you must add the following following configuration to your `config/website`:
+
+```js title="config/website.js"
+module.exports = {
+ ...
+  search: {
+    dynamicFacetSize: 10,
+    ignoredAttributeKeys: [],
+    attributeFacetMinimumDocumentCount: 1,
+    authorizedCategoriesFacet: [],
+    categoryFacetMinimumDocumentCount: 1,
+    // add-next-line
+    useAttributeLabels: true,
+  },
+};
+```
+
+This also introduced the new `isUsingIdsForAttributes` method for datasources, if you have custom datasources, 
+you must implement this method. 
+
+If your datasource already uses labels as values the method should return `false`, for example:
+- [Algolia](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/08ab2dd5a9b128592df2b76f1975b061dc2639e0/modules/datasource-algolia/server/datasource/index.js#L193-195) uses labels as values
+- [Elasticsearch](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/08ab2dd5a9b128592df2b76f1975b061dc2639e0/modules/datasource-elasticsearch/server/datasource/index.js#L225-227) uses ids as values
+
 ### Multi shipment enhanced display
 
 :::info

--- a/versioned_docs/version-2.x/reference/configurations.mdx
+++ b/versioned_docs/version-2.x/reference/configurations.mdx
@@ -93,6 +93,8 @@ your website. The term website refers to what a
     that means only category facets leading to at least one document are
     displayed. By setting it to 0, category facets leading to no document are
     also displayed but disabled in the UI.
+  - `useAttributeLabels`: if set to `true`, the attribute labels will be used
+    instead of the attribute codes in the filters. Default value: `false`.
 - `theme-color`: a CSS value that will be used in your layout for a
   `<meta name="theme-color" />`
 - `phoneNumber`: support/contact number of the website


### PR DESCRIPTION
- [Migration Guide](https://deploy-preview-690--heuristic-almeida-1a1f35.netlify.app/docs/2.x/appendices/migration-guides/#use-facet-labels-as-values)
- [Documentation](https://deploy-preview-690--heuristic-almeida-1a1f35.netlify.app/docs/2.x/reference/configurations#configwebsitejs)