### PR TITLE
fix: version banner for future remixed docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -61,6 +61,7 @@ const config = {
               label: "Remixed 🚧",
               path: "remixed",
               noIndex: true, // TODO dont index until we are ready to launch
+              banner: "unreleased",
             },
             "2.x": {
               label: "2.x",


### PR DESCRIPTION
### What?

This fixes the banner which is displayed at the top of the docs for the `remixed` version

### Example

| Before | After  |
| ------- | ------ |
| ![image](https://github.com/front-commerce/developers.front-commerce.com/assets/39598117/e8ecb791-1e68-42e0-8080-ae8a71404fd2) | ![image](https://github.com/front-commerce/developers.front-commerce.com/assets/39598117/53a98f56-c679-4694-aa4c-f031962b2332) |