### PR TITLE
Move extensions to example extension

### DIFF
--- a/blog/2023-advent-calendar/03-how-to-create-a-new-front-commerce-project.mdx
+++ b/blog/2023-advent-calendar/03-how-to-create-a-new-front-commerce-project.mdx
@@ -175,13 +175,13 @@ directory, and a similar transition is underway for our examples.
 
 In Front-Commerce 3.x, a notable feature is **the ability to package everything
 as an extension**. Leveraging this functionality, we have encapsulated our
-examples and demos as extensions, housed in the `./extensions` subdirectory of
-the skeleton.
+examples and demos as extensions, housed in the `./example-extensions`
+subdirectory of the skeleton.
 
 When initiating a new project, you can enable any of these extension by
 registering them in the `front-commerce.config.ts` file.<br /> For those
 embarking on a new "long-term" project, the extra-step of removing the
-`./extensions` directory will set you on the right path.
+`./example-extensions` directory will set you on the right path.
 
 Our rationale behind this approach is that the ability to swiftly run a demo or
 example locally far outweighs the trade-off of having additional code in the

--- a/docs/01-get-started/loading-data-from-unified-graphql-schema.mdx
+++ b/docs/01-get-started/loading-data-from-unified-graphql-schema.mdx
@@ -19,7 +19,7 @@ place:
 
 - A Front-Commerce project configured and ready to use
 - Basic knowledge of [Remix routes](/docs/3.x/get-started/your-first-route)
-- [FAQ GraphQL Module](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/c317ab057ae0927e294a5287eb8e0be73ca7e1fb/skeleton/extensions/faq-demo/graphql)
+- [FAQ GraphQL Module](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/skeleton/example-extensions/faq-demo/graphql)
   installed and configured if you want to execute code samples without any
   changes
 

--- a/docs/02-guides/extend-the-graphql-schema.mdx
+++ b/docs/02-guides/extend-the-graphql-schema.mdx
@@ -28,7 +28,7 @@ create an extension. An extension can be created by adding a new folder under
 `extensions` and by creating a `index.ts` file (the extension definition) with
 the following content:
 
-```typescript title="extensions/click-counter/index.ts"
+```typescript title="example-extensions/click-counter/index.ts"
 import { defineExtension } from "@front-commerce/core";
 
 export default function clickCounter() {
@@ -53,9 +53,9 @@ to the extension containing a schema and some resolvers.
 ### Add an empty GraphQL module
 
 For that, you can create the GraphQL module definition in the file
-`extensions/click-counter/graphql/index.ts` with the following content:
+`example-extensions/click-counter/graphql/index.ts` with the following content:
 
-```typescript title="extensions/click-counter/graphql/index.ts"
+```typescript title="example-extensions/click-counter/graphql/index.ts"
 export default {
   namespace: "ClickCounter",
 };
@@ -67,7 +67,7 @@ and that does nothing for now.
 Then, the extension needs to declare that it provides a GraphQL module by
 modifying the extension's index.ts:
 
-```typescript title="Changes to extensions/click-counter/index.ts"
+```typescript title="Changes to example-extensions/click-counter/index.ts"
 import { defineExtension } from "@front-commerce/core";
 
 export default function clickCounter() {
@@ -78,7 +78,7 @@ export default function clickCounter() {
     },
     // highlight-start
     graphql: {
-      unstable_module: "./extensions/click-counter/graphql",
+      unstable_module: "./example-extensions/click-counter/graphql",
     },
     // highlight-end
   });
@@ -123,7 +123,7 @@ For that file to be taken into account, the extension needs to declare that it
 provides one or several schema file by modifying the
 `extension/click-counter/index.ts`:
 
-```typescript title="Changes to extensions/click-counter/index.ts"
+```typescript title="Changes to example-extensions/click-counter/index.ts"
 import { defineExtension } from "@front-commerce/core";
 
 export default function clickCounter() {
@@ -134,8 +134,8 @@ export default function clickCounter() {
     },
     graphql: {
       // highlight-next-line
-      schema: ["./extensions/click-counter/graphql/schema.gql"],
-      unstable_module: "./extensions/click-counter/graphql",
+      schema: ["./example-extensions/click-counter/graphql/schema.gql"],
+      unstable_module: "./example-extensions/click-counter/graphql",
     },
   });
 }
@@ -144,7 +144,7 @@ export default function clickCounter() {
 :::tip
 
 The `schema` can also be a be a globby pattern, for instance
-`./extensions/click-counter/graphql/*.gql`.
+`./example-extensions/click-counter/graphql/*.gql`.
 
 :::
 
@@ -204,7 +204,7 @@ To learn more about resolvers and their internals, we recommend reading
 
 First, let's update the module definition as follow:
 
-```typescript title="Changes to extensions/click-counter/graphql/index.ts"
+```typescript title="Changes to example-extensions/click-counter/graphql/index.ts"
 // highlight-next-line
 import resolvers from "./resolvers";
 
@@ -217,7 +217,7 @@ export default {
 
 And then create the `resolvers.ts` file with a resolver map as below:
 
-```typescript title="extensions/click-counter/graphql/resolvers.ts"
+```typescript title="example-extensions/click-counter/graphql/resolvers.ts"
 export default {
   Product: {
     clickCounter: (product) => {
@@ -250,7 +250,7 @@ playground.
 As stated above, a resolver function can also return a Promise and thus handle
 asynchronous result. A more real life resolver map would like look like:
 
-```typescript title="extensions/click-counter/graphql/resolvers.ts"
+```typescript title="example-extensions/click-counter/graphql/resolvers.ts"
 export default {
   Product: {
     clickCounter: (product) => {

--- a/docs/03-extensions/algolia/how-to/standalone.mdx
+++ b/docs/03-extensions/algolia/how-to/standalone.mdx
@@ -137,7 +137,7 @@ configuration settings. To customize it, you need
 [to inject a specific configurations](/docs/3.x/guides/configuration). For that,
 you can create a dedicated extension that registers a configuration provider.
 
-[The example extension `custom-algolia-search`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/skeleton/extensions/custom-algolia-search)
+[The example extension `custom-algolia-search`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/tree/main/skeleton/example-extensions/custom-algolia-search)
 shows how the index prefix can be manipulated, in that example the current shop
 locale is added to it.
 


### PR DESCRIPTION
This PR follows [!3037](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/3037) and updates all `skeleton/extensions` reference to `skeleton/example-extensions`.