### PR TITLE
chore: document simpler shop access

### DIFF
--- a/docs/02-guides/configuration/01-add-a-configuration-provider.mdx
+++ b/docs/02-guides/configuration/01-add-a-configuration-provider.mdx
@@ -1,11 +1,8 @@
 ---
-title: Inject configurations
+title: Adding a configuration provider
 description:
-  Configuration is a part of software development that can quickly become messy.
-  Validation, detection, performance… there is a lot to take care of. In this
-  guide, we will see how Front-Commerce configuration works and how to create
-  new configurations or override existing ones.
-sidebar_position: 5
+  Discover how configuration providers customize your app's settings, ensuring
+  efficient and tailored functionality for every server request.
 ---
 
 <p>{frontMatter.description}</p>
@@ -43,9 +40,23 @@ section `config`.
       "locale": "en-GB",
       "magentoStoreCode": "default",
       "currency": "EUR"
+    },
+    "store:fr": {
+      "id": "fr",
+      "url": "http://fr.localhost:3000",
+      "locale": "fr-FR",
+      "magentoStoreCode": "fr",
+      "currency": "EUR"
     }
   },
   "currentShopId": "default",
+  "shop": {
+    "id": "default",
+    "url": "http://localhost:3000",
+    "locale": "en-GB",
+    "magentoStoreCode": "default",
+    "currency": "EUR"
+  },
   "cache": {
     "defaultMaxBatchSize": 100,
     "strategies": [
@@ -104,6 +115,12 @@ section `config`.
     },
     "password": {
       "disableHint": false
+    }
+    "shop":{
+      "id": "default",
+      "url": "http://localhost:3000",
+      "locale": "en-GB",
+      "currency": "EUR"
     }
   },
   "magento": {

--- a/docs/02-guides/configuration/02-public-configuration.mdx
+++ b/docs/02-guides/configuration/02-public-configuration.mdx
@@ -4,7 +4,6 @@ description:
   The public configuration is a set of configuration options that are available
   to any user of the application, they are accessible both from the client and
   the server.
-sidebar_position: 5
 ---
 
 # Public Configuration
@@ -14,11 +13,12 @@ sidebar_position: 5
 ## Extending the public configuration
 
 To extend the public configuration please ensure you have read the
-[Inject configurations](/docs/3.x/guides/configuration) section.
+[Add a configuration provider](/docs/3.x/guides/configuration/add-a-configuration-provider)
+section.
 
 The public configuration can be extended by
-[injecting a config provider](/docs/3.x/guides/configuration) which exposes a
-`public` object in the schema, for example:
+[Adding a configuration provider](/docs/3.x/guides/configuration/add-a-configuration-provider)
+which exposes a `public` object in the schema, for example:
 
 ```ts title="./my-extensions/acme-extension/configProvider.ts"
 export default {
@@ -84,7 +84,7 @@ We additionally attached the public configuration to the
 :::
 
 ```tsx title="./my-extensions/acme-extension/theme/components/MyComponent.tsx"
-import { usePublicConfig } from "@front-commerce/core";
+import { usePublicConfig } from "@front-commerce/core/react";
 
 const MyComponent = () => {
   const { acmeValue } = usePublicConfig();

--- a/docs/02-guides/configuration/03-accessing-current-shop-configuration.mdx
+++ b/docs/02-guides/configuration/03-accessing-current-shop-configuration.mdx
@@ -1,0 +1,141 @@
+---
+title: Accessing current shop configuration
+description:
+  Explore how to access the shop's current configuration to adapt your
+  application to the current context. It is exposed in the configuration `shop`
+  keys.
+---
+
+## From the Client <small>(_Public_)</small>
+
+The current shop configuration can be accessed from the client using the
+[public configuration](/docs/3.x/guides/configuration/public-configuration).
+
+:::note
+
+The public shop configuration (`config.public.shop`) is a subset of the private
+shop configuration (`config.shop`).
+
+This will only contain information that can be exposed to the client.
+
+:::
+
+```mdx-code-block
+<Tabs>
+<TabItem value="React Hook">
+```
+
+To learn more see
+[`usePublicConfig`](/docs/3.x/api-reference/front-commerce-core/react#usepublicconfig)
+documentation.
+
+```ts
+import { usePublicConfig } from "@front-commerce/core/react";
+
+const MyComponent = () => {
+  const { shop } = usePublicConfig();
+
+  return (
+    <div>
+      <h1>{shop.id}</h1>
+      <p>{shop.locale}</p>
+    </div>
+  );
+};
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="Utility Function">
+```
+
+To learn more see
+[`getPublicConfig`](/docs/3.x/api-reference/front-commerce-core/react#getpublicconfig)
+documentation.
+
+```ts
+import { getPublicConfig } from "@front-commerce/core/react";
+
+const myFunction = () => {
+  const publicConfig = getPublicConfig();
+
+  return {
+    id: publicConfig.shop.id,
+    locale: publicConfig.shop.locale,
+  };
+};
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```
+
+## From the Server <small>(_Private_)</small>
+
+The current shop configuration can be accessed from the client using the
+[app configuration](/docs/3.x/guides/configuration/add-a-configuration-provider).
+
+:::note
+
+The private shop configuration (`config.shop`) is a superset of the public shop
+configuration (`config.public.shop`).
+
+This can contain additional information that should not be exposed to the
+client.
+
+:::
+
+```mdx-code-block
+<Tabs>
+<TabItem value="Remix Loader">
+```
+
+```ts
+import type { LoaderFunctionArgs } from "@remix-run/node";
+
+export const loader = async ({ context }: LoaderFunctionArgs) => {
+  const app = new FrontCommerceApp(context.frontCommerce);
+  // add-next-line
+  const currentShopConfig = app.config.shop;
+  // ...
+};
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="Remix Action">
+```
+
+```ts
+import type { ActionFunctionArgs } from "@remix-run/node";
+
+export const action = async ({ context }: ActionFunctionArgs) => {
+  const app = new FrontCommerceApp(context.frontCommerce);
+  // add-next-line
+  const currentShopConfig = app.config.shop;
+  // ...
+};
+```
+
+```mdx-code-block
+</TabItem>
+<TabItem value="GraphQL Resolver">
+```
+
+```ts
+export default {
+  Query: {
+    myQuery: async (parent, args, context, info) => {
+      // add-next-line
+      const currentShopConfig = context.config.shop;
+      // ...
+    },
+  },
+};
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```

--- a/docs/02-guides/configuration/_category_.yml
+++ b/docs/02-guides/configuration/_category_.yml
@@ -1,0 +1,9 @@
+label: Configuration
+position: 91
+link:
+  type: generated-index
+  description:
+    Configuration is a part of software development that can quickly become messy.
+    Validation, detection, performance… there is a lot to take care of. In this
+    guide, we will see how Front-Commerce configuration works and how to create
+    new configurations or override existing ones.

--- a/docs/03-extensions/algolia/how-to/standalone.mdx
+++ b/docs/03-extensions/algolia/how-to/standalone.mdx
@@ -49,7 +49,7 @@ FRONT_COMMERCE_ALGOLIA_INDEX_NAME_PREFIX=myproject_
 <a name="algolia-standalone-config"></a>
 
 To further configure the Algolia module for instance to define facets, you have
-[to create a configuration provider to override](/docs/3.x/guides/configuration)
+[to create a configuration provider to override](/docs/3.x/guides/configuration/add-a-configuration-provider)
 [the `algoliaConfigProvider`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/871107f4f1c8c4acc88b555efa54f1d264227bf5/modules/datasource-algolia/server/config/algoliaConfigProvider.js).
 
 ## Indices requirements
@@ -134,8 +134,9 @@ For CMS page indices:
 
 In the `standalone` _flavor_, the Algolia extension relies on default
 configuration settings. To customize it, you need
-[to inject a specific configurations](/docs/3.x/guides/configuration). For that,
-you can create a dedicated extension that registers a configuration provider.
+[to inject a specific configurations](/docs/3.x/guides/configuration/add-a-configuration-provider).
+For that, you can create a dedicated extension that registers a configuration
+provider.
 
 [The example extension `custom-algolia-search`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/skeleton/example-extensions/custom-algolia-search)
 shows how the index prefix can be manipulated, in that example the current shop

--- a/docs/04-api-reference/front-commerce-core/config.mdx
+++ b/docs/04-api-reference/front-commerce-core/config.mdx
@@ -45,21 +45,6 @@ This is an internal API, we recommend you to use the
 
 :::
 
-## `getCurrentShopConfig`
-
-Get the current shop configuration.
-
-_Example_
-
-```ts
-import { getCurrentShopConfig } from "@front-commerce/core/config";
-
-const getAcmeConfig(config) {
-  return getCurrentShopConfig(config);
-}
-
-```
-
 ## UserConfig
 
 ### `extensions`

--- a/docs/04-api-reference/front-commerce-core/defineExtension.mdx
+++ b/docs/04-api-reference/front-commerce-core/defineExtension.mdx
@@ -151,5 +151,5 @@ Called when the server services are initialized with the following params:
   Generally used to register new services
 - [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) - The
   request object
-- [`ResolvedConfig`](/docs/3.x/guides/configuration) - The resolved
-  configuration object
+- [`ResolvedConfig`](/docs/3.x/guides/configuration/add-a-configuration-provider) -
+  The resolved configuration object

--- a/docs/04-api-reference/front-commerce-remix/front-commerce-app.mdx
+++ b/docs/04-api-reference/front-commerce-remix/front-commerce-app.mdx
@@ -164,7 +164,8 @@ export const action = ({ context }: ActionFunctionArgs) => {
 ### `app.config`
 
 Exposes the configurations from the ConfigProviders, see
-[Inject Configurations](/docs/3.x/guides/configuration) for more information.
+[Add a configuration provider](/docs/3.x/guides/configuration/add-a-configuration-provider)
+for more information.
 
 ```ts
 import { LoaderFunctionArgs, ActionFunctionArgs } from "@remix-run/node";

--- a/docs/100-upgrade/migration-guides/3.2-3.3.mdx
+++ b/docs/100-upgrade/migration-guides/3.2-3.3.mdx
@@ -92,12 +92,28 @@ index 297a34fa2..8012fda4c 100644
 
 ```diff
 diff --git a/skeleton/app/root.tsx b/skeleton/app/root.tsx
-index a28dcf87e..9030e925f 100644
+index a28dcf87e..68e788d96 100644
 --- a/skeleton/app/root.tsx
 +++ b/skeleton/app/root.tsx
-@@ -37,14 +37,7 @@ export const loader = async ({ context }: LoaderFunctionArgs) => {
+@@ -21,30 +21,15 @@ import {
+ import { usePageProgress } from "theme/components/helpers/usePageProgress";
+ import "theme/main.css";
+ import config from "~/config/website";
+-import { AppQueryDocument } from "~/graphql/graphql";
+ import { LiveReload, useSWEffect } from "@remix-pwa/sw";
+ import manifest from "~/manifest";
+
+ export const loader = async ({ context }: LoaderFunctionArgs) => {
+   const app = new FrontCommerceApp(context.frontCommerce);
+
+-  const response = await app.graphql.query(AppQueryDocument);
+-
+-  if (!response.shop) {
+-    throw new Response("", { status: 500, statusText: "Shop not found" });
+-  }
+-
    return json({
-     shop: response.shop,
+-    shop: response.shop,
      device: app.config.device,
 -    process: {
 -      env: {
@@ -199,7 +215,44 @@ const example = {
 We highly suggest that you move any of your custom values to a new config
 provider which extends the `public` schema.
 
-See [Public configurations documentation](/docs/3.x/guides/public-configuration)
+See
+[Public configurations documentation](/docs/3.x/guides/configuration/public-configuration)
 for more details.
 
 :::
+
+### Deprecate `getCurrentShopConfig` usage
+
+In this version we have deprecated the usages of `getCurrentShopConfig` in favor
+`config.shop`, the function has been moved to
+`@front-commerce/compat/shop/getShopConfig` for compatibility reasons, but we
+suggest you to use `config.shop` instead.
+
+```ts
+// from a loader
+export const loader = async ({ context }) => {
+  const app = new FrontCommerceApp(context.frontCommerce);
+  // add-next-line
+  const currentShopConfig = app.config.shop;
+  // ...
+};
+
+// from an action
+export const action = async ({ context }) => {
+  const app = new FrontCommerceApp(context.frontCommerce);
+  // add-next-line
+  const currentShopConfig = app.config.shop;
+  // ...
+};
+
+// from a graphql resolver
+export default {
+  Query: {
+    myQuery: async (parent, args, context, info) => {
+      // add-next-line
+      const currentShopConfig = context.config.shop;
+      // ...
+    },
+  },
+};
+```

--- a/src/theme/MDXComponents.ts
+++ b/src/theme/MDXComponents.ts
@@ -10,6 +10,8 @@ import Calendly from "@site/src/components/Calendly";
 import Description from "@site/src/components/Description";
 import BackportList from "@site/src/components/BackportList";
 import ReleaseSchedule from "@site/src/components/ReleaseSchedule";
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 export default {
   ...MDXComponents,
@@ -22,4 +24,6 @@ export default {
   Description,
   BackportList,
   ReleaseSchedule,
+  Tabs,
+  TabItem,
 };


### PR DESCRIPTION
## What?
- Documents changes in root.ts
- Documents deprecation of `getCurrentShopConfig`


## Preview
- https://deploy-preview-834--heuristic-almeida-1a1f35.netlify.app/docs/3.x/upgrade/migration-guides/3.2-3.3
- https://deploy-preview-834--heuristic-almeida-1a1f35.netlify.app/docs/3.x/api-reference/front-commerce-core/config