### PR TITLE
Mark 3.x as official documentation and activate it by default

### DIFF
--- a/blog/2023-advent-calendar/03-how-to-create-a-new-front-commerce-project.mdx
+++ b/blog/2023-advent-calendar/03-how-to-create-a-new-front-commerce-project.mdx
@@ -119,8 +119,8 @@ pnpm dlx create-remix hello-front-commerce --template https://new.front-commerce
 ```
 
 **Please follow our detailed
-[Installation page](/docs/remixed/get-started/installation)** if you want to try
-it out.
+[Installation page](/docs/3.x/get-started/installation)** if you want to try it
+out.
 
 :::info Transition period
 

--- a/changelog/front-commerce-2.24.mdx
+++ b/changelog/front-commerce-2.24.mdx
@@ -8,12 +8,15 @@ image: ./assets/2.24/stripe-payment-screen.jpg
 
 ## Apple Pay & Google Pay support for Stripe, Akamai Image Manager and first alpha versions of Front-Commerce Remixed
 
-Front-Commerce 2.24 is out. As usual, it contains features requested by customers and continuous improvements.
-The key features of this release are Akamai Image Manager and payment wallets support for our Stripe connector.
+Front-Commerce 2.24 is out. As usual, it contains features requested by
+customers and continuous improvements. The key features of this release are
+Akamai Image Manager and payment wallets support for our Stripe connector.
 
-We've also been busy working on Front-Commerce Remixed, and are excited to share this progress with you!
+We've also been busy working on Front-Commerce Remixed, and are excited to share
+this progress with you!
 
-☕ Read on to learn more about these updates and as always, should you have any requests regarding the product roadmap, do not hesitate to contact us 👋
+☕ Read on to learn more about these updates and as always, should you have any
+requests regarding the product roadmap, do not hesitate to contact us 👋
 
 <!-- truncate -->
 
@@ -21,82 +24,149 @@ import ChangelogFooter from "@site/src/components/ChangelogFooter";
 import BackportList from "@site/src/components/BackportList";
 import ContactLink from "@site/src/components/ContactLink";
 
-
 ## Stripe update: Apple Pay & Google Pay support
 
-In this release, we added support for Apple Pay and Google Pay wallets in our [Stripe payment integration.](/docs/2.x/advanced/payments/stripe)
+In this release, we added support for Apple Pay and Google Pay wallets in our
+[Stripe payment integration.](/docs/2.x/advanced/payments/stripe)
 
 ![Checkout payment step with Stripe card payment selected](assets/2.24/stripe-payment-screen.jpg)
 
-Users can now easily pay for their purchases using their preferred mobile payment method. This feature is seamlessly integrated into the payment process, providing a smooth and efficient transaction experience.
+Users can now easily pay for their purchases using their preferred mobile
+payment method. This feature is seamlessly integrated into the payment process,
+providing a smooth and efficient transaction experience.
 
-
-We also took this as an opportunity to update Stripe dependencies to their latest version.
+We also took this as an opportunity to update Stripe dependencies to their
+latest version.
 
 ## Akamai Image Manager support
 
-After Cloudinary and TwicPics, we ensured our Front-Commerce component could be used with [Akamai Image Manager](https://www.akamai.com/products/image-and-video-manager).
+After Cloudinary and TwicPics, we ensured our Front-Commerce component could be
+used with
+[Akamai Image Manager](https://www.akamai.com/products/image-and-video-manager).
 
-Akamai Image Manager optimizes website images for faster delivery and improved website performance. Images are cached on Akamai's global network of servers and optimized automatically for every user and any device.
+Akamai Image Manager optimizes website images for faster delivery and improved
+website performance. Images are cached on Akamai's global network of servers and
+optimized automatically for every user and any device.
 
-Image Manager chooses the optimal format based on the user device and bandwidth and compresses images without degrading quality.
+Image Manager chooses the optimal format based on the user device and bandwidth
+and compresses images without degrading quality.
 
-As for other image adapters, using Akamai Image Manager doesn't require any code change. [Follow our documentation](/docs/2.x/advanced/images-adapters/akamai-image-manager) to configure it in your application.
+As for other image adapters, using Akamai Image Manager doesn't require any code
+change.
+[Follow our documentation](/docs/2.x/advanced/images-adapters/akamai-image-manager)
+to configure it in your application.
 
 :::note
 
-**About Front-Commerce Cloud:** Image Manager isn't enabled by default for Front-Commerce Cloud customers using the Akamai <abbr title="Content Delivery Network">CDN</abbr>. Please <ContactLink>contact us</ContactLink> if you want to use this service in your project.
+**About Front-Commerce Cloud:** Image Manager isn't enabled by default for
+Front-Commerce Cloud customers using the Akamai
+<abbr title="Content Delivery Network">CDN</abbr>. Please <ContactLink>contact
+us</ContactLink> if you want to use this service in your project.
 
 :::
 
 ## Front-Commerce Remixed saw its first (technical) alpha versions
 
-As announced [in our previous changelog entry](/changelog/front-commerce-2.23#the-front-commerce-dj-team-has-started-to-remix-it), our `main` branch is now active with work on the Front-Commerce Remixed upcoming release.
+As announced
+[in our previous changelog entry](/changelog/front-commerce-2.23#the-front-commerce-dj-team-has-started-to-remix-it),
+our `main` branch is now active with work on the Front-Commerce Remixed upcoming
+release.
 
-We tagged 3 `alpha` versions as we made progress on core features and repository reorganization. It still isn't ready for you to play with, but we're getting closer!
+We tagged 3 `alpha` versions as we made progress on core features and repository
+reorganization. It still isn't ready for you to play with, but we're getting
+closer!
 
 Here are the highlights of these versions if you want to stay in the loop.
 
 ### Deprecated code in `2.x` versions was removed
 
-In [our `3.0.0-alpha.0` release](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/3.0.0-alpha.0), we've finalized the removal of all deprecated code since our  `2.0` version (almost 4 years ago!).
+In
+[our `3.0.0-alpha.0` release](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/3.0.0-alpha.0),
+we've finalized the removal of all deprecated code since our `2.0` version
+(almost 4 years ago!).
 
 More than 7K lines were removed across more than 250 files! 😅
 
-Notable removals include the *legacy analytics* implementation and components. For an exhaustive list, please refer to [our migration guide](/docs/remixed/migration/deprecated-code-removal).
+Notable removals include the _legacy analytics_ implementation and components.
+For an exhaustive list, please refer to
+[our migration guide](/docs/3.x/migration/deprecated-code-removal).
 
-We've also taken this as an opportunity to [rename Magento environment variables prefix](/docs/remixed/migration/manual-migration#magento) to include the platform version number: `FRONT_COMMERCE_MAGENTO_*` becomes either `FRONT_COMMERCE_MAGENTO1_*` or `FRONT_COMMERCE_MAGENTO2_*`.
+We've also taken this as an opportunity to
+[rename Magento environment variables prefix](/docs/3.x/migration/manual-migration#magento)
+to include the platform version number: `FRONT_COMMERCE_MAGENTO_*` becomes
+either `FRONT_COMMERCE_MAGENTO1_*` or `FRONT_COMMERCE_MAGENTO2_*`.
 
 ### A new repository layout was introduced
 
-Front-Commerce is composed of several parts. In versions `2.x` developers installed everything at once, as a single dependency.
+Front-Commerce is composed of several parts. In versions `2.x` developers
+installed everything at once, as a single dependency.
 
-In FC Remixed, we've decided to switch to a monorepo layout (using `pnpm` workspaces) and split the `front-commerce` dependency into discrete packages that could be distributed through an NPM registry (e.g: `@front-commerce/core`, `@front-commerce/magento2`, `@front-commerce/adyen` …).
+In FC Remixed, we've decided to switch to a monorepo layout (using `pnpm`
+workspaces) and split the `front-commerce` dependency into discrete packages
+that could be distributed through an NPM registry (e.g: `@front-commerce/core`,
+`@front-commerce/magento2`, `@front-commerce/adyen` …).
 
-The Front-Commerce *skeleton* is also back into our main repository, and will be distributed as a [Remix Stack](https://remix.run/docs/en/main/pages/stacks) so you could start a Front-Commerce project with a single command! It is a standard Remix/TypeScript/Express application with Front-Commerce core and tooling already configured.
+The Front-Commerce _skeleton_ is also back into our main repository, and will be
+distributed as a [Remix Stack](https://remix.run/docs/en/main/pages/stacks) so
+you could start a Front-Commerce project with a single command! It is a standard
+Remix/TypeScript/Express application with Front-Commerce core and tooling
+already configured.
 
-For more details, customers can read our [monorepo <abbr title="Architecture Decision Record">ADR</abbr>](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/docs/adr/0007-monorepo-distribution-tooling.md) along with our [Front-Commerce as Remix extensions <abbr title="Architecture Decision Record">ADR</abbr>](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/docs/adr/0008-front-commerce-as-remix-extensions.md).
+For more details, customers can read our
+[monorepo <abbr title="Architecture Decision Record">ADR</abbr>](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/docs/adr/0007-monorepo-distribution-tooling.md)
+along with our
+[Front-Commerce as Remix extensions <abbr title="Architecture Decision Record">ADR</abbr>](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/docs/adr/0008-front-commerce-as-remix-extensions.md).
 
 ### `@front-commerce/compat`: our promise to Front-Commerce projects
 
-In [3.0.0-alpha.1](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/3.0.0-alpha.1#front-commercecompat) and [3.0.0-alpha.2](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/3.0.0-alpha.2#front-commercecompat), we focused on our key core packages. One of the most important for all our customers is the `@front-commerce/compat` package.
+In
+[3.0.0-alpha.1](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/3.0.0-alpha.1#front-commercecompat)
+and
+[3.0.0-alpha.2](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/3.0.0-alpha.2#front-commercecompat),
+we focused on our key core packages. One of the most important for all our
+customers is the `@front-commerce/compat` package.
 
-This package will contain all the code needed to progressively migrate a project started on Front-Commerce `2.x` to Front-Commerce Remixed, and then benefit from all the improvements it brings!
+This package will contain all the code needed to progressively migrate a project
+started on Front-Commerce `2.x` to Front-Commerce Remixed, and then benefit from
+all the improvements it brings!
 
-In these releases, we've added an initial version of our **Codemods** scripts which will allow us to [automate every migration step](/docs/remixed/migration/automated-migration) that can be automated (import changes, conventions…).
+In these releases, we've added an initial version of our **Codemods** scripts
+which will allow us to
+[automate every migration step](/docs/3.x/migration/automated-migration) that
+can be automated (import changes, conventions…).
 
-We've also added `@front-commerce/compat/recompose` utility functions to replace the unmaintained `recompose` library we heavily used in our components before hooks were announced. This package is compatible with React 18 (which isn't the case of other forks).
+We've also added `@front-commerce/compat/recompose` utility functions to replace
+the unmaintained `recompose` library we heavily used in our components before
+hooks were announced. This package is compatible with React 18 (which isn't the
+case of other forks).
 
 ### Front-Commerce as Remix extensions
 
-We want Front-Commerce projects to be Remix projects. For this reason, we've [decided to build Front-Commerce Remixed as Remix extensions](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/docs/adr/0008-front-commerce-as-remix-extensions.md). In [`3.0.0-alpha.2`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/3.0.0-alpha.2#front-commercecompat) we implemented the fundamental pieces of this integration:
+We want Front-Commerce projects to be Remix projects. For this reason, we've
+[decided to build Front-Commerce Remixed as Remix extensions](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/docs/adr/0008-front-commerce-as-remix-extensions.md).
+In
+[`3.0.0-alpha.2`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/3.0.0-alpha.2#front-commercecompat)
+we implemented the fundamental pieces of this integration:
 
-- A new [`FrontCommerceApp` class](/docs/remixed/api-reference/front-commerce-remix/front-commerce-app) that will be the main way to interact with the Front-Commerce application domain, mostly through GraphQL. This class should be constructed in each Remix `loader` and `action`, and allows developers to run GraphQL requests and mutations and access information about the current context (user, configurations etc…).
-- It is a core component of our `@front-commerce/remix` package, containing all the glue between the agnostic `@front-commerce/*` packages and the Remix framework.
-- The `@front-commerce/remix` package also serves [a GraphQL playground](/docs/remixed/api-reference/front-commerce-remix/graphql-playground) in development mode. It is based on the latest GraphiQL version (bye-bye GraphQL playground 👋). For the most curious: Front-Commerce Remixed GraphQL server stack is now based on `envelop` and `yoga`!
+- A new
+  [`FrontCommerceApp` class](/docs/3.x/api-reference/front-commerce-remix/front-commerce-app)
+  that will be the main way to interact with the Front-Commerce application
+  domain, mostly through GraphQL. This class should be constructed in each Remix
+  `loader` and `action`, and allows developers to run GraphQL requests and
+  mutations and access information about the current context (user,
+  configurations etc…).
+- It is a core component of our `@front-commerce/remix` package, containing all
+  the glue between the agnostic `@front-commerce/*` packages and the Remix
+  framework.
+- The `@front-commerce/remix` package also serves
+  [a GraphQL playground](/docs/3.x/api-reference/front-commerce-remix/graphql-playground)
+  in development mode. It is based on the latest GraphiQL version (bye-bye
+  GraphQL playground 👋). For the most curious: Front-Commerce Remixed GraphQL
+  server stack is now based on `envelop` and `yoga`!
 
-More is coming in the next weeks, with the introduction of the Front-Commerce CLI, Front-Commerce Extensions, GraphQL Codegen and of course… the first modules! Stay tuned.
-
+More is coming in the next weeks, with the introduction of the Front-Commerce
+CLI, Front-Commerce Extensions, GraphQL Codegen and of course… the first
+modules! Stay tuned.
 
 ## Other changes
 
@@ -106,8 +176,9 @@ More is coming in the next weeks, with the introduction of the Front-Commerce CL
 ```
 
 - **csp:** we added support for more CSP directives in CSP configurations
-- **image:** image adapters can now customize extension types generated in each element. It allows to adapt to each service image delivery and supported image types
-
+- **image:** image adapters can now customize extension types generated in each
+  element. It allows to adapt to each service image delivery and supported image
+  types
 
 ```mdx-code-block
 </details>
@@ -118,11 +189,18 @@ More is coming in the next weeks, with the introduction of the Front-Commerce CL
   <summary><h3 className="mb-0">Bug Fixes</h3></summary>
 ```
 
-- **external-logins:** improved redirection URLs generation to prevent double slashes in their path
-- **image:** ensured Image adapters are registered with a predictable name to prevent having different adapters used between SSR and hydration
-- **magento1:** the *"use buildBuckets() method instead"* deprecation warnings is not incorrectly displayed anymore on category layer when the cache is enabled
-- **prismic:** avoided cache corruption edge cases by removing Prismic reference TTL
-- **search:** search results are now resilient to incorrect page identifiers returned by search datasources. Not found pages are ignored to prevent crashes.
+- **external-logins:** improved redirection URLs generation to prevent double
+  slashes in their path
+- **image:** ensured Image adapters are registered with a predictable name to
+  prevent having different adapters used between SSR and hydration
+- **magento1:** the _"use buildBuckets() method instead"_ deprecation warnings
+  is not incorrectly displayed anymore on category layer when the cache is
+  enabled
+- **prismic:** avoided cache corruption edge cases by removing Prismic reference
+  TTL
+- **search:** search results are now resilient to incorrect page identifiers
+  returned by search datasources. Not found pages are ignored to prevent
+  crashes.
 
 ```mdx-code-block
 </details>
@@ -133,7 +211,8 @@ More is coming in the next weeks, with the introduction of the Front-Commerce CL
   <summary><h3 className="mb-0">Performance Improvements</h3></summary>
 ```
 
-- **i18n:** translations are not duplicated anymore in chunks. It should reduce the amount of Javascript served to users.
+- **i18n:** translations are not duplicated anymore in chunks. It should reduce
+  the amount of Javascript served to users.
 
 ```mdx-code-block
 </details>

--- a/changelog/front-commerce-3.1-2.27.mdx
+++ b/changelog/front-commerce-3.1-2.27.mdx
@@ -219,7 +219,7 @@ was important to highlight the main fixes brought to all versions._
 <ChangelogFooter>
 
 Upgrade Front-Commerce (Migration guides):
-[3.1.0](/docs/remixed/upgrade/migration-guides/3.0-3.1) or
+[3.1.0](/docs/3.x/upgrade/migration-guides/3.0-3.1) or
 [2.27.0](/docs/2.x/appendices/migration-guides#2260---2270)<br /> Read the full
 changelog (Customers only):
 [3.1.0](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/3.1.0)

--- a/docs/01-get-started/installation.mdx
+++ b/docs/01-get-started/installation.mdx
@@ -203,7 +203,7 @@ export default defineConfig({
 :::info
 
 Learn more about
-[configuring the Magento2 extension](/docs/remixed/extensions/magento2/) and the
+[configuring the Magento2 extension](/docs/3.x/extensions/magento2/) and the
 prerequisites.
 
 :::
@@ -218,7 +218,7 @@ FRONT_COMMERCE_COOKIE_PASS=cookie-secret
 FRONT_COMMERCE_SITEMAP_TOKEN=sitemap-secret
 FRONT_COMMERCE_CACHE_API_TOKEN=cache-api-secret
 
-# Magento2 configuration (see https://developers.front-commerce.com/docs/remixed/extensions/magento2#configuration)
+# Magento2 configuration (see https://developers.front-commerce.com/docs/3.x/extensions/magento2#configuration)
 FRONT_COMMERCE_MAGENTO2_ENDPOINT=https://magento2.example.com
 FRONT_COMMERCE_MAGENTO2_CONSUMER_KEY=xxxxxxxxx
 FRONT_COMMERCE_MAGENTO2_CONSUMER_SECRET=xxxxxxxxx

--- a/docs/02-guides/customize-the-styles.mdx
+++ b/docs/02-guides/customize-the-styles.mdx
@@ -52,7 +52,7 @@ and atoms under its `theme/components/atoms` subdirectory.
 :::tip
 
 For example, files for
-[theme-chocolatine](/docs/remixed/extensions/theme-chocolatine/), will be in
+[theme-chocolatine](/docs/3.x/extensions/theme-chocolatine/), will be in
 [`@front-commerce/theme-chocolatine/theme`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/packages/theme-chocolatine/theme)
 
 The theme-chocolatine will be used as an example for this guide
@@ -217,5 +217,5 @@ existing to your convenience. However, that is not the only benefit of having a
 Design System already in place. It is actually a perfect canvas to help you
 creating new components and styles matching to your brand.
 
-See the [override component guide](/docs/remixed/guides/override-a-component) to
+See the [override component guide](/docs/3.x/guides/override-a-component) to
 learn more about this.

--- a/docs/02-guides/extend-the-graphql-schema.mdx
+++ b/docs/02-guides/extend-the-graphql-schema.mdx
@@ -42,7 +42,7 @@ export default function clickCounter() {
 ```
 
 Then you need to
-[register the extension into your Front-Commerce project](/docs/remixed/guides/register-an-extension).
+[register the extension into your Front-Commerce project](/docs/3.x/guides/register-an-extension).
 
 ## Add a GraphQL module within the extension
 

--- a/docs/02-guides/override-a-component.mdx
+++ b/docs/02-guides/override-a-component.mdx
@@ -20,7 +20,7 @@ iterate from there.
 **Theme override is what allows you to:**
 
 - customize existing themes:
-  - [theme-chocolatine](/docs/remixed/extensions/theme-chocolatine/)
+  - [theme-chocolatine](/docs/3.x/extensions/theme-chocolatine/)
 - upgrade Front-Commerce and benefit from the latest component improvements.
 - or create a slightly different theme for events like Black Friday with
   confidence!
@@ -73,8 +73,8 @@ your custom theme!
 ### In your own extension
 
 You can also extend theme in your extension, please read
-[Register an extension](/docs/remixed/guides/register-an-extension) guide to
-know how to create your own extension.
+[Register an extension](/docs/3.x/guides/register-an-extension) guide to know
+how to create your own extension.
 
 First in your extension definition file, add the `theme` entry:
 
@@ -107,7 +107,7 @@ The original file is:
 :::info
 
 Please refer to the
-[Front-Commerce’s folder structure documentation page](/docs/remixed/concepts/react-components-structure)
+[Front-Commerce’s folder structure documentation page](/docs/3.x/concepts/react-components-structure)
 to get a better understanding of how components are organized in the base theme.
 
 :::
@@ -127,8 +127,8 @@ component use data fetched by a GraphQL request, we need to update this fragment
 to add the data we want to the request.
 
 We invite you to read the
-[request data flow](/docs/remixed/concepts/a-request-data-flow) to learn more
-about how data are fetched in Front-Commerce.
+[request data flow](/docs/3.x/concepts/a-request-data-flow) to learn more about
+how data are fetched in Front-Commerce.
 
 :::
 

--- a/docs/02-guides/register-an-extension.mdx
+++ b/docs/02-guides/register-an-extension.mdx
@@ -14,10 +14,10 @@ importing the extension definitions (or functions returning an extension
 definition) and adding them the `extensions` list.
 
 For instance, in a project configured to be connected to a Magento2 instance and
-with the theme chocolatine, [the Magento2
-extension](/docs/remixed/guides/register-an-extension) and [the Theme
-Chocolatine extension](/docs/remixed/extensions/magento2/) are registered in
-`front-commerce.config.ts`:
+with the theme chocolatine,
+[the Magento2 extension](/docs/3.x/guides/register-an-extension) and
+[the Theme Chocolatine extension](/docs/3.x/extensions/magento2/) are registered
+in `front-commerce.config.ts`:
 
 ```typescript title="front-commerce.config.ts"
 import { defineConfig } from "@front-commerce/core/config";
@@ -39,7 +39,6 @@ export default defineConfig({
 
 In that project, if you want to add an extension, you could add the following
 changes to `front-commerce.config.ts`:
-
 
 ```typescript title="front-commerce.config.ts"
 import { defineConfig } from "@front-commerce/core/config";

--- a/docs/02-guides/translate-your-application.mdx
+++ b/docs/02-guides/translate-your-application.mdx
@@ -180,7 +180,7 @@ That's why Front-Commerce uses a mechanism called **translations fallbacks**.
 Instead of relying on a single file for translations, Front-Commerce will look
 out for translations that are defined by extensions
 
-#### From your extension [declared in `front-commerce.config.js`](/docs/remixed/guides/register-an-extension)
+#### From your extension [declared in `front-commerce.config.js`](/docs/3.x/guides/register-an-extension)
 
 If you are developing an extension, you will need to add the path to your
 translations in the extension configuration file, for example lets say your
@@ -256,7 +256,7 @@ content from your backend. Learn more about
 ## Loaders and Meta function
 
 The
-[`FrontCommerceApp`](/docs/remixed/api-reference/front-commerce-remix/front-commerce-app)
+[`FrontCommerceApp`](/docs/3.x/api-reference/front-commerce-remix/front-commerce-app)
 instance exposes the [`intl` object](https://formatjs.io/docs/intl) which can be
 used to translate strings in your loaders, which can then be used in in the meta
 function.

--- a/docs/03-extensions/algolia/how-to/magento1.mdx
+++ b/docs/03-extensions/algolia/how-to/magento1.mdx
@@ -41,9 +41,8 @@ steps.
 
 ## Front-Commerce
 
-[After installing the Algolia
-package](/docs/remixed/extensions/algolia/#installation), you need to enable the
-corresponding extension. For that, you need to tweak your
+[After installing the Algolia package](/docs/3.x/extensions/algolia/#installation),
+you need to enable the corresponding extension. For that, you need to tweak your
 `front-commerce.config.ts` file like:
 
 ```typescript title="front-commerce.config.ts for a Magento¬1 based project"

--- a/docs/03-extensions/algolia/how-to/magento2.mdx
+++ b/docs/03-extensions/algolia/how-to/magento2.mdx
@@ -33,9 +33,8 @@ steps.
 
 ## Front-Commerce
 
-[After installing the Algolia
-package](/docs/remixed/extensions/algolia/#installation), you need to enable the
-corresponding extension. For that, you need to tweak your
+[After installing the Algolia package](/docs/3.x/extensions/algolia/#installation),
+you need to enable the corresponding extension. For that, you need to tweak your
 `front-commerce.config.ts` file like:
 
 ```typescript title="front-commerce.config.ts for a Magento 2 based project"

--- a/docs/03-extensions/algolia/how-to/standalone.mdx
+++ b/docs/03-extensions/algolia/how-to/standalone.mdx
@@ -9,9 +9,8 @@ sidebar_position: 3
 
 ## Front-Commerce
 
-[After installing the Algolia
-package](/docs/remixed/extensions/algolia/#installation), you need to enable the
-corresponding extension. For that, you need to tweak your
+[After installing the Algolia package](/docs/3.x/extensions/algolia/#installation),
+you need to enable the corresponding extension. For that, you need to tweak your
 `front-commerce.config.ts` file like:
 
 ```typescript title="front-commerce.config.ts"
@@ -50,9 +49,8 @@ FRONT_COMMERCE_ALGOLIA_INDEX_NAME_PREFIX=myproject_
 <a name="algolia-standalone-config"></a>
 
 To further configure the Algolia module for instance to define facets, you have
-[to create a configuration provider to override](/docs/remixed/guides/configuration)
+[to create a configuration provider to override](/docs/3.x/guides/configuration)
 [the `algoliaConfigProvider`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/871107f4f1c8c4acc88b555efa54f1d264227bf5/modules/datasource-algolia/server/config/algoliaConfigProvider.js).
-
 
 ## Indices requirements
 
@@ -135,12 +133,11 @@ For CMS page indices:
 ## Further customizations
 
 In the `standalone` _flavor_, the Algolia extension relies on default
-configuration settings. To customize it, you need [to inject a specific
-configurations](/docs/remixed/guides/configuration). For that, you can create a
-dedicated extension that registers a configuration provider.
+configuration settings. To customize it, you need
+[to inject a specific configurations](/docs/3.x/guides/configuration). For that,
+you can create a dedicated extension that registers a configuration provider.
 
-[The example extension
-`custom-algolia-search`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/skeleton/extensions/custom-algolia-search)
+[The example extension `custom-algolia-search`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/skeleton/extensions/custom-algolia-search)
 shows how the index prefix can be manipulated, in that example the current shop
 locale is added to it.
 

--- a/docs/03-extensions/algolia/index.mdx
+++ b/docs/03-extensions/algolia/index.mdx
@@ -28,15 +28,18 @@ to your `front-commerce.config.ts`. When doing that, you need to pass the
 _flavor_ in which you want to run the extension, the _flavor_ must be one of the
 following values:
 
-* `magento2`: in this _flavor_, the extension is configured to work with indices
-  created by the Magento2 Algolia module. See [the corresponding
-  How-to](/docs/remixed/extensions/algolia/how-to/magento2) for more details.
-* `magento1`: in this _flavor_, the extension is configured to work with indices
-  created by the Magento1 Algolia module. See [the corresponding
-  How-to](/docs/remixed/extensions/algolia/how-to/magento1) for more details.
-* `standalone`: in this _flavor_, the extension is configured to work on custom
-  indices. This is an advanced behavior. See [the corresponding
-  How-to](/docs/remixed/extensions/algolia/how-to/standalone) for more details.
+- `magento2`: in this _flavor_, the extension is configured to work with indices
+  created by the Magento2 Algolia module. See
+  [the corresponding How-to](/docs/3.x/extensions/algolia/how-to/magento2) for
+  more details.
+- `magento1`: in this _flavor_, the extension is configured to work with indices
+  created by the Magento1 Algolia module. See
+  [the corresponding How-to](/docs/3.x/extensions/algolia/how-to/magento1) for
+  more details.
+- `standalone`: in this _flavor_, the extension is configured to work on custom
+  indices. This is an advanced behavior. See
+  [the corresponding How-to](/docs/3.x/extensions/algolia/how-to/standalone) for
+  more details.
 
 :::caution Known issue
 

--- a/docs/03-extensions/algolia/reference/environment-variables.mdx
+++ b/docs/03-extensions/algolia/reference/environment-variables.mdx
@@ -14,10 +14,13 @@ the `DEBUG` environment variable containing `front-commerce:algolia`.
 
 ## Required environment variables
 
-When [the extension is configured in the `standalone`
-flavor](/docs/remixed/extensions/algolia/how-to/standalone), the following
-variables must be defined:
+When
+[the extension is configured in the `standalone` flavor](/docs/3.x/extensions/algolia/how-to/standalone),
+the following variables must be defined:
 
-* `FRONT_COMMERCE_ALGOLIA_APPLICATION_ID` with [the Application ID](https://www.algolia.com/doc/guides/sending-and-managing-data/send-and-update-your-data/how-to/importing-with-the-api/#application-id)
-* `FRONT_COMMERCE_ALGOLIA_SEARCH_ONLY_API_KEY` with [the search only API key](https://www.algolia.com/doc/guides/security/api-keys/#search-only-api-key)
-* `FRONT_COMMERCE_ALGOLIA_INDEX_NAME_PREFIX` with the prefix of indices to take into account
+- `FRONT_COMMERCE_ALGOLIA_APPLICATION_ID` with
+  [the Application ID](https://www.algolia.com/doc/guides/sending-and-managing-data/send-and-update-your-data/how-to/importing-with-the-api/#application-id)
+- `FRONT_COMMERCE_ALGOLIA_SEARCH_ONLY_API_KEY` with
+  [the search only API key](https://www.algolia.com/doc/guides/security/api-keys/#search-only-api-key)
+- `FRONT_COMMERCE_ALGOLIA_INDEX_NAME_PREFIX` with the prefix of indices to take
+  into account

--- a/docs/03-extensions/contentful/index.mdx
+++ b/docs/03-extensions/contentful/index.mdx
@@ -13,13 +13,13 @@ description:
 Before you can use the Contentful extension, you need to have the following:
 
 - Access to a [Contentful](https://www.contentful.com/) instance
-- A working [Front-Commerce environment](/docs/remixed/get-started/installation)
+- A working [Front-Commerce environment](/docs/3.x/get-started/installation)
 
 To set up a Contentful instance, please refer to the
 [Contentful documentation](https://www.contentful.com/developers/docs/).
 
 To set up a Front-Commerce environment, please refer to the
-[Front-Commerce documentation](/docs/remixed/get-started/installation).
+[Front-Commerce documentation](/docs/3.x/get-started/installation).
 
 ## Installation
 

--- a/docs/03-extensions/theme-chocolatine/reference/css-variables.mdx
+++ b/docs/03-extensions/theme-chocolatine/reference/css-variables.mdx
@@ -11,8 +11,8 @@ Front-Commerce's theme Chocolatine uses a set of CSS variables defined in
 `theme/_variables.scss` to ensure a certain consistency in the application's
 design. We recommend to reuse these variables as much as possible, and adapting
 them to your project's design choices. See
-[Customize the styles](/docs/remixed/guides/customize-the-styles) for more
-details about adapting your application to your brand.
+[Customize the styles](/docs/3.x/guides/customize-the-styles) for more details
+about adapting your application to your brand.
 
 ## Colors
 

--- a/docs/04-api-reference/front-commerce-core/defineExtension.mdx
+++ b/docs/04-api-reference/front-commerce-core/defineExtension.mdx
@@ -11,8 +11,7 @@ description:
 
 Extensions are registered in the application using the
 `front-commerce.config.ts` file. Read
-[Register an extension](/docs/remixed/guides/register-an-extension) to learn
-more.
+[Register an extension](/docs/3.x/guides/register-an-extension) to learn more.
 
 :::
 

--- a/docs/04-api-reference/front-commerce-remix/defineRemixExtension.mdx
+++ b/docs/04-api-reference/front-commerce-remix/defineRemixExtension.mdx
@@ -10,8 +10,7 @@ description:
 
 Extensions are registered in the application using the
 `front-commerce.config.ts` file. Read
-[Register an extension](/docs/remixed/guides/register-an-extension) to learn
-more.
+[Register an extension](/docs/3.x/guides/register-an-extension) to learn more.
 
 :::
 

--- a/docs/04-api-reference/front-commerce-remix/front-commerce-app.mdx
+++ b/docs/04-api-reference/front-commerce-remix/front-commerce-app.mdx
@@ -7,7 +7,7 @@ description:
 ---
 
 The `FrontCommerceApp` instance uses the
-[`frontCommerce` context](/docs/remixed/api-reference/front-commerce-remix/#front-commerce-context)
+[`frontCommerce` context](/docs/3.x/api-reference/front-commerce-remix/#front-commerce-context)
 to expose different API's which can be used in your Application.
 
 To use the `FrontCommerceApp` instance you can add it to your loaders or

--- a/docs/100-upgrade/release-notes.mdx
+++ b/docs/100-upgrade/release-notes.mdx
@@ -29,7 +29,7 @@ Compatible with:
 > Adobe Commerce B2B projects
 
 - [Announcement](/changelog/front-commerce-3.1-2.27/)
-- [Migration guide](/docs/remixed/upgrade/migration-guides/3.0-3.1)
+- [Migration guide](/docs/3.x/upgrade/migration-guides/3.0-3.1)
 - [Changelog](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/releases/3.1.0)
 
 ## 3.0.0 (2023-09-28)

--- a/docs/migration/deprecated-code-removal.mdx
+++ b/docs/migration/deprecated-code-removal.mdx
@@ -76,15 +76,15 @@ The `WysiwygV2` implementation has been renamed to `Wysiwyg` in
 [this merge request](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2339).
 To ensure that you are using the correct version of the component, before
 running the
-[automated migration process](/docs/remixed/migration/automated-migration) step,
-you should search for any imports in your codebase which is still targeting
+[automated migration process](/docs/3.x/migration/automated-migration) step, you
+should search for any imports in your codebase which is still targeting
 `Wysiwyg` (V1) implementation: `theme/modules/Wysiwyg`, and follow
 [the documentation](/docs/2.x/advanced/theme/wysiwyg/#wysiwygv2--usage) to
 update the usages to `WysiwygV2`.
 
 After running the
-[automated migration process](/docs/remixed/migration/automated-migration) step,
-all related imports will be automatically updated, for example:
+[automated migration process](/docs/3.x/migration/automated-migration) step, all
+related imports will be automatically updated, for example:
 
 ```diff
 js:
@@ -206,10 +206,9 @@ project.
 
 ## Features
 
-Some code has also been removed while not explicitly deprecated in `2.x`. Most of
-the time it was because the feature was not used or made obsolete with the
+Some code has also been removed while not explicitly deprecated in `2.x`. Most
+of the time it was because the feature was not used or made obsolete with the
 release of `3.x`.
 
-Please read the
-[features removal page](/docs/remixed/migration/features-removal) for more
-information.
+Please read the [features removal page](/docs/3.x/migration/features-removal)
+for more information.

--- a/docs/migration/manual-migration.mdx
+++ b/docs/migration/manual-migration.mdx
@@ -22,7 +22,7 @@ If you use SEO components or have overriden Seo components, you need to:
 
 - Remove import and usage of the component from your page
 - Use the [meta](https://remix.run/docs/en/main/route/meta-v2) function with our
-  [generateMetas helper](/docs/remixed/api-reference/front-commerce-remix/generate-metas)
+  [generateMetas helper](/docs/3.x/api-reference/front-commerce-remix/generate-metas)
   to inject your custom metadatas in your Route Module.
 
 ### Refactor pages to Remix routes
@@ -319,7 +319,8 @@ $min: breakpoint-min("sm");
 }
 ```
 
-For cases where you were using the `media-breakpoint-up`, you can use a media query with `min-width` too. For example:
+For cases where you were using the `media-breakpoint-up`, you can use a media
+query with `min-width` too. For example:
 
 **Before:**
 
@@ -619,7 +620,7 @@ Other optional variables updated:
 The `makeImageProxyRouter` function has been removed in favor of the new
 `createResizedImageResponse` function. You can read more about the
 implementation details in the
-[`createResizedImageResponse` documentation](/docs/remixed/api-reference/front-commerce-core/create-resized-image-response).
+[`createResizedImageResponse` documentation](/docs/3.x/api-reference/front-commerce-core/create-resized-image-response).
 
 All images which are located under `public/images/resized/*` should now be moved
 to `public/images/*`. This will allow for the
@@ -664,8 +665,7 @@ will now need to move it the
 
 ## Client side log handler removal
 
-[The client side log mechanism has been removed from Front-Commerce
-3.0](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2594).
+[The client side log mechanism has been removed from Front-Commerce 3.0](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2594).
 For future version, we plan to bring back this feature. In the meantime, if you
 are using this feature or you have overridden a component using this feature,
 you need to remove it. In version 2.x, the API was imported from

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,7 +14,7 @@ const REPOSITORY_URL =
 // see: https://docs.netlify.com/configure-builds/environment-variables/#build-metadata
 const noIndex = process.env.CONTEXT !== "production";
 
-const LAST_VERSION = "2.x";
+const LAST_VERSION = "current";
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -42,7 +42,7 @@ const config = {
 
   customFields: {
     INTERCOM_APP_ID: process.env.INTERCOM_APP_ID || "xh1u2003",
-    LAST_VERSION,
+    LAST_VERSION: LAST_VERSION === "current" ? "3.x" : LAST_VERSION,
   },
 
   presets: [
@@ -58,14 +58,13 @@ const config = {
           lastVersion: LAST_VERSION,
           versions: {
             current: {
-              label: "Remixed 🚧",
-              path: "remixed",
-              noIndex: true, // TODO dont index until we are ready to launch
-              banner: "unreleased",
+              label: "3.x",
+              path: "3.x",
             },
             "2.x": {
               label: "2.x",
               path: "2.x",
+              banner: "none",
             },
           },
         },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -15,6 +15,7 @@ const REPOSITORY_URL =
 const noIndex = process.env.CONTEXT !== "production";
 
 const LAST_VERSION = "current";
+const LAST_VERSION_URL = LAST_VERSION === "current" ? "3.x" : LAST_VERSION;
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -42,7 +43,7 @@ const config = {
 
   customFields: {
     INTERCOM_APP_ID: process.env.INTERCOM_APP_ID || "xh1u2003",
-    LAST_VERSION: LAST_VERSION === "current" ? "3.x" : LAST_VERSION,
+    LAST_VERSION: LAST_VERSION_URL,
   },
 
   presets: [
@@ -122,16 +123,16 @@ const config = {
             title: "Docs",
             items: [
               {
-                label: "Introduction",
-                to: `/docs/${LAST_VERSION}/welcome`,
+                label: "3.x",
+                to: `/docs/3.x/welcome`,
               },
               {
-                label: "Essentials",
-                to: `/docs/${LAST_VERSION}/category/essentials`,
+                label: "2.x",
+                to: `/docs/2.x/welcome`,
               },
               {
-                label: "Concepts",
-                to: `/docs/${LAST_VERSION}/category/concepts`,
+                label: "Migrating from v2",
+                to: `/docs/3.x/category/migrating-from-v2`,
               },
             ],
           },

--- a/src/theme/NotFound.tsx
+++ b/src/theme/NotFound.tsx
@@ -31,12 +31,6 @@ const PopularPages = () => {
       href: "/changelog",
     },
     {
-      title: "Migration Guides",
-      description: "Migrations guides that cover popular setups",
-      icon: BookmarkSquareIcon,
-      href: `/docs/${LAST_VERSION}/appendices/migration-guides`,
-    },
-    {
       title: "Support",
       description: "Read our latest help articles or contact support",
       icon: RssIcon,

--- a/static/_redirects
+++ b/static/_redirects
@@ -14,6 +14,7 @@
 /docs/:version/*/:category/overview.html					      /docs/:version/category/:category	                      302
 
 # Since we introduced documentation versioning, unversioned documentation should redirect to version 2.x
+/docs/remixed/*                                         /docs/3.x/:splat                                        302
 /docs/2.x/*                                             /docs/2.x/:splat                                        200!
-/docs/remixed/*                                         /docs/remixed/:splat                                    200!
+/docs/3.x/*                                             /docs/3.x/:splat                                        200!
 /docs/*                                                 /docs/2.x/:splat                                        302

--- a/versions.json
+++ b/versions.json
@@ -1,1 +1,1 @@
-["2.x", "current"]
+["current", "2.x"]


### PR DESCRIPTION
This PR renames the `remixed` WIP documentation version to a `3.x` one, which becomes the default.

- it is now indexable
- all content has been updated to directly target the `3.x` versioned URL
- redirections were added to redirect WIP "/remixed/*" urls to their "/3.x/*" counterpart