### PR TITLE
Add Adyen extension documentation

### DIFF
--- a/docs/03-extensions/adyen/_category_.yml
+++ b/docs/03-extensions/adyen/_category_.yml
@@ -1,0 +1,5 @@
+label: "Adyen"
+position: 6
+link:
+  type: doc
+  id: index

--- a/docs/03-extensions/adyen/how-to/_category_.yml
+++ b/docs/03-extensions/adyen/how-to/_category_.yml
@@ -1,0 +1,3 @@
+label: "How-to"
+position: 1
+collapsible: true

--- a/docs/03-extensions/adyen/how-to/front-commerce.mdx
+++ b/docs/03-extensions/adyen/how-to/front-commerce.mdx
@@ -1,0 +1,191 @@
+---
+title: Use as a Front-Commerce payment
+description:
+  "This guides explains how to configure the Adyen extension to use it with
+  Front-Commerce payment methods."
+sidebar_position: 3
+---
+
+<p>{frontMatter.description}</p>
+
+## Front-Commerce configuration
+
+[After installing the Adyen package](/docs/3.x/extensions/adyen/#installation),
+you need to enable the corresponding extension. For that, you need to tweak your
+`front-commerce.config.ts` file like:
+
+```typescript title="front-commerce.config.ts"
+import { defineConfig } from "@front-commerce/core/config";
+import themeChocolatine from "@front-commerce/theme-chocolatine";
+import magento2 from "@front-commerce/magento2"; // or magento1
+// highlight-next-line
+import adyen from "@front-commerce/adyen";
+import storesConfig from "./app/config/stores";
+import cacheConfig from "./app/config/caching";
+
+// highlight-next-line
+const adyenFlavor = "front-commerce-magento2"; // or "front-commerce-magento1"
+
+export default defineConfig({
+  extensions: [
+    magento2(storesConfig),
+    themeChocolatine(),
+    // highlight-next-line
+    adyen(adyenFlavor), // ⚠️ need to be after themeChocolatine()
+  ],
+  stores: storesConfig,
+  cache: cacheConfig,
+  configuration: {
+    providers: [],
+  },
+});
+```
+
+## Add the required environment variables
+
+In the .env, you need to define the following environment variables:
+
+```shell title=".env"
+FRONT_COMMERCE_ADYEN_MERCHANT_ACCOUNT=ExampleMerchant
+FRONT_COMMERCE_ADYEN_CLIENT_KEY=live_32charactersstring
+# the Adyen client key is prefixed with live_ or test_
+FRONT_COMMERCE_ADYEN_API_KEY=a_very_very_very_long_key
+FRONT_COMMERCE_ADYEN_LIVE_URL_PREFIX=1797a841fbb37ca7-AdyenDemo-
+FRONT_COMMERCE_ADYEN_NOTIFICATION_USERNAME=a_username
+FRONT_COMMERCE_ADYEN_NOTIFICATION_PASSWORD=a_password
+FRONT_COMMERCE_ADYEN_HMAC_KEY=the_hmac_key
+FRONT_COMMERCE_ADYEN_PREVIOUS_HMAC_KEY=the_previous_hmac_key
+FRONT_COMMERCE_ADYEN_STORE_PAYMENT_DETAILS=true
+```
+
+See our
+[extension reference](/docs/3.x/extensions/adyen/reference/environment-variables)
+for more information about these variables.
+
+## Register your Adyen payment components
+
+:::note
+
+This is a temporary way to setup payment components. We are aware that it is
+tedious. It will definitely change in the future, when Front-Commerce will
+support new extension points for Payments.
+
+:::
+
+1. Override the file that lets you register additional payments forms in
+   Front-Commerce
+
+   ```shell
+   mkdir -p app/theme/modules/Checkout/Payment/AdditionalPaymentInformation/
+   cp -u node_modules/@front-commerce/theme-chocolatine/theme/modules/Checkout/Payment/AdditionalPaymentInformation/getAdditionalDataComponent.js app/theme/modules/Checkout/Payment/AdditionalPaymentInformation/getAdditionalDataComponent.js
+   ```
+
+2. Register Adyen
+
+   ```diff title="app/theme/modules/Checkout/Payment/AdditionalPaymentInformation/getAdditionalDataComponent.js"
+   +import AdyenCheckout from "theme/modules/Checkout/Payment/AdditionalPaymentInformation/AdyenCheckout";
+
+   const ComponentMap = {};
+
+   const getAdditionalDataComponent = (method) => {
+   +  if (method.code.startsWith("adyen_")) {
+   +    return AdyenCheckout;
+   +  }
+     return ComponentMap[method.code];
+   };
+   ```
+
+3. Override the file that lets you register additional payments actions in
+   Front-Commerce
+
+   ```shell
+   mkdir -p app/theme/modules/Checkout/PlaceOrder
+   cp -u node_modules/@front-commerce/theme-chocolatine/theme/modules/Checkout/PlaceOrder/getAdditionalActionComponent.js app/theme/modules/Checkout/PlaceOrder/getAdditionalActionComponent.js
+   ```
+
+4. Register the Adyen action
+
+   ```diff title="app/theme/modules/Checkout/PlaceOrder/getAdditionalActionComponent.js"
+   import None from "theme/modules/Checkout/PlaceOrder/AdditionalAction/None";
+   +import Adyen from "theme/modules/Checkout/PlaceOrder/AdditionalAction/Adyen";
+
+   const ComponentMap = {};
+
+   const getAdditionalActionComponent = (paymentCode, paymentAdditionalData) => {
+   +  if (paymentCode.startsWith("adyen")) {
+   +    return Adyen;
+   +  }
+     return ComponentMap?.[paymentCode] ?? None;
+   };
+   ```
+
+## Register custom styles (optional)
+
+Developers can
+[customize Adyen drop-in UI styles using CSS](https://docs.adyen.com/checkout/drop-in-web/customization).
+
+You can add an optional stylesheet from Front-Commerce in your application to
+customize styles. The provided stylesheet reuses existing styles from the theme
+as much as possible for a good integration by default. You can override it if
+needed to adapt the UI as wanted.
+
+Add the following line to your your main `.scss` file to load these styles:
+
+```scss
+@import "theme/modules/Adyen/dropinCustomizations";
+```
+
+## Add webhook
+
+In your Adyen Customer Area under `Developers > Webhooks` click on the
+`+ Webkook` button on the right top corner then click on `Add` for the
+`Standard Notification` type. Fill the fields as follows:
+
+- Transport:
+  - URL: the full url of your site followed by
+    `/webhooks/payment/notification/adyen` e.g.
+    `https://www.example.com/webhooks/payment/notification/adyen`
+  - Method: JSON
+- Authentication:
+  - User Name: the `FRONT_COMMERCE_ADYEN_NOTIFICATION_USERNAME` environment
+    variable defined above
+  - Password: the `FRONT_COMMERCE_ADYEN_NOTIFICATION_PASSWORD` environment
+    variable defined above
+- Additional Settings
+  - HMAC Key (HEX Encoded): click generate and copy it to
+    `FRONT_COMMERCE_ADYEN_HMAC_KEY` environment variable defined above
+
+## Enable Adyen's Stored Payment Methods (optional)
+
+You can opt for Adyen to store your customers' credit card information and allow
+a faster checkout experience by adding
+`FRONT_COMMERCE_ADYEN_STORE_PAYMENT_DETAILS=true` in your `.env` file.
+
+If you are using the default Front-Commerce Adyen component, your customer
+should now be able to save their credit card information during checkout by
+checking the "Save for my next payment" checkbox.
+
+## Enable Paypal payments
+
+To enable PayPal payments, you need to
+[add PayPal payment method](https://docs.adyen.com/payment-methods/paypal/web-drop-in)
+in your Adyen account.
+
+## Enable Google Pay payments
+
+To enable Google Pay payments, you need to
+[add Google Pay payment method](https://docs.adyen.com/payment-methods/google-pay/web-drop-in)
+in your Adyen account.
+
+## Test it
+
+To make sure Adyen APIs are properly used, you can restart Front-Commerce with
+the `DEBUG` environment variable containing `front-commerce:payment:adyen` so
+that it displays various information on the requests:
+
+```bash title="Run Front-Commerce with Adyen's debug flag"
+DEBUG=front-commerce:payment:adyen pnpm run dev
+```
+
+After restarting Front-Commerce, you should be able to see the payment methods
+you have configured in your Adyen account at the "Payment" step of the checkout.

--- a/docs/03-extensions/adyen/how-to/magento2.mdx
+++ b/docs/03-extensions/adyen/how-to/magento2.mdx
@@ -1,0 +1,237 @@
+---
+title: "Use with the Magento 2 payment plugin"
+description:
+  "This guides explains how to configure the Adyen extension to work with
+  Magento2 Adyen integration."
+sidebar_position: 1
+---
+
+import ContactLink from "@site/src/components/ContactLink";
+
+<p>{frontMatter.description}</p>
+
+:::note
+
+<span>
+  This integration aims to be transparent for administrators and developers.
+  That is why we haven't duplicated documentation from existing Magento
+  resources. Please <ContactLink /> if you need further assistance.
+</span>
+
+:::
+
+Front-Commerce is compatible with
+[Adyen's official Magento headless integration](https://docs.adyen.com/plugins/magento-2/magento-headless-integration)
+in its native version.
+
+This integration is slightly different from
+[traditional Magento2 headless payments](/docs/2.x/magento2/headless-payments)
+in the sense that it contains a "companion component" in Front-Commerce. The
+component allows to display and Authorize payments from the checkout page, using
+[Adyen's Web Drop-in integration](https://docs.adyen.com/online-payments/drop-in-web)
+on the front-end. No redirection to other payment platforms is involved unless
+it is absolutely necessary, the customer remains on the Front-Commerce store.
+
+Here is how to set this payment method up.
+
+## Adyen Magento 2 integration installation
+
+Follow [Adyen's documentation](https://docs.adyen.com/plugins/magento-2) to
+install and configure the official Magento2 extension for Adyen payments. We
+currently support any version from
+[7.2.0](https://github.com/Adyen/adyen-magento2/releases/tag/7.2.0) to
+[8.x](https://github.com/Adyen/adyen-magento2/releases/tag/8.0.0).
+
+:::tip
+
+If you were using Adyen with Magento2 without Front-Commerce, don't forget to
+check Adyen settings. For instance, make sure
+[allowed origins set the step 1](https://docs.adyen.com/plugins/adobe-commerce/set-up-adyen-customer-area/?tab=manual_2)
+match you setup with Front-Commerce.
+
+:::
+
+You must configure the extension's Headless/PWA settings with your
+Front-Commerce URL **for each of your stores**. Settings
+[changed in version 8.0.0](https://github.com/Adyen/adyen-magento2/releases/tag/8.0.0),
+so it will be slightly different depending on your version.
+
+- `< 8`: configure "Payment Origin URL" in the `Advanced: PWA` section
+- `>= 8`: configure `Advanced settings > Headless Integration` with
+  - Payment Origin URL: your Front-Commerce URL (e.g:
+    [http://localhost:4000/](http://localhost:4000/))
+  - Payment Return URL: the `/adyen/process/result` path (e.g:
+    [http://localhost:4000/adyen/process/result](http://localhost:4000/adyen/process/result))
+  - Custom Success Redirect Path: same value as Payment Return URL
+
+:::info important
+
+Please note that enabling or disabling payments in Magento's admin area has no
+effect on payment methods visible on the storefront. This is a _feature_ of the
+module: every active payment method in Adyen will be available. **You either
+have to filter them in the frontend or from your Adyen account.**
+
+:::
+
+## Front-Commerce configuration
+
+[After installing the Adyen package](/docs/3.x/extensions/adyen/#installation),
+you need to enable the corresponding extension. For that, you need to tweak your
+`front-commerce.config.ts` file like:
+
+```typescript title="front-commerce.config.ts"
+import { defineConfig } from "@front-commerce/core/config";
+import themeChocolatine from "@front-commerce/theme-chocolatine";
+import magento2 from "@front-commerce/magento2"; // or magento1
+// highlight-next-line
+import adyen from "@front-commerce/adyen";
+import storesConfig from "./app/config/stores";
+import cacheConfig from "./app/config/caching";
+
+export default defineConfig({
+  extensions: [
+    magento2(storesConfig),
+    themeChocolatine(),
+    // highlight-next-line
+    adyen(magento2), // ⚠️ must be after themeChocolatine()
+  ],
+  stores: storesConfig,
+  cache: cacheConfig,
+  configuration: {
+    providers: [],
+  },
+});
+```
+
+## Add the required environment variables
+
+In the .env, you need to define the following environment variables:
+
+```sh title=".env"
+FRONT_COMMERCE_ADYEN_CLIENT_KEY=live_32charactersstring
+# the Adyen client key is prefixed with live_ or test_
+FRONT_COMMERCE_ADYEN_MAGENTO_MODULE_VERSION=8.3.3
+FRONT_COMMERCE_ADYEN_STORE_PAYMENT_DETAILS=true
+```
+
+See our
+[extension reference](/docs/3.x/extensions/adyen/reference/environment-variables)
+for more information about these variables.
+
+## Register your Adyen payment components
+
+:::note
+
+This is a temporary way to setup payment components. We are aware that it is
+tedious. It will definitely change in the future, when Front-Commerce will
+support new extension points for Payments.
+
+:::
+
+1. Override the file that lets you register additional payments forms in
+   Front-Commerce
+
+   ```shell
+   mkdir -p app/theme/modules/Checkout/Payment/AdditionalPaymentInformation/
+   cp -u node_modules/@front-commerce/theme-chocolatine/theme/modules/Checkout/Payment/AdditionalPaymentInformation/getAdditionalDataComponent.js app/theme/modules/Checkout/Payment/AdditionalPaymentInformation/getAdditionalDataComponent.js
+   ```
+
+2. Register Adyen
+
+   ```diff title="app/theme/modules/Checkout/Payment/AdditionalPaymentInformation/getAdditionalDataComponent.js"
+   +import AdyenCheckout from "theme/modules/Checkout/Payment/AdditionalPaymentInformation/AdyenCheckout";
+
+   const ComponentMap = {};
+
+   const getAdditionalDataComponent = (method) => {
+   +  if (method.code.startsWith("adyen_")) {
+   +    return AdyenCheckout;
+   +  }
+     return ComponentMap[method.code];
+   };
+   ```
+
+3. Override the file that lets you register additional payments actions in
+   Front-Commerce
+
+   ```shell
+   mkdir -p app/theme/modules/Checkout/PlaceOrder
+   cp -u node_modules/@front-commerce/theme-chocolatine/theme/modules/Checkout/PlaceOrder/getAdditionalActionComponent.js app/theme/modules/Checkout/PlaceOrder/getAdditionalActionComponent.js
+   ```
+
+4. Register the Adyen action
+
+   ```diff title="app/theme/modules/Checkout/PlaceOrder/getAdditionalActionComponent.js"
+   import None from "theme/modules/Checkout/PlaceOrder/AdditionalAction/None";
+   +import Adyen from "theme/modules/Checkout/PlaceOrder/AdditionalAction/Adyen";
+
+   const ComponentMap = {};
+
+   const getAdditionalActionComponent = (paymentCode, paymentAdditionalData) => {
+   +  if (paymentCode.startsWith("adyen")) {
+   +    return Adyen;
+   +  }
+     return ComponentMap?.[paymentCode] ?? None;
+   };
+   ```
+
+## Register custom styles (optional)
+
+Developers can
+[customize Adyen drop-in UI styles using CSS](https://docs.adyen.com/checkout/drop-in-web/customization).
+
+You can add an optional stylesheet from Front-Commerce in your application to
+customize styles. The provided stylesheet reuses existing styles from the theme
+as much as possible for a good integration by default. You can override it if
+needed to adapt the UI as wanted.
+
+Add the following line to your your main `.scss` file to load these styles:
+
+```scss
+@import "theme/modules/Adyen/dropinCustomizations";
+```
+
+## Enable Adyen's Stored Payment Methods (optional)
+
+You can opt for Adyen to store your customers' credit card information to allow
+a faster checkout experience.
+
+In order to do so:
+
+- Add `FRONT_COMMERCE_ADYEN_STORE_PAYMENT_DETAILS=true` in your `.env` file
+- Follow
+  [Adyen's guide](https://docs.adyen.com/plugins/magento-2/set-up-tokenization?tab=magento-vault-version-8-2-0_2#set-up-adyen-tokenization)
+  on how to setup tokenization using Adyen's Magento module.
+
+If you are using the default Front-Commerce Adyen component, your customer
+should now be able to save their credit card information during checkout by
+checking the "Save for my next payment" checkbox.
+
+### Enable Paypal payments
+
+To enable PayPal payments, you need to:
+
+- [add PayPal payment method](https://docs.adyen.com/payment-methods/paypal/web-drop-in)
+  in your Adyen account
+- enable Adyen's `Alternative Payment Methods` in your Magento2 backend, located
+  in
+  `Stores > Configuration > Sales > Payment Methods > Adyen Payments > Configure payment methods`
+
+## Enable Google Pay payments
+
+To enable Google Pay payments, you need to
+[add Google Pay payment method](https://docs.adyen.com/payment-methods/google-pay/web-drop-in)
+in your Adyen account.
+
+## Test it
+
+You can now configure the Magento extension to use a Test mode and
+[test the integration](https://docs.adyen.com/development-resources/test-cards/test-card-numbers)
+
+:::note
+
+Please keep in mind that Adyen payment methods depends on the Customer country,
+the Cart amount and the Store currency. Different contexts could display
+different payment methods in the checkout.
+
+:::

--- a/docs/03-extensions/adyen/index.mdx
+++ b/docs/03-extensions/adyen/index.mdx
@@ -1,0 +1,83 @@
+---
+title: "Adyen"
+description:
+  "The Adyen extension allows customer to pay using Adyen payment methods."
+---
+
+<p>{frontMatter.description}</p>
+
+## Prerequisites
+
+To use this extension, you need an Adyen account to its dashboard. You will also
+need to create API credentials to retrieve the corresponding API keys.
+
+Depending on how the extension is configured (it's _flavor_), you might also
+need to install the Adyen Magento module.
+
+## Installation
+
+First, you need to install the `@front-commerce/adyen` package:
+
+```bash title="Command to install @front-commerce/adyen"
+$ pnpm install @front-commerce/adyen
+```
+
+Then to enable the extension, you need to add the Adyen extension definition to
+your `front-commerce.config.ts`. When doing that, you need to pass the _flavor_
+in which you want to run the extension, the _flavor_ must be one of the
+following values:
+
+- `magento2`: in this _flavor_, the extension is configured to work with indices
+  created by the Magento2 Adyen module. See
+  [the corresponding How-to](/docs/3.x/extensions/adyen/how-to/magento2) for
+  more details.
+- `front-commerce-magento1` or `front-commerce-magento2`: in this _flavor_, the
+  extension is configured to work as Front-Commerce payments. See
+  [the corresponding How-to](/docs/3.x/extensions/adyen/how-to/front-commerce)
+  for more details.
+
+:::caution
+
+The Adyen extension must be registered after the  
+Theme-Chocolatine extension in the `extensions` array.
+
+:::
+
+For instance, in a Magento 2 based project where the Adyen Magento 2 module is
+installed on Magento side, the `front-commerce.config.ts` file would be
+something like:
+
+```typescript title="front-commerce.config.ts for a Magento2 based project"
+import { defineConfig } from "@front-commerce/core/config";
+import themeChocolatine from "@front-commerce/theme-chocolatine";
+import magento2 from "@front-commerce/magento2";
+// highlight-next-line
+import adyen from "@front-commerce/adyen";
+import storesConfig from "./app/config/stores";
+import cacheConfig from "./app/config/caching";
+
+// highlight-start
+// depending on your setup, it can also be "front-commerce-magento1" or "front-commerce-magento2"
+// see corresponding how-tos
+const adyenFlavor = "magento2";
+// highlight-end
+
+export default defineConfig({
+  extensions: [
+    magento2(storesConfig),
+    themeChocolatine(),
+    // highlight-next-line
+    adyen(adyenFlavor), // ⚠️ must be after themeChocolatine()
+  ],
+  stores: storesConfig,
+  cache: cacheConfig,
+  configuration: {
+    providers: [],
+  },
+});
+```
+
+## Next steps
+
+- [Use Adyen with the Magento2 plugin](/docs/3.x/extensions/adyen/how-to/magento2)
+- [Use Adyen as a Front-Commerce payment](/docs/3.x/extensions/adyen/how-to/front-commerce)

--- a/docs/03-extensions/adyen/reference/_category_.yml
+++ b/docs/03-extensions/adyen/reference/_category_.yml
@@ -1,0 +1,3 @@
+label: "Reference"
+position: 2
+collapsible: true

--- a/docs/03-extensions/adyen/reference/environment-variables.mdx
+++ b/docs/03-extensions/adyen/reference/environment-variables.mdx
@@ -1,0 +1,66 @@
+---
+title: "Environment variables"
+description:
+  "This reference lists environment variables used by the Adyen extension"
+sidebar_position: 1
+---
+
+<p>{frontMatter.description}</p>
+
+## Debug
+
+This extension will output some debug information when Front-Commerce is ran
+with the `DEBUG` environment variable containing `front-commerce:payment:adyen`.
+
+## Required environment variables
+
+### When using the Magento2 Adyen module
+
+- `FRONT_COMMERCE_ADYEN_CLIENT_KEY`: The environment variable which contains
+  [your Adyen client key](https://docs.adyen.com/development-resources/client-side-authentication)
+  for the domains of your Front-Commerce stores. You can find it in your Adyen
+  Customer Area under Developers > API Credential >
+  \[your_prefered_credential\] > Client Key > Client Key
+- `FRONT_COMMERCE_ADYEN_STORE_PAYMENT_DETAILS`: (optional) (more on
+  [Adyen's Stored Payment Methods](/docs/2.x/advanced/payments/adyen#enable-adyens-stored-payment-methods-optional)).
+  If you want to enable Adyen's Stored Payment Methods (Tokenization).
+- `FRONT_COMMERCE_ADYEN_MAGENTO_MODULE_VERSION`: The version of the Magento2
+  Adyen module you use. You can find it in your magento backend, under
+  `Stores > Configuration > Sales > Payment Methods > Adyen Payments > Documentation and Support`.
+
+### When using Adyen as Front-Commerce payment
+
+- `FRONT_COMMERCE_ADYEN_MERCHANT_ACCOUNT`: The merchant account name. You can
+  find it in your Adyen Customer Area in the top left corner next to your
+  company name
+- `FRONT_COMMERCE_ADYEN_CLIENT_KEY`: The environment variable which contains
+  [your Adyen client key](https://docs.adyen.com/development-resources/client-side-authentication)
+  for the domains of your Front-Commerce stores. You can find it in your Adyen
+  Customer Area under Developers > API Credential >
+  \[your_prefered_credential\] > Client Key > Client Key
+- `FRONT_COMMERCE_ADYEN_API_KEY`: The API key. You can find it in your Adyen
+  Customer Area under Developers > API Credential >
+  \[your_prefered_credential\] > API Key > API Key
+- `FRONT_COMMERCE_ADYEN_LIVE_URL_PREFIX`: only needed in production environment.
+  Should be configured to contain
+  [the Adyen live URL prefix](https://docs.adyen.com/development-resources/live-endpoints#live-url-prefix)
+- `FRONT_COMMERCE_ADYEN_NOTIFICATION_USERNAME`: (more on
+  [webhooks below](/docs/2.x/advanced/payments/adyen#add-webhook)) you create
+  it. You then have to copy it to the webhook section in your Adyen Customer
+  Area under Developers > Webhooks > \[your_prefered_webhook\] >
+  Authentication > User Name
+- `FRONT_COMMERCE_ADYEN_NOTIFICATION_PASSWORD`: (more on
+  [webhooks below](/docs/2.x/advanced/payments/adyen#add-webhook)) you create
+  it. You then have to copy it to the webhook section in your Adyen Customer
+  Area under Developers > Webhooks > \[your_prefered_webhook\] >
+  Authentication > Password
+- `FRONT_COMMERCE_ADYEN_HMAC_KEY`: (more on
+  [webhooks below](/docs/2.x/advanced/payments/adyen#add-webhook)) create it
+  from the webhook section in your Adyen Customer Area under Developers >
+  Webhooks > \[your_prefered_webhook\] > Additional Settings > HMAC key
+- `FRONT_COMMERCE_ADYEN_PREVIOUS_HMAC_KEY`: (more on
+  [webhooks below](/docs/2.x/advanced/payments/adyen#add-webhook)) when you
+  regenerate your HMAC key configure this to be the old one
+- `FRONT_COMMERCE_ADYEN_STORE_PAYMENT_DETAILS`: (optional) (more on
+  [Adyen's Stored Payment Methods](/docs/2.x/advanced/payments/adyen#enable-adyens-stored-payment-methods-optional)).
+  If you want to enable Adyen's Stored Payment Methods (Tokenization).


### PR DESCRIPTION
This MR adds the Adyen extension documentation in our v3.x docs. It mainly takes the v2.x documentation while also adding the v3-specific part about `front-commerce.config.ts`. It also does not include the Flashmessage configuration as this is not yet supported.

Related MRs:
- [!2929](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2929)
- [!2938](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2938)
- [!2940](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2940)
- [!2947](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/2947)

Previews:
- [Main category](https://deploy-preview-825--heuristic-almeida-1a1f35.netlify.app/docs/3.x/extensions/adyen/)
- [As Front-Commerce payments](https://deploy-preview-825--heuristic-almeida-1a1f35.netlify.app/docs/3.x/extensions/adyen/how-to/front-commerce)
- [With Magento2 integration](https://deploy-preview-825--heuristic-almeida-1a1f35.netlify.app/docs/3.x/extensions/adyen/how-to/magento2)
- [Reference](https://deploy-preview-825--heuristic-almeida-1a1f35.netlify.app/docs/3.x/extensions/adyen/reference/environment-variables)