### PR TITLE
Migration guide: add the case where the resolver for `Shipment.trackingDetails` is redefined

### DIFF
--- a/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
@@ -99,6 +99,12 @@ Only for Magento 2
 In this version we've added the
 [list of products shipped in each shipments of an order](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2075).
 
+If you've redefined the resolver for `Shipment.trackingDetails`, you must
+synchronize your version to apply [the same kind of change as in the patch
+providing the
+feature](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2075/diffs#diff-content-75bbde141df1d2d7e11f59ac7dcb34eaddd2882f)
+so that `items` is correctly defined in the tracking details.
+
 If you've overridden the `OrderShipmentTrackingFragment.gql` file, you must
 inject a new fragment:
 


### PR DESCRIPTION
Feedback from support where this resolver was redefined than displaying an order was broken