### PR TITLE
Document withCartTracking deprecation

### DIFF
--- a/docs/migration/manual-migration.mdx
+++ b/docs/migration/manual-migration.mdx
@@ -146,6 +146,15 @@ const MyComponent = () => {
 }
 ```
 
+#### `withCartTracking` replaced with `useCartTracking`
+
+The page-based HOC `withCartTracking` has been completely removed, in favor of a
+new `useCartTracking` hook.
+
+If you used this HOC in your code, you will have to replace it by calling
+`useCartTracking` in the component the HOC was previously used on.
+`useCartTracking` only takes the cart as parameter.
+
 ## `makeCommandDispatcherWithCommandFeedback` API change
 
 [`makeCommandDispatcherWithCommandFeedback` API has changed](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/2cc5515682349ca0f1b1aba922a277db27ad067c?merge_request_iid=2200).


### PR DESCRIPTION
This MR document the deprecation (removal) of `withCartTracking` HOC, replaced by `useCartTracking` hook.

[Related MR](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2416)

[Preview](https://deploy-preview-745--heuristic-almeida-1a1f35.netlify.app/docs/remixed/migration/manual-migration#withcarttracking-replaced-with-usecarttracking)
