### PR TITLE
chore: update docs to reference remix v2

### DIFF
--- a/docs/04-api-reference/front-commerce-core/create-resized-image-response.mdx
+++ b/docs/04-api-reference/front-commerce-core/create-resized-image-response.mdx
@@ -7,8 +7,8 @@ description:
 ---
 
 The `createResizedImageResponse` allows to create
-[resource routes](https://remix.run/docs/en/2.0.1/guides/resource-routes) which
-allow resizing and caching images on the fly.
+[resource routes](https://remix.run/docs/en/2.0.1/guides/resource-routes#creating-resource-routes)
+which allow resizing and caching images on the fly.
 
 ## Usage
 
@@ -26,13 +26,13 @@ file system, next we will see examples for both cases.
 ### Remote image
 
 For this example, we will create a
-[splat route](https://remix.run/docs/en/1.19.3/file-conventions/route-files-v2#splat-routes)
+[splat route](https://remix.run/docs/en/2.0.1/file-conventions/routes#splat-routes)
 that will fetch an image from a remote service.
 
 To do so, we will introduce the `createResizedImageResponse` function.
 
 ```ts title="/app/routes/media.picsum.$.ts"
-import type { LoaderArgs } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/node";
 // highlight-next-line
 import { createResizedImageResponse } from "@front-commerce/core/resizedImage.server";
 
@@ -43,7 +43,7 @@ const fetchRemoteImage = async (imagePath: string) => {
 };
 // highlight-end
 
-const loader = async ({ request, params }: LoaderArgs) => {
+const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const imagePath = params["*"] as string;
 
   const ONE_WEEK = 7 * 24 * 60 * 60; // the default cache duration is set to one year
@@ -75,7 +75,7 @@ For this example, we will create a new route that will fetch an image from a
 local directory
 
 ```ts title="/app/routes/media.local.$.ts"
-import type { LoaderArgs } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/node";
 import { createResizedImageResponse } from "@front-commerce/core/resizedImage.server";
 // highlight-next-line
 import fs from "fs";
@@ -91,7 +91,7 @@ const fetchLocalImage = (relativePath: string) => {
 };
 // highlight-end
 
-const loader = async ({ request, params }: LoaderArgs) => {
+const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const imagePath = params["*"] as string;
 
   const relativePath = path.resolve(

--- a/docs/04-api-reference/front-commerce-remix/front-commerce-app.mdx
+++ b/docs/04-api-reference/front-commerce-remix/front-commerce-app.mdx
@@ -66,10 +66,10 @@ Exposes the graphql client.
 - `mutate` - Executes a graphql mutation.
 
 ```ts
-import { LoadingFunctionArgs, ActionFunctionArgs } from "@remix-run/node";
+import { LoaderFunctionArgs, ActionFunctionArgs } from "@remix-run/node";
 import { FrontCommerceApp } from "@front-commerce/remix";
 
-export const loader = ({ context }: LoadingFunctionArgs) => {
+export const loader = ({ context }: LoaderFunctionArgs) => {
   const app = new FrontCommerceApp(context.frontCommerce);
 
   // highlight-start

--- a/docs/04-api-reference/front-commerce-remix/generate-metas.mdx
+++ b/docs/04-api-reference/front-commerce-remix/generate-metas.mdx
@@ -12,21 +12,22 @@ The main features of this helper are:
   `root.tsx`)
 - Will allow easier canonical generation
 
-:::tip
-We highly recommend you to use this helper as it will make your life
+:::tip We highly recommend you to use this helper as it will make your life
 easier when using nested routes. However you can still use the
-[standard Remix Meta method](https://remix.run/docs/en/main/route/meta-v2)
-:::
+[standard Remix Meta method](https://remix.run/docs/en/main/route/meta-v2) :::
 
 ## Usage
 
-- The first parameter is a [Remix V2 Meta Function](https://remix.run/docs/en/main/route/meta-v2#meta-function-parameters)
-- The second parameter is the canonical path (base url will be automatically injected)
+- The first parameter is a
+  [Remix V2 Meta Function](https://remix.run/docs/en/main/route/meta#meta-function-parameters)
+- The second parameter is the canonical path (base url will be automatically
+  injected)
 
 ```typescript
+import { MetaFunction } from "@remix-run/node";
 import { generateMetas } from "@front-commerce/remix/node";
 
-export const meta: V2_MetaFunction = (args) => {
+export const meta: MetaFunction = (args) => {
   const metas = generateMetas(() => [{ title: "Welcome home" }], "/");
   return metas(args);
 };

--- a/docs/04-api-reference/front-commerce-remix/index.mdx
+++ b/docs/04-api-reference/front-commerce-remix/index.mdx
@@ -16,12 +16,19 @@ $ pnpm install @front-commerce/remix@latest
 
 ## Type Safety
 
-You can get type safety over the network for your loaders with
+You can get type safety over the network for your loaders with <<<<<<<
+HEAD:docs/04-api-reference/front-commerce-remix/index.mdx
 [LoaderFunctionArgs](https://remix.run/docs/en/2.0.1/route/loader#loader) and
-for your actions with
-[ActionFunctionArgs](https://remix.run/docs/en/2.0.1/route/action#action). To
-ensure that the typed frontCommerce context is in the arguments, you can add the
-`@front-commerce/remix` reference to your `remix.env.d.ts` file.
+for your actions with =======
+[LoaderFunctionArgs](https://remix.run/docs/en/2.0.1/route/loader#type-safety)
+and for your actions with
+
+> > > > > > > 00cf530 (chore: update docs to reference remix
+> > > > > > > v2):docs/api-reference/front-commerce-remix/index.mdx
+> > > > > > > [ActionFunctionArgs](https://remix.run/docs/en/2.0.1/route/action#action).
+> > > > > > > To ensure that the typed frontCommerce context is in the
+> > > > > > > arguments, you can add the `@front-commerce/remix` reference to
+> > > > > > > your `remix.env.d.ts` file.
 
 ```ts title="remix.env.d.ts"
 /// <reference types="@remix-run/dev" />
@@ -93,10 +100,10 @@ SerializeObject<UndefinedToOptional<{ foo: "bar"; date: string }>>;
 ## Front-Commerce Context
 
 To ensure the Front-Commerce Context is available in your loaders and actions,
-it needs to be added to the
+you need to add the `createFrontCommerceContext` to your server via the
 [`getLoadContext`](https://remix.run/docs/en/2.0.1/route/loader#context), to do
-this you can use the `createFrontCommerceContext` method from in your
-[`server.ts`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/b6e60a53aad662ec87f83cb8dd6d581f8bf13e91/skeleton/server.ts)
+this, update your
+[`server.ts`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/b99f0475ce494591a54fdc2b904e956a083e9b51/skeleton/server.ts)
 
 ```ts
 // add-start

--- a/docs/migration/manual-migration.mdx
+++ b/docs/migration/manual-migration.mdx
@@ -623,7 +623,7 @@ implementation details in the
 
 All images which are located under `public/images/resized/*` should now be moved
 to `public/images/*`. This will allow for the
-[`/images/resized/*` resource route](https://remix.run/docs/en/1.19.3/guides/resource-routes)
+[`/images/resized/*` resource route](https://remix.run/docs/en/2.0.1/guides/resource-routes)
 to be reserved for the new `createResizedImageResponse` function.
 
 ## Removal of `SmartLayout` component
@@ -638,7 +638,7 @@ This is can be retrieved via a loader: _see example in
 [`_main.tsx` layout](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/1237955dda56451bf50b507c1cdd0a703ea32795/skeleton/app/routes/_main.tsx)_
 
 ```tsx title="app/routes/_main.tsx"
-export const loader = async ({ context }: LoaderArgs) => {
+export const loader = async ({ context }: LoaderFunctionArgs) => {
   const app = new FrontCommerceApp(context.frontCommerce);
   const headerResponse = await app.graphql.query(HeaderQueryDocument, {
     name: "data",
@@ -660,8 +660,7 @@ export const loader = async ({ context }: LoaderArgs) => {
 In version 3, `react-helmet-async` has been removed as it does not make sense in
 a remix application. If you used this in any custom components or pages, you
 will now need to move it the
-[`meta` function](https://remix.run/docs/en/1.19.3/route/meta-v2#meta-v2) of the
-route.
+[`meta` function](https://remix.run/docs/en/2.0.1/route/meta) of the route.
 
 ## Client side log handler removal
 
@@ -691,7 +690,7 @@ project.
 In version 3, `CartSeo` has been removed as it is not used by the base theme
 anymore. If you overrode this component or one using it, you will need to move
 any of the customisation to the `cart` route
-[`meta` function](https://remix.run/docs/en/1.19.3/route/meta-v2#meta-v2).
+[`meta` function](https://remix.run/docs/en/2.0.1/route/meta).
 
 ## `EmptyCart` refactor
 


### PR DESCRIPTION
## What
This updates our documentation to reference remix v2

## Related
- https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2559
- https://remix.run/docs/en/2.0.1/start/v2