### PR TITLE
Migration guide: Add an explicit note about resolvers override for label as values

### DIFF
--- a/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
@@ -77,6 +77,16 @@ module.exports = {
 };
 ```
 
+:::note Check your customizations
+
+This change was implemented by modifying the `Category.layer` and
+`AttributeBucket.value` resolvers. If you've rewritten them with a custom logic,
+you'll have to update your code accordingly. Check
+[the Merge Request](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2069)
+for more details.
+
+:::
+
 This also introduced the new `isUsingIdsForAttributes` method for datasources,
 if you have custom datasources, you must implement this method.
 


### PR DESCRIPTION
This PR adds an admonition to the 2.25 migration guide section about using labels as values.

When upgrading, an integrator required support because they haven't thought about updating their resolvers ([conversation](https://app.intercom.com/a/inbox/ehgzoeah/inbox/shared/all/conversation/188350900000936?view=List)). Having custom logic for layers isn't such uncommon, and it makes sense to add a note a bit more explicit so integrators could autonomously update their codebase.

**[Preview](https://deploy-preview-721--heuristic-almeida-1a1f35.netlify.app/docs/2.x/appendices/migration-guides/#use-facet-labels-as-values)**