### PR TITLE
Bad loggingService import path

### DIFF
--- a/versioned_docs/version-2.x/advanced/production-ready/logging.mdx
+++ b/versioned_docs/version-2.x/advanced/production-ready/logging.mdx
@@ -157,7 +157,7 @@ By doing this, you've configured your logger. But you still need to use it by
 importing the `loggingService` that will let you create the logger.
 
 ```js
-import loggingService from "server/express/loggingService";
+import loggingService from "server/core/logs/loggingService";
 
 const logger = loggingService.createLogger("myLoggerName");
 ```


### PR DESCRIPTION
Try on version 2.20, but the path for import loggingService is invalid, we need to use `server/core/logs/loggingService`