### PR TITLE
Add a new "Community" page, to centralize community initiatives.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -105,6 +105,7 @@ const config = {
             position: "right",
             label: "Docs",
           },
+          { to: "/community", label: "Community", position: "right" },
           { to: "/blog", label: "Blog", position: "right" },
           { to: "/changelog", label: "Changelog", position: "right" },
           {

--- a/src/pages/community.md
+++ b/src/pages/community.md
@@ -25,25 +25,18 @@ regularly!
 
 ## Extensions
 
-These projects extends Front-Commerce core features using Front-Commerce
+These projects extend Front-Commerce core features using Front-Commerce
 extension points.
 
-### Analytics: Facebook conversions API
+- [Analytics: Facebook conversions API](https://github.com/PH2M/front-commerce-facebook-conversions-api) -
+  PH2M
 
-_Contributor: PH2M_
+  > Implement the
+  > [Facebook conversions API](https://www.facebook.com/business/help/2041148702652965?id=818859032317965)
+  > to your Front-Commerce project
 
-> Implement the
-> [Facebook conversions API](https://www.facebook.com/business/help/2041148702652965?id=818859032317965)
-> to your Front-Commerce project
-
-[View on Github.](https://github.com/PH2M/front-commerce-facebook-conversions-api)
-
-### External login: Apple
-
-_Contributor: PH2M_
-
-> Implement the external login with Apple your Front-Commerce project using
-> [passport-apple](https://www.npmjs.com/package/passport-apple) and following
-> [Front-Commerce documentation](/docs/2.x/advanced/features/external-logins/)
-
-[View on Github.](https://github.com/PH2M/front-commerce-external-login-apple)
+- [External login: Apple](https://github.com/PH2M/front-commerce-external-login-apple) -
+  PH2M
+  > Implement the external login with Apple in your Front-Commerce project using
+  > [passport-apple](https://www.npmjs.com/package/passport-apple) and following
+  > [Front-Commerce documentation](/docs/2.x/advanced/features/external-logins/)

--- a/src/pages/community.md
+++ b/src/pages/community.md
@@ -1,0 +1,49 @@
+---
+title: Community
+description:
+  This page contains a curated list of interesting Front-Commerce community
+  projects and resources.
+---
+
+# Community
+
+<p>{frontMatter.description}</p>
+
+import ContactLink from "@site/src/components/ContactLink";
+
+Please <ContactLink>let us know</ContactLink> if you want to share a project
+here.
+
+## Examples
+
+For common tasks, or more specific examples, check the
+[community-driven examples repository](https://github.com/front-commerce/examples).
+
+Contribute examples of patterns you proved to be useful in your Front-Commerce
+projects there. The Front-Commerce support team also contributes new examples
+regularly!
+
+## Extensions
+
+These projects extends Front-Commerce core features using Front-Commerce
+extension points.
+
+### Analytics: Facebook conversions API
+
+_Contributor: PH2M_
+
+> Implement the
+> [Facebook conversions API](https://www.facebook.com/business/help/2041148702652965?id=818859032317965)
+> to your Front-Commerce project
+
+[View on Github.](https://github.com/PH2M/front-commerce-facebook-conversions-api)
+
+### External login: Apple
+
+_Contributor: PH2M_
+
+> Implement the external login with Apple your Front-Commerce project using
+> [passport-apple](https://www.npmjs.com/package/passport-apple) and following
+> [Front-Commerce documentation](/docs/2.x/advanced/features/external-logins/)
+
+[View on Github.](https://github.com/PH2M/front-commerce-external-login-apple)


### PR DESCRIPTION
This PR adds a new "Community" page in the header navigation menu.

This page allows to centralize all known community projects, in order to:
- increase discoverability of "non-core" features
- highlight teams and individuals who contribute to our community

**[Preview](https://deploy-preview-715--heuristic-almeida-1a1f35.netlify.app/community)**

![2023-08-01_18-05](https://github.com/front-commerce/developers.front-commerce.com/assets/75968/2ddbcce7-87b8-4723-b37a-a77608b25d23)
