### PR TITLE
Document FRONT_COMMERCE_STRIPE_MAX_NETWORK_RETRY

### DIFF
--- a/versioned_docs/version-2.x/advanced/payments/stripe.mdx
+++ b/versioned_docs/version-2.x/advanced/payments/stripe.mdx
@@ -182,3 +182,33 @@ See the tests for an example (while a detailed documentation is being written):
 
 - https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/3c550dfa0142dde7da3761011379118612841de7/src/server/modules/payment-stripe/__tests__/loader.js#L77
 - https://gitlab.blackswift.cloud/front-commerce/front-commerce/blob/3c550dfa0142dde7da3761011379118612841de7/src/server/modules/payment-stripe/__tests__/loader.js#L147
+
+### Advanced: network retries
+
+<SinceVersion tag="2.27" />
+
+Optionally the environment variable `FRONT_COMMERCE_STRIPE_MAX_NETWORK_RETRY`
+can be set to an integer [to configure the Stripe client `maxNetworkRetries`
+option](https://github.com/stripe/stripe-node#network-retries). In versions
+where this variable is supported, `maxNetworkRetries` is configured to `3` by
+default.
+
+:::note
+
+Support for this environment variable has also been added in
+[2.26.1](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.26.1),
+[2.25.3](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.25.3),
+[2.24.5](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.24.5),
+[2.23.6](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.23.6),
+[2.22.7](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.22.7),
+[2.21.8](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.21.8),
+[2.20.10](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.20.10)
+and
+[2.19.16](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.19.16)
+releases.
+
+:::
+
+```shell title=".env"
+FRONT_COMMERCE_STRIPE_MAX_NETWORK_RETRY=5
+```

--- a/versioned_docs/version-2.x/reference/environment-variables.mdx
+++ b/versioned_docs/version-2.x/reference/environment-variables.mdx
@@ -356,6 +356,15 @@ for further details.
 See
 [our dedicated documentation page](/docs/2.x/advanced/payments/buybox#configure-your-environment).
 
+### Stripe
+
+- `FRONT_COMMERCE_STRIPE_SECRET_KEY`
+- `FRONT_COMMERCE_WEB_STRIPE_PUBLISHABLE_KEY`
+- `FRONT_COMMERCE_STRIPE_DISABLE_CAPTURE`
+- `FRONT_COMMERCE_STRIPE_MAX_NETWORK_RETRY`
+
+See [Stripe documentation page for details](/docs/2.x/advanced/payments/stripe).
+
 ### Capency
 
 See


### PR DESCRIPTION
Documentation for FRONT_COMMERCE_STRIPE_MAX_NETWORK_RETRY introduced in https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2468 (also added stripe env variables to https://developers.front-commerce.com/docs/2.x/reference/environment-variables).

https://deploy-preview-754--heuristic-almeida-1a1f35.netlify.app/docs/2.x/advanced/payments/stripe#advanced-network-retries