### PR TITLE
fix: Fixed 'description' medatada typo

### DIFF
--- a/versioned_docs/version-2.x/prismic/resolver-cache.mdx
+++ b/versioned_docs/version-2.x/prismic/resolver-cache.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 8
 title: Cache
-descriptions:
+description:
   The PrismicCachedResolver is a decorator for a resolver that returns Prismic
   Content. It caches the results at a resolver level with references to the
   documents.


### PR DESCRIPTION
This MR fixes a typo in Prismic Cache documentation, that made a visual bug in the Prismic category page.

Before:

![image](https://github.com/front-commerce/developers.front-commerce.com/assets/4162177/5bf84800-3691-43dd-a39c-e4aa7f49baa2)


After:

![image](https://github.com/front-commerce/developers.front-commerce.com/assets/4162177/7ffcd2f8-2098-49b5-8053-da6e8de53a3b)

Preview: https://deploy-preview-848--heuristic-almeida-1a1f35.netlify.app/docs/2.x/category/prismic
