### PR TITLE
fix: spelling from `@loadable/component`

### DIFF
--- a/docs/migration/manual-migration.mdx
+++ b/docs/migration/manual-migration.mdx
@@ -632,7 +632,7 @@ will now need to move it the
 [`meta` function](https://remix.run/docs/en/1.19.3/route/meta-v2#meta-v2) of the
 route.
 
-## `@loadable/comoonent` removal
+## `@loadable/component` removal
 
 `@loadable/component` is no longer a dependency of Front-Commerce. That means
 components that were previously made _loadable_ are now loaded synchronously as


### PR DESCRIPTION
Fixes `comoonent` -> `component`