### PR TITLE
chore: remove __dirname examples

### DIFF
--- a/docs/02-guides/override-a-component.mdx
+++ b/docs/02-guides/override-a-component.mdx
@@ -86,7 +86,7 @@ export default function themeAcme() {
   return defineExtension({
     name: "AcmeTheme",
     // highlight-next-line
-    theme: path.join(__dirname, "theme"),
+    theme: "extensions/theme-acme/theme",
     configuration: {
       providers: [],
     },

--- a/docs/02-guides/translate-your-application.mdx
+++ b/docs/02-guides/translate-your-application.mdx
@@ -196,12 +196,12 @@ $ pnpm run front-commerce translate <my-extension>/**/*.{js,jsx,ts,tsx} --locale
 And then in your extension definition file you should add the `translations`
 option:
 
-```ts title="<my-extension>/index.ts"
+```ts title="extensions/acme-extension/index.ts"
 import { defineExtension } from "@front-commerce/core";
 
 export default defineExtension({
   // ...
-  translations: `${__dirname}/translations`, // path to your translations
+  translations: `extensions/acme-extension/translations`, // path to your translations
 });
 ```
 


### PR DESCRIPTION
## What?
Removes `__dirname` from examples to be more iso with what happens when installing a front-commerce app