### PR TITLE
Update migration guide with latest implementation about automatic session commit

### DIFF
--- a/docs/100-upgrade/migration-guides/3.2-3.3.mdx
+++ b/docs/100-upgrade/migration-guides/3.2-3.3.mdx
@@ -17,9 +17,24 @@ pnpm update "@front-commerce/\*@3.3.0"
 
 ## Automated Migration
 
+We provide a codemod to automatically update your codebase to the latest version
+of Front-Commerce. This tool will update your code when possible and flag the
+places where you need to manually update your code (with `// TODO Codemod`
+comments).
+
 ```shell
 pnpm run front-commerce migrate --transform 3.3.0
 ```
+
+Search for `TODO Codemod` comments in your codebase. They could be added to for
+the following manual updates:
+
+- removing `Set-Cookie` headers defined in routes, they are now automatically
+  set by Front-Commerce when needed (for a user session commit). See
+  [Automatic session cookie headers](#automatic-session-cookie-headers) for
+  details.
+- simplifying the `entry.server.tsx` file after automatic removal of
+  transformers
 
 ## Code changes
 
@@ -29,63 +44,6 @@ In this release, we improved features that required to hook into your Remix
 application files created with the initial skeleton.<br /> You must update these
 files in your application, as detailed below **or copy the ones from the latest
 skeleton**.
-
-<details>
-  <summary><code>entry.server.ts</code> file</summary>
-
-```diff
-diff --git a/skeleton/app/entry.server.tsx b/skeleton/app/entry.server.tsx
-index 297a34fa2..8012fda4c 100644
---- a/skeleton/app/entry.server.tsx
-+++ b/skeleton/app/entry.server.tsx
-@@ -89,10 +89,10 @@ function handleBotRequest(
-             headers: responseHeaders,
-             status: responseStatusCode,
-           });
--          transformBotResponse(response, loadContext.frontCommerce);
--          resolve(response);
--
--          pipe(body);
-+          transformBotResponse(response, loadContext.frontCommerce).then(() => {
-+            resolve(response);
-+            pipe(body);
-+          });
-         },
-         onShellError(error: unknown) {
-           reject(error);
-@@ -143,10 +143,12 @@ function handleBrowserRequest(
-             headers: responseHeaders,
-             status: responseStatusCode,
-           });
--          transformBrowserResponse(response, loadContext.frontCommerce);
--          resolve(response);
--
--          pipe(body);
-+          transformBrowserResponse(response, loadContext.frontCommerce).then(
-+            () => {
-+              resolve(response);
-+              pipe(body);
-+            }
-+          );
-         },
-         onShellError(error: unknown) {
-           reject(error);
-@@ -162,10 +164,10 @@ function handleBrowserRequest(
-   });
- }
-
--export function handleDataRequest(
-+export async function handleDataRequest(
-   response: Response,
-   { context }: DataFunctionArgs
- ) {
--  transformDataResponse(response, context.frontCommerce);
-+  await transformDataResponse(response, context.frontCommerce);
-   return response;
- }
-```
-
-</details>
 
 <details>
   <summary><code>root.tsx</code> file</summary>
@@ -135,12 +93,6 @@ index a28dcf87e..68e788d96 100644
 In this release, we added a feature that will automatically set the `Set-Cookie`
 header for the session cookie when the user session needs to be commited.
 
-<details>
-
-<summary>
-  <code>app/routes/my-route.ts</code> file
-</summary>
-
 ```diff title="app/routes/my-route.ts"
 import { FrontCommerceApp } from "@front-commerce/remix";
 import { json } from "@front-commerce/remix/node";
@@ -152,22 +104,13 @@ const loader = async ({ context, request }) => {
     const data = app.query(MyQuery);
 -    return json(data, {
 -        headers: {
+-            // TODO Codemod FC-3.3: please, remove the `Set-Cookie` header manually. Session is now automatically commited by FC.
 -            "Set-Cookie": await app.user.session.commit(),
 -        },
 -    });
 +    return json(data);
 }
 ```
-
-</details>
-
-:::caution
-
-Due to how the requests are handled by the current version of Remix, this will
-only work when creating response with `json()` without passing a second
-parameter.
-
-:::
 
 ### Deprecate `process.env.FRONT_COMMERCE_WEB_*` usage
 


### PR DESCRIPTION
This PR updates the migration guide documented in #831 to be synced with latest changes (and codemods) added in https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/3061 and https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/3062

[:eyeglasses: **Preview**](https://deploy-preview-839--heuristic-almeida-1a1f35.netlify.app/docs/3.x/upgrade/migration-guides/3.2-3.3)