### PR TITLE
Document the `npm install` command to upgrade FC in a project

### DIFF
--- a/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
@@ -12,6 +12,17 @@ import ContactLink from "@site/src/components/ContactLink";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
+:::info
+
+To update Front-Commerce in your project, use the command below _(with the exact
+version you need)_:
+
+```
+npm install git+ssh://git@gitlab.blackswift.cloud/front-commerce/front-commerce.git#2.25.0
+```
+
+:::
+
 ## `2.24.0` -> `2.25.0`
 
 ### Updated canonical URL creation method


### PR DESCRIPTION
This PR brings a minor improvement to the Migration guide: it adds a reminder with the command integrators could use to update FC in their project.

It is a command that we're regularly asked about, and it felt to be a good idea to have it here.

**[Preview](https://deploy-preview-713--heuristic-almeida-1a1f35.netlify.app/docs/2.x/appendices/migration-guides/)**