### PR TITLE
chore: add `-` to all Front-Commerce mentions in the doc

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -18,7 +18,7 @@ const LAST_VERSION = "2.x";
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: "Front Commerce Developers",
+  title: "Front-Commerce Developers",
   tagline:
     "Stay one step ahead and consistently deliver the brand experience your customers expect",
   url: "https://developers.front-commerce.com",

--- a/versioned_docs/version-2.x/advanced/features/display-a-map.mdx
+++ b/versioned_docs/version-2.x/advanced/features/display-a-map.mdx
@@ -58,7 +58,7 @@ consistent across different components.
 
     ```js title=".front-commerce.js"
     module.exports = {
-      name: "Front Commerce DEV",
+      name: "Front-Commerce DEV",
       url: "http://www.front-commerce.test",
       modules: [
         // highlight-next-line
@@ -119,7 +119,7 @@ If you don't, you can create one by following
 
    ```js title=".front-commerce.js"
    module.exports = {
-     name: "Front Commerce DEV",
+     name: "Front-Commerce DEV",
      url: "http://www.front-commerce.test",
      modules: [
        // highlight-next-line

--- a/versioned_docs/version-2.x/advanced/features/external-logins/advanced-external-logins.mdx
+++ b/versioned_docs/version-2.x/advanced/features/external-logins/advanced-external-logins.mdx
@@ -227,7 +227,7 @@ do not forget to also register the base `auth-external-login` module.
 
 ```js title=".front-commerce.js"
 module.exports = {
-  name: "Front Commerce DEV",
+  name: "Front-Commerce DEV",
   url: "http://www.front-commerce.test",
   modules: [
     "./node_modules/front-commerce/theme-chocolatine",

--- a/versioned_docs/version-2.x/advanced/features/external-logins/index.mdx
+++ b/versioned_docs/version-2.x/advanced/features/external-logins/index.mdx
@@ -14,7 +14,7 @@ import SinceVersion from "@site/src/components/SinceVersion";
 
 <p>{frontMatter.description}</p>
 
-Front Commerce supports external logins. The API for supporting external logins
+Front-Commerce supports external logins. The API for supporting external logins
 comes in 2 parts:
 
 - The `LoginProvider` which implements the login with the external systems (such
@@ -52,7 +52,7 @@ file:
 
 ```js title="./front-commerce.js"
 module.exports = {
-  name: "Front Commerce DEV",
+  name: "Front-Commerce DEV",
   url: "http://www.front-commerce.test",
   modules: [
     "./node_modules/front-commerce/theme-chocolatine",

--- a/versioned_docs/version-2.x/advanced/shipping/chronorelais.mdx
+++ b/versioned_docs/version-2.x/advanced/shipping/chronorelais.mdx
@@ -38,7 +38,7 @@ Then, within your Front-Commerce project, you have to:
 
   ```javascript title=".front-commerce.js"
   module.exports = {
-    name: "Front Commerce DEV",
+    name: "Front-Commerce DEV",
     url: "http://www.front-commerce.test",
     modules: [
      // highlight-next-line

--- a/versioned_docs/version-2.x/advanced/shipping/colissimo.mdx
+++ b/versioned_docs/version-2.x/advanced/shipping/colissimo.mdx
@@ -34,7 +34,7 @@ Then, within your Front-Commerce project, you have to:
 
 ```diff title=".front-commerce.js"
 module.exports = {
-  name: "Front Commerce DEV",
+  name: "Front-Commerce DEV",
   url: "http://www.front-commerce.test",
   modules: [
 +  "./node_modules/front-commerce/modules/shipping-colissimo-magento2"

--- a/versioned_docs/version-2.x/advanced/shipping/mondial-relay.mdx
+++ b/versioned_docs/version-2.x/advanced/shipping/mondial-relay.mdx
@@ -35,7 +35,7 @@ Then, within your Front-Commerce project, you have to:
 
   ```diff title=".front-commerce.js"
     module.exports = {
-    name: "Front Commerce DEV",
+    name: "Front-Commerce DEV",
     url: "http://www.front-commerce.test",
     modules: [
   + "./node_modules/front-commerce/modules/shipping-mondialrelay"
@@ -95,7 +95,7 @@ Then, within your Front-Commerce project, you have to:
 
   ```diff title=".front-commerce.js"
   module.exports = {
-    name: "Front Commerce DEV",
+    name: "Front-Commerce DEV",
     url: "http://www.front-commerce.test",
     modules: [
   +   "./node_modules/front-commerce/modules/shipping-mondialrelay"

--- a/versioned_docs/version-2.x/appendices/migration-guides/archives.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/archives.mdx
@@ -1975,7 +1975,7 @@ For more information, please have a look at the
 2. Add Front-Commerce's web module to your project in `.front-commerce.js`
    ```diff
    module.exports = {
-     name: "Front Commerce DEV",
+     name: "Front-Commerce DEV",
      url: "http://www.front-commerce.test",
      modules: ["./src"],
      serverModules: [
@@ -1991,7 +1991,7 @@ For more information, please have a look at the
    - Add your own web module to `.front-commerce.js`
      ```diff
      module.exports = {
-       name: "Front Commerce DEV",
+       name: "Front-Commerce DEV",
        url: "http://www.front-commerce.test",
        modules: ["./src"],
        serverModules: [

--- a/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
@@ -429,7 +429,7 @@ ElasticSearch, Algolia or Attraqt), you don't have anything to do.
 
 This version contains improvements to RMA functionality. When updating your
 project, you must also update the
-[Magento2 Commerce - Module Front Commerce to version `2.1.0+`](https://gitlab.blackswift.cloud/front-commerce/magento2-commerce-module-front-commerce/-/releases/2.1.0)
+[Magento2 Commerce - Module Front-Commerce to version `2.1.0+`](https://gitlab.blackswift.cloud/front-commerce/magento2-commerce-module-front-commerce/-/releases/2.1.0)
 
 ```shell
 composer require front-commerce/magento2-commerce-module@2.1.0

--- a/versioned_docs/version-2.x/essentials/add-a-page-client-side.mdx
+++ b/versioned_docs/version-2.x/essentials/add-a-page-client-side.mdx
@@ -88,7 +88,7 @@ resolution at the build level. Then add it as a webModule in your
 
 ```js title="./front-commerce.js"
 module.exports = {
-  name: "Front Commerce DEV",
+  name: "Front-Commerce DEV",
   url: "http://www.front-commerce.test",
   modules: ["./my-module"],
   serverModules: [

--- a/versioned_docs/version-2.x/essentials/add-component-to-storybook.mdx
+++ b/versioned_docs/version-2.x/essentials/add-component-to-storybook.mdx
@@ -201,7 +201,7 @@ the key
 
 ```js title=".front-commerce.js"
 module.exports = {
-  name: "Front Commerce Demo",
+  name: "Front-Commerce Demo",
   url: "https://demo.front-commerce.com",
   modules: ["./my-module"],
   serverModules: [

--- a/versioned_docs/version-2.x/essentials/create-a-business-component.mdx
+++ b/versioned_docs/version-2.x/essentials/create-a-business-component.mdx
@@ -8,7 +8,7 @@ description:
 
 <p>{frontMatter.description}</p>
 
-In Front Commerce we have separated our components in two categories: the
+In Front-Commerce we have separated our components in two categories: the
 [**UI** components](./create-a-ui-component) available in the
 `web/theme/components` folder, and the **Business** components available in the
 `web/theme/modules` and `web/theme/pages` folders.

--- a/versioned_docs/version-2.x/essentials/installation.mdx
+++ b/versioned_docs/version-2.x/essentials/installation.mdx
@@ -75,7 +75,7 @@ the Magento1 module instead of the Magento2 one.
 
 ```diff
 module.exports = {
-  name: "Front Commerce Skeleton",
+  name: "Front-Commerce Skeleton",
   url: "http://localhost:4000",
   modules: ["./src"],
   serverModules: [

--- a/versioned_docs/version-2.x/magento1/advanced.mdx
+++ b/versioned_docs/version-2.x/magento1/advanced.mdx
@@ -39,6 +39,6 @@ Storage button on the top right corner. (see below screenshot for more details).
 
 <BrowserWindow url="http://magento1.localhost.me/admin" fullscreen>
 
-![Clear front commerce cache](./assets/clear-fc-cache.jpg)
+![Clear Front-Commerce cache](./assets/clear-fc-cache.jpg)
 
 </BrowserWindow>

--- a/versioned_docs/version-2.x/magento2/add-new-attribute.mdx
+++ b/versioned_docs/version-2.x/magento2/add-new-attribute.mdx
@@ -55,7 +55,7 @@ Now we will add the module we just made to Front-Commerce. Edit the
 
 ```diff title=".front-commerce.js"
 module.exports = {
-  name: "Front Commerce Skeleton",
+  name: "Front-Commerce Skeleton",
   url: "http://localhost:4000",
 - modules: ["./src"],
 + modules: ["./my-module", "./src"],

--- a/versioned_docs/version-2.x/magento2/advanced.mdx
+++ b/versioned_docs/version-2.x/magento2/advanced.mdx
@@ -147,6 +147,6 @@ There are two ways to clear the magento cache:
 
 <Figure>
 
-![Clear front commerce cache](./assets/clear-fc-cache.jpg)
+![Clear Front-Commerce cache](./assets/clear-fc-cache.jpg)
 
 </Figure>

--- a/versioned_docs/version-2.x/wordpress/installation.mdx
+++ b/versioned_docs/version-2.x/wordpress/installation.mdx
@@ -9,8 +9,8 @@ description:
 
 ## Install
 
-The Front-Commerce Wordpress module lives [in a dedicated
-repository](https://gitlab.blackswift.cloud/front-commerce/front-commerce-wordpress).
+The Front-Commerce Wordpress module lives
+[in a dedicated repository](https://gitlab.blackswift.cloud/front-commerce/front-commerce-wordpress).
 As a result, you first need to install it with npm:
 
 ```shell
@@ -50,7 +50,7 @@ In any case, you also need to enable the `WordPress/Core` module.
 
 ```javascript title=.front-commerce.js
 module.exports = {
-  name: "Front Commerce Skeleton",
+  name: "Front-Commerce Skeleton",
   url: "http://localhost:4000",
   modules: [
     // highlight-next-line


### PR DESCRIPTION
I just found that there was a missing `-` on all pages titles, and ran a quick search/replace in the whole documentation to ensure FC is written with a `-` everywhere.