### PR TITLE
Document `useDevice()` removal

### DIFF
--- a/docs/migration/manual-migration.mdx
+++ b/docs/migration/manual-migration.mdx
@@ -746,3 +746,12 @@ adapt it in your code:
   [MR](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2582))
 - `EnhanceAddToCartModal` (see
   [MR](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2586))
+
+## `useDevice()` removal
+
+We removed the `useDevice()` hook in version 3.0. It was unused in the base
+theme, and we had no use cases in mind for it.
+
+Device information are still available in the configuration. Access it using
+`config.device`. Please contact us if you have a use case we don't support
+anymore.


### PR DESCRIPTION
This MR documents the removal done in https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/8ddc943ba38d7a71a4e8830c60de4330bf1818a1

**[Preview](https://deploy-preview-766--heuristic-almeida-1a1f35.netlify.app/docs/remixed/migration/manual-migration#usedevice-removal)**