### PR TITLE
chore: document lifecycle hooks in extensions

### DIFF
--- a/docs/04-api-reference/front-commerce-core/defineExtension.mdx
+++ b/docs/04-api-reference/front-commerce-core/defineExtension.mdx
@@ -117,3 +117,29 @@ Example:
   "translations": "./extensions/acme/translations"
 }
 ```
+
+### `unstable_lifecycleHooks`
+
+:::caution
+
+This feature is unstable and may change in the future.
+
+:::
+
+_Optional_
+
+Specifies the lifecycle hooks that should be executed by the application. These
+hooks allow you to register custom logic at specific points of the application
+lifecycle.
+
+Example:
+
+```js
+{
+  unstable_lifecycleHooks: {
+    onServerServicesInit: async (services, request, config) => {
+      // Do something with the services
+    };
+  }
+}
+```


### PR DESCRIPTION
## What?
This documents the `lifecycleHooks` in extensions config.

## Next?
- Migrate Magic Button documentation
- Document registration for content metadata extractor
  