### PR TITLE
feat(magento2): update supported magento version

### DIFF
--- a/versioned_docs/version-2.x/appendices/release-notes.mdx
+++ b/versioned_docs/version-2.x/appendices/release-notes.mdx
@@ -14,7 +14,7 @@ description:
 Compatible with:
 
 - **Node.js:**: 16.13+ or 18.12+
-- **Magento2**: 2.4.4 -> 2.4.5-p4 (Open Source & Commerce & B2B)
+- **Magento2**: 2.4.4 -> 2.4.6-p2 (Open Source & Commerce & B2B)
 - **Magento1**: CE 1.7+, EE 1.12+,
   [OpenMage LTS](https://www.openmage.org/supported-versions.html) 19.4+
 

--- a/versioned_docs/version-2.x/magento2/installation.mdx
+++ b/versioned_docs/version-2.x/magento2/installation.mdx
@@ -23,6 +23,13 @@ Magento 2.4.3 requires [an Adobe official patch](https://experienceleague.adobe.
 
 :::
 
+:::caution
+
+To use Magento >= 2.4.6 you need at least version 2.9.4 of the Front-Commerce
+Magento2 Module
+
+:::
+
 ## Install with composer
 
 ```shell


### PR DESCRIPTION
# What

This MR updates the minimum supported version of Magento2 and the minimum FC Module version

# Preview

[Added warn about minimum module version](https://deploy-preview-743--heuristic-almeida-1a1f35.netlify.app/docs/2.x/magento2/installation#module-compatibility)

[Updated compatible version](https://deploy-preview-743--heuristic-almeida-1a1f35.netlify.app/docs/2.x/appendices/release-notes#latest-version)