### PR TITLE
Improve exposing additional attribute page example

### DIFF
--- a/versioned_docs/version-2.x/magento1/exposing-additional-attributes.mdx
+++ b/versioned_docs/version-2.x/magento1/exposing-additional-attributes.mdx
@@ -23,7 +23,7 @@ add this attribute on your `api2.xml` file.
 
 For that, you need to retrieve resource name (API_UNIQUE_NAME value if you
 follow the basic structure shown in "Add custom endpoint section") and add your
-attribute(s) into the `attributes` node.
+attribute(s) code into the `attributes` node.
 
 ## Retrieve the resource name
 
@@ -31,8 +31,8 @@ You can find this data on all `api2.xml` files.
 
 ## Update your `api2.xml` file
 
-In this section you will learn how to expose a `custom_attribute` for the most
-common Magento resources.
+In this section you will learn how to expose an attribute which code is
+`my_custom_attribute` for the most common Magento resources.
 
 ### Customer data
 
@@ -44,7 +44,7 @@ It can be achieved with the following XML instructions:
  <resources>
     <customer>
         <attributes>
-            <custom_attribute />
+            <my_custom_attribute />
         </attributes>
     </customer>
 </resources>
@@ -61,7 +61,7 @@ It can be achieved with the following XML instructions:
  <resources>
     <product>
         <attributes>
-            <custom_attribute />
+            <my_custom_attribute />
         </attributes>
     </product>
 </resources>
@@ -78,7 +78,7 @@ It can be achieved with the following XML instructions:
  <resources>
     <category>
         <attributes>
-            <custom_attribute />
+            <my_custom_attribute />
         </attributes>
     </category>
 </resources>


### PR DESCRIPTION
Make clear that `custom_attribute` is an example by renaming it and writing it.