### PR TITLE
chore: add documentation for the createResizedImageResponse

### DIFF
--- a/docs/api-reference/front-commerce-core/_category_.yml
+++ b/docs/api-reference/front-commerce-core/_category_.yml
@@ -1,0 +1,5 @@
+label: "@front-commerce/core"
+position: 1
+link:
+  type: doc
+  id: index

--- a/docs/api-reference/front-commerce-core/create-resized-image-response.mdx
+++ b/docs/api-reference/front-commerce-core/create-resized-image-response.mdx
@@ -30,7 +30,7 @@ that will fetch an image from a remote service.
 
 To do so, we will introduce the `createResizedImageResponse` function.
 
-```ts title="/app/routes/media.prismic.$.ts"
+```ts title="/app/routes/media.picsum.$.ts"
 import type { LoaderArgs } from "@remix-run/node";
 // highlight-next-line
 import { createResizedImageResponse } from "@front-commerce/core/resizedImage.server";

--- a/docs/api-reference/front-commerce-core/create-resized-image-response.mdx
+++ b/docs/api-reference/front-commerce-core/create-resized-image-response.mdx
@@ -1,0 +1,116 @@
+---
+title: "createResizedImageResponse"
+sidebar_position: 2
+description:
+  "The createResizedImageResponse allows to create custom loaders which allow
+  resizing and caching images on the fly."
+---
+
+The `createResizedImageResponse` allows to create custom loaders which allow
+resizing and caching images on the fly.
+
+## Usage
+
+The `createResizedImageResponse` function has 3 parameters:
+
+- `request`:The request to handle.
+- `fetchRemoteImage`: A function that returns the image buffer.
+- `cacheConfig`: The optional
+  [cache configuration](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/fdcbea5288ca66b12e4c839653bcbe033114a3e9/packages/core/resized-image/createResizedImageResponse.ts#L17-22)
+  which handles the caching of an image
+
+This can be used to serve images either from a remote service, or from a local
+file system, next we will see examples for both cases.
+
+### Remote image
+
+For this example, we will create a
+[splat route](https://remix.run/docs/en/1.19.3/file-conventions/route-files-v2#splat-routes)
+that will fetch an image from a remote service.
+
+To do so, we will introduce the `createResizedImageResponse` function.
+
+```ts title="/app/routes/media.prismic.$.ts"
+import type { LoaderArgs } from "@remix-run/node";
+// highlight-next-line
+import { createResizedImageResponse } from "@front-commerce/core/resizedImage.server";
+
+// highlight-start
+const fetchRemoteImage = async (imagePath: string) => {
+  const image = await fetch(`https://picsum.photos/${imagePath}`);
+  return image.arrayBuffer();
+};
+// highlight-end
+
+const loader = async ({ request, params }: LoaderArgs) => {
+  const imagePath = params["*"] as string;
+
+  const ONE_WEEK = 7 * 24 * 60 * 60; // the default cache duration is set to one year
+
+  // highlight-start
+  return createResizedImageResponse(
+    request,
+    () => fetchRemoteImage(imagePath),
+    {
+      cacheDuration: ONE_YEAR,
+    }
+  );
+  // highlight-end
+};
+```
+
+:::info
+
+When we visit the `/media/picsum/200/300.jpg?format=large&extension=webp` route,
+the image will be retrieved from the `https://picsum.photos/200/300` URL and
+resized to the same size defined in your images config for the `large` format,
+and it will be converted to a `webp` image.
+
+:::
+
+### Local image
+
+For this example, we will create a new route that will fetch an image from a
+local directory
+
+```ts title="/app/routes/media.local.$.ts"
+import type { LoaderArgs } from "@remix-run/node";
+import { createResizedImageResponse } from "@front-commerce/core/resizedImage.server";
+// highlight-next-line
+import fs from "fs";
+
+// highlight-start
+const fetchLocalImage = (relativePath: string) => {
+  try {
+    return fs.readFileSync(relativePath);
+  } catch (error) {
+    console.error(error);
+    throw new Response("Image not found", { status: 404 });
+  }
+};
+// highlight-end
+
+const loader = async ({ request, params }: LoaderArgs) => {
+  const imagePath = params["*"] as string;
+
+  const relativePath = path.resolve(
+    process.cwd(),
+    `public/images/${imagePath}`
+  );
+
+  // highlight-start
+  return createResizedImageResponse(request, () =>
+    fetchLocalImage(relativePath)
+  );
+  // highlight-end
+};
+```
+
+:::info
+
+When we visit the `/media/local/my-image.jpg?format=large&extension=webp` route,
+the image will be retrieved from the `public/images/my-image.jpg` file and
+resized to the same size defined in your images config for the `large` format,
+and it will be converted to a `webp` image.
+
+:::

--- a/docs/api-reference/front-commerce-core/create-resized-image-response.mdx
+++ b/docs/api-reference/front-commerce-core/create-resized-image-response.mdx
@@ -6,7 +6,7 @@ description:
   resizing and caching images on the fly."
 ---
 
-The `createResizedImageResponse` allows to create custom loaders which allow
+The `createResizedImageResponse` allows to create [resource routes](https://remix.run/docs/en/1.19.3/guides/resource-routes) which allow
 resizing and caching images on the fly.
 
 ## Usage

--- a/docs/api-reference/front-commerce-core/index.mdx
+++ b/docs/api-reference/front-commerce-core/index.mdx
@@ -1,0 +1,14 @@
+---
+title: "@front-commerce/core"
+description:
+  "This package contains the core implementations used in a Front-Commerce
+  project."
+---
+
+<p>{frontMatter.description}</p>
+
+## Installation
+
+```bash
+$ pnpm install @front-commerce/core@latest
+```

--- a/docs/migration/manual-migration.mdx
+++ b/docs/migration/manual-migration.mdx
@@ -21,28 +21,33 @@ The `xxxSeo` components (eg: `HomeSeo`) have been removed in favor of
 If you use SEO components or have overriden Seo components, you need to:
 
 - Remove import and usage of the component from your page
-- Use the [meta](https://remix.run/docs/en/main/route/meta-v2)
-  function with our
+- Use the [meta](https://remix.run/docs/en/main/route/meta-v2) function with our
   [generateMetas helper](/docs/remixed/api-reference/front-commerce-remix/generate-metas)
   to inject your custom metadatas in your Route Module.
 
 ### Refactor pages to Remix routes
 
-Page `Enhancer` HOC usually were responsible for data loading in `2.x`. As we now embrace [Remix Server/Client Model](https://remix.run/docs/en/main/pages/philosophy#serverclient-model), 
-page enhancers must be removed in favor of [Remix route loaders](https://remix.run/docs/en/main/route/loader).
+Page `Enhancer` HOC usually were responsible for data loading in `2.x`. As we
+now embrace
+[Remix Server/Client Model](https://remix.run/docs/en/main/pages/philosophy#serverclient-model),
+page enhancers must be removed in favor of
+[Remix route loaders](https://remix.run/docs/en/main/route/loader).
 
-You can see an example in the [category route file](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/skeleton/app/routes/category.%24id.tsx) on
-how the data loading is now used with the `loader` method.
+You can see an example in the
+[category route file](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/skeleton/app/routes/category.%24id.tsx)
+on how the data loading is now used with the `loader` method.
 
 You need to pay attention to two thing if you've overriden this file :
 
 - Did you update the query to fetch category?
 
-We now recommend you to update the GraphQL query used in category route and pass down any new props to the Category component.
+We now recommend you to update the GraphQL query used in category route and pass
+down any new props to the Category component.
 
 - Did you added more HOC to the `Enhancer`?
 
-You can either add your custom HOC to the `Category` component or replace HOC with hooks if relevant.
+You can either add your custom HOC to the `Category` component or replace HOC
+with hooks if relevant.
 
 ## `makeCommandDispatcherWithCommandFeedback` API change
 
@@ -136,7 +141,8 @@ $min: breakpoint-min("sm");
 }
 ```
 
-For cases where you were using the `media-breakpoint-up`, you can use a media query with `min-width` too. For example:
+For cases where you were using the `media-breakpoint-up`, you can use a media
+query with `min-width` too. For example:
 
 **Before:**
 
@@ -430,3 +436,15 @@ Other optional variables updated:
 | `FRONT_COMMERCE_MAGENTO_TIMEOUT`       | `FRONT_COMMERCE_MAGENTO1_TIMEOUT`       | `FRONT_COMMERCE_MAGENTO2_TIMEOUT`       |
 | `FRONT_COMMERCE_MAGENTO_ADMIN_TIMEOUT` | `FRONT_COMMERCE_MAGENTO1_ADMIN_TIMEOUT` | `FRONT_COMMERCE_MAGENTO2_ADMIN_TIMEOUT` |
 | `FRONT_COMMERCE_XRAY_MAGENTO_VERSION`  | `FRONT_COMMERCE_XRAY_MAGENTO1_VERSION`  | :x: N/A                                 |
+
+## `makeImageProxyRouter` → `createResizedImageResponse`
+
+The `makeImageProxyRouter` function has been removed in favor of the new
+`createResizedImageResponse` function. You can read more about the
+implementation details in the
+[`createResizedImageResponse` documentation](/docs/remixed/api-reference/front-commerce-core/create-resized-image-response).
+
+All images which are located under `public/images/resized/*` should now be moved
+to `public/images/*`. This will allow for the
+[`/images/resized/*` resource route](https://remix.run/docs/en/1.19.3/guides/resource-routes)
+to be reserved for the new `createResizedImageResponse` function.


### PR DESCRIPTION
### Documents

https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2377

### Preview

 - https://deploy-preview-738--heuristic-almeida-1a1f35.netlify.app/docs/remixed/api-reference/front-commerce-core/create-resized-image-response
 - https://deploy-preview-738--heuristic-almeida-1a1f35.netlify.app/docs/remixed/migration/manual-migration#makeimageproxyrouter--createresizedimageresponse