### PR TITLE
Added migration guide about theme chocolatine style refactor

### DIFF
--- a/docs/100-upgrade/migration-guides/3.2-3.3.mdx
+++ b/docs/100-upgrade/migration-guides/3.2-3.3.mdx
@@ -199,3 +199,24 @@ export default {
   },
 };
 ```
+
+### Theme chocolatine styles refactor
+
+In this release, we refactored how the design tokens are included in the style
+sheets. They are now included through the
+[`_design-tokens.scss`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/packages/theme-chocolatine/theme/_design-tokens.scss)
+file. <br /> If you have overwritten the
+[`theme/main.scss` ](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/packages/theme-chocolatine/theme/main.scss#L3)
+then you should either apply the changes as detailed below or
+[copy the file from the latest skeleton](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/packages/theme-chocolatine/theme/main.scss).
+
+- `theme/components/_components.scss` has been completely removed
+- `theme/main.scss` design tokens importation
+  ```scss title="theme/main.scss"
+  @import "theme/normalize";
+  @import "theme/variables";
+  // remove-next-line
+  @import "theme/components/components";
+  // add-next-line
+  @import "theme/design-tokens";
+  ```


### PR DESCRIPTION
This MR documents a forgotten migration guide following [FC-1802](https://linear.app/front-commerce/issue/FC-1802/styles-typography-fonts-etc-import-from-a-location-making-sense).

[Preview](https://deploy-preview-854--heuristic-almeida-1a1f35.netlify.app/docs/3.x/upgrade/migration-guides/3.2-3.3#theme-chocolatine-styles-refactor)