### PR TITLE
fix: Changed wording on netive search for magento1 and magento2

### DIFF
--- a/versioned_docs/version-2.x/magento1/search-engine.mdx
+++ b/versioned_docs/version-2.x/magento1/search-engine.mdx
@@ -24,9 +24,10 @@ platforms:
 
 ## Native search
 
-Front-Commerce supports searching using the native Magento API for category
-listing pages. Please <ContactLink /> if your store uses a custom Magento search
-implementation to see how to make it work in your Front-Commerce project.
+Front-Commerce supports browsing products using the native Magento API for
+category listing pages. Please <ContactLink /> if your store uses a custom
+Magento search implementation to see how to make it work in your Front-Commerce
+project.
 
 ## Elasticsearch
 


### PR DESCRIPTION
Following [this intercom ticket](https://app.intercom.com/a/inbox/ehgzoeah/inbox/shared/mentions/conversation/188350900000904?view=List), we noticed the documentation could be confusing as to what feature exactly was usable natively with magento1 and  magento2.