### PR TITLE
feat(metadata): adding HomeSeo and generateMetas migration

### DIFF
--- a/docs/api-reference/front-commerce-remix/generate-metas.mdx
+++ b/docs/api-reference/front-commerce-remix/generate-metas.mdx
@@ -1,0 +1,33 @@
+---
+title: "generateMetas"
+sidebar_position: 3
+description: "Generate Meta tags for your Front-Commerce site."
+---
+
+The `generateMetas` helper will generate metadatas for your site.
+
+The main features of this helper are :
+
+- Merge metadata with parents Metadata (defined in the parent routes /
+  `root.tsx`)
+- Will allow easier canonical generation
+
+:::tip
+We highly recommend you to use this helper as it will make your life
+easier when using nested routes. However you can still use the
+[standard Remix Meta method](https://remix.run/docs/en/main/route/meta-v2)
+:::
+
+## Usage
+
+- The first parametes is a [Remix V2 Meta Function](https://remix.run/docs/en/main/route/meta-v2#meta-function-parameters)
+- The second parameter is the canonical path (base url will be automatically injected)
+
+```jsx
+import generateMetas from "@front-commerce/remix/generateMetas";
+
+export const meta: V2_MetaFunction = (args) => {
+  const metas = generateMetas(() => [{ title: "Welcome home" }], "/");
+  return metas(args);
+};
+```

--- a/docs/migration/manual-migration.mdx
+++ b/docs/migration/manual-migration.mdx
@@ -11,6 +11,21 @@ This manual migration process should be run after the
 [automated migration process](./automated-migration), to complete the missing
 parts, or debug issues in the migration CLI output.
 
+## Components
+
+### SEO Components
+
+The `xxxSeo` components (eg: `HomeSeo`) have been removed in favor of
+[Remix Meta](https://remix.run/docs/en/main/route/meta-v2).
+
+If you use SEO components or have overriden Seo components, you need to:
+
+- Remove import and usage of the component from your page
+- Use the [meta](https://remix.run/docs/en/main/route/meta-v2)
+  function with our
+  [generateMetas helper](/docs/remixed/api-reference/front-commerce-remix/generate-metas) 
+  to inject your custom metadatas in your Route Module.
+
 ## `makeCommandDispatcherWithCommandFeedback` API change
 
 [`makeCommandDispatcherWithCommandFeedback` API has


### PR DESCRIPTION
This PR introduce migration for the HomeSeo component removal and explain the `generateMetas` helper