### PR TITLE
doc: fix link to syle customization on css variables reference page

### DIFF
--- a/docs/03-extensions/theme-chocolatine/reference/css-variables.mdx
+++ b/docs/03-extensions/theme-chocolatine/reference/css-variables.mdx
@@ -11,7 +11,7 @@ Front-Commerce's theme Chocolatine uses a set of CSS variables defined in
 `theme/_variables.scss` to ensure a certain consistency in the application's
 design. We recommend to reuse these variables as much as possible, and adapting
 them to your project's design choices. See
-[Override a stylesheet](/docs/remixed/guides/override-a-stylesheet) for more
+[Customize the styles](/docs/remixed/guides/customize-the-styles) for more
 details about adapting your application to your brand.
 
 ## Colors


### PR DESCRIPTION
# What

This PR update a link in css variables references in theme-chocolatine to style customization