### PR TITLE
fix: Apple Pay only show up on Apple devices

### DIFF
--- a/versioned_docs/version-2.x/advanced/payments/adyen.mdx
+++ b/versioned_docs/version-2.x/advanced/payments/adyen.mdx
@@ -529,7 +529,7 @@ The following payment methods have been tested:
 - Paypal
 - Klarna (Pay now, Pay over time, Pay later)
 - Google Pay
-- Apple Pay
+- Apple Pay (only shown when using Safari on an Apple device)
 - Sofort
 - Alipay Magento 2 module
 - iDeal


### PR DESCRIPTION
related to a recent support request.

It should have been documented after merging [this MR](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/1775).