### PR TITLE
3.1/2.27 release chores

### DIFF
--- a/changelog/front-commerce-3.1-2.27.mdx
+++ b/changelog/front-commerce-3.1-2.27.mdx
@@ -217,7 +217,8 @@ was important to highlight the main fixes brought to all versions._
 
 <ChangelogFooter>
 
-Upgrade Front-Commerce (Migration guides): 3.1.0 or
+Upgrade Front-Commerce (Migration guides):
+[3.1.0](/docs/remixed/upgrade/migration-guides/3.0-3.1) or
 [2.27.0](/docs/2.x/appendices/migration-guides#2260---2270)<br /> Read the full
 changelog (Customers only):
 [3.1.0](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/3.1.0)

--- a/docs/100-upgrade/_category_.yml
+++ b/docs/100-upgrade/_category_.yml
@@ -1,0 +1,9 @@
+label: Upgrade
+collapsible: false
+collapsed: false
+position: 5
+link:
+  type: generated-index
+  description:
+    This section contains documentation about our releases and how to upgrade
+    your application to the latest version of Front-Commerce.

--- a/docs/100-upgrade/migration-guides/3.0-3.1.mdx
+++ b/docs/100-upgrade/migration-guides/3.0-3.1.mdx
@@ -1,0 +1,23 @@
+---
+title: 3.0 -> 3.1
+description:
+  This page lists the highlights for upgrading a project from Front-Commerce 3.0
+  to 3.1.
+---
+
+<p>{frontMatter.description}</p>
+
+## Update dependencies
+
+Update all your `@front-commerce/*` dependencies to this version:
+
+```shell
+pnpm update "@front-commerce/\*@3.1.0"
+```
+
+## Code changes
+
+There is no specific code changes for this upgrade.
+
+We have already contacted most projects using early versions of Front-Commerce
+3.0 during alpha releases.

--- a/docs/100-upgrade/migration-guides/_category_.yml
+++ b/docs/100-upgrade/migration-guides/_category_.yml
@@ -1,0 +1,3 @@
+label: Migration guides
+collapsible: true
+position: 2

--- a/docs/100-upgrade/release-notes.mdx
+++ b/docs/100-upgrade/release-notes.mdx
@@ -1,0 +1,50 @@
+---
+title: Release notes
+description:
+  This page lists the changes between each Front-Commerce minor release.
+sidebar_position: 1
+---
+
+<p>{frontMatter.description}</p>
+
+## Latest version
+
+**Front-Commerce [`3.1.0`](#310-2023-11-20)**
+
+Compatible with:
+
+- **Node.js:**: ^18.12.0 or ^20.0.0
+- **Magento2**: 2.4.4 -> 2.4.6-p3 (Open Source & Commerce & B2B)
+- **Magento1**: CE 1.7+, EE 1.12+,
+  [OpenMage LTS](https://www.openmage.org/supported-versions.html) 19.4+
+
+## 3.1.0 (2023-11-20)
+
+> This update includes several core stabilization fixes, a new PWA assets
+> generation API, `useCart` and `useCustomer` hooks and Magento2 order
+> filtering. It also features Attraqt Datasource Compatibility for Magento1,
+> extended support for product reviews to Magento1, and facets order
+> customization for Magento1. Additionally, the update improves the performance
+> of adding multiple items to the cart in Magento2, particularly beneficial for
+> Adobe Commerce B2B projects
+
+- [Announcement](/changelog/front-commerce-3.1-2.27/)
+- [Migration guide](/docs/remixed/upgrade/migration-guides/3.0-3.1)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/3.1.0)
+
+## 3.0.0 (2023-09-28)
+
+> We are excited to introduce Front-Commerce 3.0, a big leap forward in
+> e-commerce development. With a focus on web performance, developer experience,
+> and adherence to web standards, this release is set to redefine how you
+> approach building your online storefronts.
+>
+> Front-Commerce is a storefront for headless commerce based on the newly
+> released Remix v2 framework. We're bringing all the goodness we developed over
+> the past 7 years, to the Remix ecosystem.
+>
+> In this release, we've merged both technologies to enhance the experience for
+> end users and developers alike.
+
+- [Announcement](/changelog/front-commerce-3.0/)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/3.0.0)

--- a/docs/migration/_category_.yml
+++ b/docs/migration/_category_.yml
@@ -1,5 +1,5 @@
 label: Migrating from v2
-position: 5
+position: 1000
 collapsible: true
 link:
   type: generated-index

--- a/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
@@ -18,7 +18,7 @@ To update Front-Commerce in your project, use the command below _(with the exact
 version you need)_:
 
 ```
-npm install git+ssh://git@gitlab.blackswift.cloud/front-commerce/front-commerce.git#2.26.0
+npm install git+ssh://git@gitlab.blackswift.cloud/front-commerce/front-commerce.git#2.27.0
 ```
 
 :::
@@ -33,8 +33,8 @@ to version 1.6.0 or above for this feature to work.
 
 ### New features in `2.27.0`
 
-* [An optimized implementation of `addMultipleItemsToCart` mutation for Magento2](/docs/2.x/magento2/advanced#optimized-add-multiple-products-to-the-cart)
-* [Review support for Magento1](/docs/2.x/magento1/installation#reviews-configuration)
+- [An optimized implementation of `addMultipleItemsToCart` mutation for Magento2](/docs/2.x/magento2/advanced#optimized-add-multiple-products-to-the-cart)
+- [Review support for Magento1](/docs/2.x/magento1/installation#reviews-configuration)
 
 ## `2.25.0` -> `2.26.0`
 

--- a/versioned_docs/version-2.x/appendices/release-notes.mdx
+++ b/versioned_docs/version-2.x/appendices/release-notes.mdx
@@ -9,14 +9,25 @@ description:
 
 ## Latest version
 
-**Front-Commerce [`2.26.3`](#2260-2023-08-17)**
+**Front-Commerce [`2.27.0`](#2270-2023-11-20)**
 
 Compatible with:
 
 - **Node.js:**: 16.13+ or 18.12+
-- **Magento2**: 2.4.4 -> 2.4.6-p2 (Open Source & Commerce & B2B)
+- **Magento2**: 2.4.4 -> 2.4.6-p3 (Open Source & Commerce & B2B)
 - **Magento1**: CE 1.7+, EE 1.12+,
   [OpenMage LTS](https://www.openmage.org/supported-versions.html) 19.4+
+
+## 2.27.0 (2023-11-20)
+
+> This update includes Attraqt Datasource Compatibility for Magento1, extended
+> support for product reviews to Magento1, and facets order customization for
+> Magento1. Additionally, the update improves the performance of adding multiple
+> items to the cart in Magento2, particularly beneficial for Adobe Commerce B2B
+> projects
+
+- [Announcement](/changelog/front-commerce-3.1-2.27/)
+- [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/2.27.0)
 
 ## 2.26.0 (2023-08-17)
 


### PR DESCRIPTION
This PR does the following:
- update release notes for 2.27
- create new "Upgrade" section in the 3.x documentation, with Release notes and Migration guides

I decided to keep Migration guide pages separated for each versions in order to make them easier to manage.