### PR TITLE
Added missing required manual change to 3.3 migration guide

### DIFF
--- a/docs/100-upgrade/migration-guides/3.0-3.1.mdx
+++ b/docs/100-upgrade/migration-guides/3.0-3.1.mdx
@@ -23,7 +23,28 @@ pnpm run front-commerce migrate --transform 3.1.0
 
 ## Code changes
 
-There is no specific code changes for this upgrade.
+### Front-Commerce `post-install` script
 
-We have already contacted most projects using early versions of Front-Commerce
-3.0 during alpha releases.
+In this release, we
+[added a `post-install` script](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/3.3.x/packages/remix/cli/front-commerce-postinstall/index.ts)
+in order to patch an issue with the current version of `@remix-run/dev` we are
+using. To cope with this, please ensure you applied have the following change in
+your
+[`package.json`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/3.3.x/skeleton/package.json?ref_type=heads#L17):
+
+```diff
+// ...
+  "scripts": {
+    "build": "front-commerce build",
+    "dev": "front-commerce dev --manual -c \"pnpm run dev:server\"",
+    "dev:debug": "front-commerce dev --manual -c \"pnpm run dev:server --inspect\"",
+    "dev:server": "tsx watch --ignore ./build/version.txt --ignore ./build/index.js --clear-screen=false -r tsconfig-paths/register server.ts",
+    "start": "cross-env NODE_ENV=production tsx -r tsconfig-paths/register ./server.ts",
+    "translate": "front-commerce translate ./app/**/*.{js,jsx,ts,tsx} --locale en",
+    "front-commerce": "front-commerce",
+-   "typecheck": "tsc"
++   "typecheck": "tsc",
++   "postinstall": "front-commerce postinstall"
+  },
+// ...
+```

--- a/docs/100-upgrade/migration-guides/3.1-3.2.mdx
+++ b/docs/100-upgrade/migration-guides/3.1-3.2.mdx
@@ -226,6 +226,32 @@ index 71936d5a1..a28dcf87e 100644
 
 </details>
 
+### Front-Commerce `post-install` script
+
+In this release, we
+[added a `post-install` script](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/3.3.x/packages/remix/cli/front-commerce-postinstall/index.ts)
+in order to patch an issue with the current version of `@remix-run/dev` we are
+using. To cope with this, please ensure you applied have the following change in
+your
+[`package.json`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/3.3.x/skeleton/package.json?ref_type=heads#L17):
+
+```diff
+// ...
+  "scripts": {
+    "build": "front-commerce build",
+    "dev": "front-commerce dev --manual -c \"pnpm run dev:server\"",
+    "dev:debug": "front-commerce dev --manual -c \"pnpm run dev:server --inspect\"",
+    "dev:server": "tsx watch --ignore ./build/version.txt --ignore ./build/index.js --clear-screen=false -r tsconfig-paths/register server.ts",
+    "start": "cross-env NODE_ENV=production tsx -r tsconfig-paths/register ./server.ts",
+    "translate": "front-commerce translate ./app/**/*.{js,jsx,ts,tsx} --locale en",
+    "front-commerce": "front-commerce",
+-   "typecheck": "tsc"
++   "typecheck": "tsc",
++   "postinstall": "front-commerce postinstall"
+  },
+// ...
+```
+
 ### Order filters
 
 **Breaking:** In this release, we updated the order filters feature (released in

--- a/docs/100-upgrade/migration-guides/3.1-3.2.mdx
+++ b/docs/100-upgrade/migration-guides/3.1-3.2.mdx
@@ -187,10 +187,10 @@ index bdb7e77a..4ece0e63 100644
   <summary><code>root.tsx</code> file</summary>
 
 ```diff
-diff --git a/skeleton/app/root.tsx b/skeleton/app/root.tsx
+diff --git a/app/root.tsx b/app/root.tsx
 index 71936d5a1..a28dcf87e 100644
---- a/skeleton/app/root.tsx
-+++ b/skeleton/app/root.tsx
+--- a/app/root.tsx
++++ b/app/root.tsx
 @@ -1,7 +1,7 @@
  import { CompatScripts } from "@front-commerce/compat/CompatProvider";
  import { FrontCommerceApp } from "@front-commerce/remix";

--- a/docs/100-upgrade/migration-guides/3.2-3.3.mdx
+++ b/docs/100-upgrade/migration-guides/3.2-3.3.mdx
@@ -84,9 +84,89 @@ index a28dcf87e..68e788d96 100644
 +    publicConfig: app.config.public,
    });
  };
+@@ -62,7 +62,7 @@ export const meta: MetaFunction = (args) => {
+     { title: config.defaultTitle },
+     { name: "robots", content: "Index,Follow" },
+     { name: "description", content: config.defaultDescription },
+-    { name: "baseUrl", content: args.data?.shop?.url },
++    { name: "baseUrl", content: args.data?.publicConfig?.shop?.url },
+     ...manifest?.pwa.metas,
+   ];
+   if (config.themeColor) {
 ```
 
 </details>
+
+<details>
+  <summary><code>entry.client.tsx</code> file</summary>
+
+```diff
+diff --git a/skeleton/app/entry.client.tsx b/skeleton/app/entry.client.tsx
+index e1530e9f8..dcb9118c1 100644
+--- a/skeleton/app/entry.client.tsx
++++ b/skeleton/app/entry.client.tsx
+@@ -21,7 +21,9 @@ const StrictModeOrNoop = appManifest.v2_compat?.useApolloClientQueries
+   : StrictMode;
+
+ const hydrate = async () => {
+-  const shop = __remixContext.state.loaderData?.root.shop;
++  const rootLoaderData = __remixContext.state.loaderData?.root;
++  const shop = rootLoaderData?.publicConfig?.shop;
++
+   const messages = await fetch(`/translations/${shop?.locale}`).then(
+     (res) => res.json() || {}
+   );
+```
+
+</details>
+
+<details>
+  <summary><code>entry.server.tsx</code> file</summary>
+
+```diff
+diff --git a/skeleton/app/entry.server.tsx b/skeleton/app/entry.server.tsx
+index ffd0db3d2..b39a41f34 100644
+--- a/skeleton/app/entry.server.tsx
++++ b/skeleton/app/entry.server.tsx
+@@ -32,7 +32,8 @@ export default async function handleRequest(
+   remixContext: EntryContext,
+   loadContext: AppLoadContext
+ ) {
+-  const shop = remixContext.staticHandlerContext.loaderData.root.shop;
++  const rootLoaderData = __remixContext.state.loaderData?.root;
++  const shop = rootLoaderData?.publicConfig?.shop;
+   const messages = await loadTranslationMessages(shop.locale);
+
+   return isbot(request.headers.get("user-agent"))
+```
+
+</details>
+
+### Front-Commerce `post-install` script
+
+In this release, we
+[added a `post-install` script](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/3.3.x/packages/remix/cli/front-commerce-postinstall/index.ts)
+in order to patch an issue with the current version of `@remix-run/dev` we are
+using. To cope with this, please ensure you applied have the following change in
+your
+[`package.json`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/3.3.x/skeleton/package.json?ref_type=heads#L17):
+
+```diff
+// ...
+  "scripts": {
+    "build": "front-commerce build",
+    "dev": "front-commerce dev --manual -c \"pnpm run dev:server\"",
+    "dev:debug": "front-commerce dev --manual -c \"pnpm run dev:server --inspect\"",
+    "dev:server": "tsx watch --ignore ./build/version.txt --ignore ./build/index.js --clear-screen=false -r tsconfig-paths/register server.ts",
+    "start": "cross-env NODE_ENV=production tsx -r tsconfig-paths/register ./server.ts",
+    "translate": "front-commerce translate ./app/**/*.{js,jsx,ts,tsx} --locale en",
+    "front-commerce": "front-commerce",
+-   "typecheck": "tsc"
++   "typecheck": "tsc",
++   "postinstall": "front-commerce postinstall"
+  },
+// ...
+```
 
 ### Automatic session cookie headers
 

--- a/docs/100-upgrade/migration-guides/3.2-3.3.mdx
+++ b/docs/100-upgrade/migration-guides/3.2-3.3.mdx
@@ -49,10 +49,10 @@ skeleton**.
   <summary><code>root.tsx</code> file</summary>
 
 ```diff
-diff --git a/skeleton/app/root.tsx b/skeleton/app/root.tsx
+diff --git a/app/root.tsx b/app/root.tsx
 index a28dcf87e..68e788d96 100644
---- a/skeleton/app/root.tsx
-+++ b/skeleton/app/root.tsx
+--- a/app/root.tsx
++++ b/app/root.tsx
 @@ -21,30 +21,15 @@ import {
  import { usePageProgress } from "theme/components/helpers/usePageProgress";
  import "theme/main.css";
@@ -101,10 +101,10 @@ index a28dcf87e..68e788d96 100644
   <summary><code>entry.client.tsx</code> file</summary>
 
 ```diff
-diff --git a/skeleton/app/entry.client.tsx b/skeleton/app/entry.client.tsx
+diff --git a/app/entry.client.tsx b/app/entry.client.tsx
 index e1530e9f8..dcb9118c1 100644
---- a/skeleton/app/entry.client.tsx
-+++ b/skeleton/app/entry.client.tsx
+--- a/app/entry.client.tsx
++++ b/app/entry.client.tsx
 @@ -21,7 +21,9 @@ const StrictModeOrNoop = appManifest.v2_compat?.useApolloClientQueries
    : StrictMode;
 
@@ -124,10 +124,10 @@ index e1530e9f8..dcb9118c1 100644
   <summary><code>entry.server.tsx</code> file</summary>
 
 ```diff
-diff --git a/skeleton/app/entry.server.tsx b/skeleton/app/entry.server.tsx
+diff --git a/app/entry.server.tsx b/app/entry.server.tsx
 index ffd0db3d2..b39a41f34 100644
---- a/skeleton/app/entry.server.tsx
-+++ b/skeleton/app/entry.server.tsx
+--- a/app/entry.server.tsx
++++ b/app/entry.server.tsx
 @@ -32,7 +32,8 @@ export default async function handleRequest(
    remixContext: EntryContext,
    loadContext: AppLoadContext


### PR DESCRIPTION
This MR covers:
- Missing changes related to `publicConfig` usage
- Missing changes in `package.json` following the addition of a `post-install` script

Previews:
- [Remix entrypoints](https://deploy-preview-855--heuristic-almeida-1a1f35.netlify.app/docs/3.x/upgrade/migration-guides/3.2-3.3#remix-entrypoints)
- [post-install](https://deploy-preview-855--heuristic-almeida-1a1f35.netlify.app/docs/3.x/upgrade/migration-guides/3.2-3.3#front-commerce-post-install-script)