### PR TITLE
fix: sort order for magic-button features

### DIFF
--- a/versioned_docs/version-2.x/magic-button/auto-refresh.mdx
+++ b/versioned_docs/version-2.x/magic-button/auto-refresh.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 title: Auto Refresh
 description:
   With this feature, your data is consistently updated every few seconds,

--- a/versioned_docs/version-2.x/magic-button/preview-mode.mdx
+++ b/versioned_docs/version-2.x/magic-button/preview-mode.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 2
 title: Preview Mode
 description:
   Get a sneak peek of your content's appearance and make necessary changes for
@@ -113,7 +113,7 @@ export default {
 
       return router;
     },
-  }
+  },
 };
 ```
 


### PR DESCRIPTION
## Why?

To follow the same ordering which we use in the Editorial Toolbox