### PR TITLE
Added required Magento 1 module version for Review feature.

### DIFF
--- a/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
@@ -23,6 +23,14 @@ npm install git+ssh://git@gitlab.blackswift.cloud/front-commerce/front-commerce.
 
 :::
 
+## `2.26.0` -> `2.27.0`
+
+### Magento1: Reviews
+
+In this release, we added the ability to see and publish product reviews for
+Magento1. However, you will need to update your Front-Commerce Magento1 module
+to version 1.6.0 or above for this feature to work.
+
 ## `2.25.0` -> `2.26.0`
 
 ### Requisition List UID Update

--- a/versioned_docs/version-2.x/magento1/installation.mdx
+++ b/versioned_docs/version-2.x/magento1/installation.mdx
@@ -223,6 +223,12 @@ For more security add a random key on `frontcommerce_secret_key` in your
 
 <SinceVersion tag="2.27" />
 
+:::info
+
+This feature requires Front-Commerce Magento 1 module version 1.6.0 or higher.
+
+:::
+
 Front-Commerce, by default, uses only one review "rating", named `"main"`. Those
 are configured in Magento1's back office under
 `Catalog > Reviews and Ratings > Manage Ratings`. If your project uses more than


### PR DESCRIPTION
Following https://github.com/front-commerce/developers.front-commerce.com/pull/803, this MR adds the required Magento1 module version to the feature's documentation.