### PR TITLE
fix: Fixed link in Adyen documentation

### DIFF
--- a/versioned_docs/version-2.x/advanced/payments/adyen.mdx
+++ b/versioned_docs/version-2.x/advanced/payments/adyen.mdx
@@ -386,18 +386,23 @@ currently support any version from
 :::tip
 
 If you were using Adyen with Magento2 without Front-Commerce, don't forget to
-check Adyen settings. For instance, make sure [allowed origins set the step
-1](https://docs.adyen.com/plugins/adobe-commerce/set-up-adyen-customer-area/?tab=manual_2)
+check Adyen settings. For instance, make sure
+[allowed origins set the step 1](https://docs.adyen.com/plugins/adobe-commerce/set-up-adyen-customer-area/?tab=manual_2)
 match you setup with Front-Commerce.
 
 :::
 
-You must configure the extension's Headless/PWA settings with your Front-Commerce URL **for each of your stores**.
-Settings [changed in version 8.0.0](https://github.com/Adyen/adyen-magento2/releases/tag/8.0.0), so it will be slightly different depending on your version.
+You must configure the extension's Headless/PWA settings with your
+Front-Commerce URL **for each of your stores**. Settings
+[changed in version 8.0.0](https://github.com/Adyen/adyen-magento2/releases/tag/8.0.0),
+so it will be slightly different depending on your version.
+
 - `< 8`: configure "Payment Origin URL" in the `Advanced: PWA` section
-- `>= 8`: configure  `Advanced settings > Headless Integration` with
-  - Payment Origin URL: your Front-Commerce URL (e.g: [http://localhost:4000/](http://localhost:4000/))
-  - Payment Return URL: the `/adyen/process/result` path (e.g: [http://localhost:4000/adyen/process/result](http://localhost:4000/adyen/process/result))
+- `>= 8`: configure `Advanced settings > Headless Integration` with
+  - Payment Origin URL: your Front-Commerce URL (e.g:
+    [http://localhost:4000/](http://localhost:4000/))
+  - Payment Return URL: the `/adyen/process/result` path (e.g:
+    [http://localhost:4000/adyen/process/result](http://localhost:4000/adyen/process/result))
   - Custom Success Redirect Path: same value as Payment Return URL
 
 :::info important
@@ -456,7 +461,7 @@ FRONT_COMMERCE_ADYEN_STORE_PAYMENT_DETAILS=true
 
 ### Register your Adyen payment components
 
-[Same as above](#register-the-adyen-payment-module-in-front-commerce-1)
+[Same as above](#register-your-adyen-payment-components)
 
 ### Update your CSPs
 


### PR DESCRIPTION
This MR fixes a link in Adyen installation documentation page.

[Preview](https://github.com/front-commerce/developers.front-commerce.com/pull/820#issue-2034948493)