### PR TITLE
chore: Fixed typo in Payzen documentation

### DIFF
--- a/docs/03-extensions/payzen/how-to/front-commerce.mdx
+++ b/docs/03-extensions/payzen/how-to/front-commerce.mdx
@@ -62,10 +62,10 @@ support new extension points for Payments.
    +import PayzenEmbeddedForm from "theme/modules/Checkout/Payment/AdditionalPaymentInformation/PayzenEmbeddedForm";
 
    const ComponentMap = {
-    +payzen_embedded: PayzenEmbeddedForm
+   +  payzen_embedded: PayzenEmbeddedForm
    };
 
    ```
 
-
-After restarting Front-Commerce, you should be able to see a new payment method called "credit card" in your checkout step.
+After restarting Front-Commerce, you should be able to see a new payment method
+called "credit card" in your checkout step.


### PR DESCRIPTION
This (small) PR fixes a (equally small) typo in Payzen's documentation.

[Preview](https://deploy-preview-858--heuristic-almeida-1a1f35.netlify.app/docs/3.x/extensions/payzen/how-to/front-commerce)

Before:

![image](https://github.com/front-commerce/developers.front-commerce.com/assets/4162177/393f804e-cb66-4a9f-8c11-93f86db7e186)

After:

![image](https://github.com/front-commerce/developers.front-commerce.com/assets/4162177/9c31d98b-3717-4620-993d-201ed865e214)
