### PR TITLE
chore: fix `code` tag alignment

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -118,3 +118,7 @@ video.video-cover:not(:fullscreen) {
 kbd {
   white-space: nowrap;
 }
+
+code {
+  vertical-align: baseline;
+}


### PR DESCRIPTION
## What?
This fixes the alignment on html `code` tags.

## Example

https://github.com/front-commerce/developers.front-commerce.com/assets/39598117/76524ce0-8e1c-43d2-8fa0-fd2b1a59043a

