### PR TITLE
Document `PerMagentoCustomerTaxZone` support for Magento1

### DIFF
--- a/src/components/SinceVersion.tsx
+++ b/src/components/SinceVersion.tsx
@@ -17,11 +17,5 @@ export default function SinceVersion(props: SinceVersionProps) {
     return <span>{content}</span>;
   }
 
-  return (
-    <p>
-      <span className="inline-flex items-center rounded-full bg-pink-100 dark:bg-pink-800/50 px-3 py-2 text-xs font-medium text-pink-800 dark:text-pink-200">
-        Since version {props.tag}
-      </span>
-    </p>
-  );
+  return <p>{content}</p>;
 }

--- a/src/components/SinceVersion.tsx
+++ b/src/components/SinceVersion.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 interface SinceVersionProps {
   tag: string;
+  platform?: string;
   inline?: boolean;
 }
 
@@ -9,6 +10,7 @@ export default function SinceVersion(props: SinceVersionProps) {
   const content = (
     <span className="inline-flex items-center rounded-full bg-pink-100 dark:bg-pink-800/50 px-3 py-2 text-xs font-medium text-pink-800 dark:text-pink-200">
       Since version {props.tag}
+      {props.platform ? ` on ${props.platform}` : ""}
     </span>
   );
 

--- a/versioned_docs/version-2.x/advanced/graphql/dataloaders-and-cache-invalidation.mdx
+++ b/versioned_docs/version-2.x/advanced/graphql/dataloaders-and-cache-invalidation.mdx
@@ -535,14 +535,17 @@ export default {
 
 ### `PerMagentoCustomerTaxZone`
 
-<SinceVersion tag="2.14" />
+<p>
+  <SinceVersion tag="2.14" platform="Magento 2" inline />{" "}
+  <SinceVersion tag="2.26" platform="Magento 1" inline />
+</p>
 
 The `PerMagentoCustomerTaxZone` implementation is a decorator that is specific
-to the Magento 2 module. It will decorate the existing caching strategies so
-that DataLoader keys are specific to the current customer's tax zone. We highly
-recommend to use it on Magento stores that have price with taxes depending on
-several tax zones, so they can leverage other caching mechanisms (such as
-`Redis`).
+to the Magento platform (Magento 1 and Magento 2). It will decorate the existing
+caching strategies so that DataLoader keys are specific to the current
+customer's tax zone. We highly recommend to use it on Magento stores that have
+price with taxes depending on several tax zones, so they can leverage other
+caching mechanisms (such as `Redis`).
 
 As such strategy can be complex, the tax zone definition is left to the
 integrator through the `taxZoneKeyFromAddress` function
@@ -571,10 +574,11 @@ export default {
       config: {
         addressType: "shipping", // or "billing" depending on which address is used to define the taxes showed to the user
         defaultTaxZoneKey: "FR",
-        taxZoneKeyFromAddress: (address) => {
-          // see https://docs.magento.com/user-guide/tax/tax-zones-rates.html
-          return "FR"; // default implementation uses the defaultTaxZoneKey value
-        },
+        // Uncomment this line to override the default tax zone partitioning
+        // taxZoneKeyFromAddress: (address) => {
+        //   // see https://docs.magento.com/user-guide/tax/tax-zones-rates.html
+        //   return address.country_id;
+        // },
       },
     },
   ],

--- a/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
@@ -12,6 +12,14 @@ import ContactLink from "@site/src/components/ContactLink";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
+## `2.25.0` -> `2.26.0`
+
+### Features
+
+- **caching:** the `PerMagentoCustomerTaxZone` caching strategy is now also
+  available for Magento 1, to cache prices per tax zone (see
+  [documentation](/docs/2.x/advanced/graphql/dataloaders-and-cache-invalidation#permagentocustomertaxzone))
+
 ## `2.24.0` -> `2.25.0`
 
 ### Updated canonical URL creation method


### PR DESCRIPTION
This MR updates the `PerMagentoCustomerTaxZone` cache strategy documentation to mention the newly introduced support for Magento1 backends.

It also updates the `<SinceVersion />` component, so we could document progressive releases of features per platform.

![2023-07-18_12-43](https://github.com/front-commerce/developers.front-commerce.com/assets/75968/5ff7a25f-e79e-4440-823b-65584705ed18)

**[Preview](https://deploy-preview-709--heuristic-almeida-1a1f35.netlify.app/docs/2.x/advanced/graphql/dataloaders-and-cache-invalidation#permagentocustomertaxzone)** + mention in [Migration guide](https://deploy-preview-709--heuristic-almeida-1a1f35.netlify.app/docs/2.x/appendices/migration-guides/#2250---2260)