### PR TITLE
fix: prettier linting of migration guide

### DIFF
--- a/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
@@ -16,7 +16,8 @@ import TabItem from "@theme/TabItem";
 
 ### Use facet labels as values
 
-To opt-in to using facet labels as values, you must add the following following configuration to your `config/website`:
+To opt-in to using facet labels as values, you must add the following following
+configuration to your `config/website`:
 
 ```js title="config/website.js"
 module.exports = {
@@ -33,12 +34,16 @@ module.exports = {
 };
 ```
 
-This also introduced the new `isUsingIdsForAttributes` method for datasources, if you have custom datasources, 
-you must implement this method. 
+This also introduced the new `isUsingIdsForAttributes` method for datasources,
+if you have custom datasources, you must implement this method.
 
-If your datasource already uses labels as values the method should return `false`, for example:
-- [Algolia](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/08ab2dd5a9b128592df2b76f1975b061dc2639e0/modules/datasource-algolia/server/datasource/index.js#L193-195) uses labels as values
-- [Elasticsearch](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/08ab2dd5a9b128592df2b76f1975b061dc2639e0/modules/datasource-elasticsearch/server/datasource/index.js#L225-227) uses ids as values
+If your datasource already uses labels as values the method should return
+`false`, for example:
+
+- [Algolia](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/08ab2dd5a9b128592df2b76f1975b061dc2639e0/modules/datasource-algolia/server/datasource/index.js#L193-195)
+  uses labels as values
+- [Elasticsearch](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/08ab2dd5a9b128592df2b76f1975b061dc2639e0/modules/datasource-elasticsearch/server/datasource/index.js#L225-227)
+  uses ids as values
 
 ### Multi shipment enhanced display
 
@@ -165,18 +170,28 @@ project.
 
 ### Negotiable Quotes: online payments
 
-In this release, we've added support for a first online payment method ([Stripe](/docs/2.x/advanced/payments/stripe#adobe-commerce-b2b)) to the negotiable quote checkout.
+In this release, we've added support for a first online payment method
+([Stripe](/docs/2.x/advanced/payments/stripe#adobe-commerce-b2b)) to the
+negotiable quote checkout.
 
-To achieve this feature, we had to perform a minor but potentially impactful Breaking Change to the negotiable checkout. The payment method selection step now only performs a single mutation instead of two.
+To achieve this feature, we had to perform a minor but potentially impactful
+Breaking Change to the negotiable checkout. The payment method selection step
+now only performs a single mutation instead of two.
 
-The `setNegotiableQuotePaymentMethod` and `placeNegotiableQuoteOrder` mutations have been merged into `setNegotiableQuotePaymentInformationAndPlaceOrder`.
-Here is [the merge request containing the diff](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2104), so that you can check whether or not your overrides are affected by this change.
+The `setNegotiableQuotePaymentMethod` and `placeNegotiableQuoteOrder` mutations
+have been merged into `setNegotiableQuotePaymentInformationAndPlaceOrder`. Here
+is
+[the merge request containing the diff](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2104),
+so that you can check whether or not your overrides are affected by this change.
 
 To use this feature you need to:
-- update your Magento2 B2B Front-Commerce module to [version 1.2.0+](https://gitlab.blackswift.cloud/front-commerce/magento2-b2b-module-front-commerce/-/releases/1.2.0)
+
+- update your Magento2 B2B Front-Commerce module to
+  [version 1.2.0+](https://gitlab.blackswift.cloud/front-commerce/magento2-b2b-module-front-commerce/-/releases/1.2.0)
 - ensure you haven't overriden theme files impacted with this breaking change
 
 Impacted files:
+
 - `theme/modules/Checkout/NegotiableQuotes/Payment/ChoosePayment.js`
 - `theme/modules/Checkout/NegotiableQuotes/Payment/EnhanceChoosePayment.js`
 - `theme/modules/Checkout/NegotiableQuotes/Payment/SetNegotiableQuotePaymentMethod.gql`
@@ -187,7 +202,11 @@ Impacted files:
 
 :::note
 
-We usually try hard to avoid Breaking Changes. In this context, we decided to remain pragmatic as we knew that this relatively new feature wasn't used by many projects. For this reason, we chose the simplest solution instead of adding complexity with deprecated GraphQL mutations and conditional paths in the checkout. **Please contact us if you need help with this upgrade.**
+We usually try hard to avoid Breaking Changes. In this context, we decided to
+remain pragmatic as we knew that this relatively new feature wasn't used by many
+projects. For this reason, we chose the simplest solution instead of adding
+complexity with deprecated GraphQL mutations and conditional paths in the
+checkout. **Please contact us if you need help with this upgrade.**
 
 :::
 


### PR DESCRIPTION
## What?
This fixes the prettier linting of the migration guide, https://github.com/front-commerce/developers.front-commerce.com/pull/690 was merged while experiencing [this issue](https://github.com/prettier/prettier-vscode/issues/3020), causing other MR's to have unnecessary changes.