### PR TITLE
docs: Updated defineRemixExtension documentation along with the migration guide

### DIFF
--- a/docs/02-guides/extend-route-layout.mdx
+++ b/docs/02-guides/extend-route-layout.mdx
@@ -50,43 +50,8 @@ export default Layout;
 
 This will override the existing `_main.tsx` layout in the original theme, it
 doing so it might also override required actions, loaders, meta, etc. Please
-refer to the original layout to ensure you are not missing anything. If you you
-simply require a new layout, you can name it differently, for example
-`_layout.tsx`. or re-use the existing layout route, see
-[below](#re-use-an-existing-layout-route).
-
-:::
-
-## Re-use an existing layout route
-
-To re-use an existing layout route you can create a new file in the `routes`
-
-```tsx title="routes/_main.tsx"
-export * from "theme/UNSTABLE_routes/_main"; // ensures all actions, loaders, meta, etc. are preserved
-export { default } from "theme/UNSTABLE_routes/_main"; // ensures the component is preserved
-```
-
-Using this method you can also extend an existing layout route, for example
-
-```tsx title="routes/_main.tsx"
-export * from "theme/UNSTABLE_routes/_main";
-import MainLayout from "theme/UNSTABLE_routes/_main";
-
-const ExtendedMainLayout = () => {
-  return (
-    <div>
-      <MainLayout />
-      <div>My custom content</div>
-    </div>
-  );
-};
-```
-
-In the above example the `<MainLayout>` already contains an `<Outlet>` so you do
-not need to add it a second time.
-
-:::caution
-
-As indicated by the `UNSTABLE_` prefix, this is an unstable API and may change.
+refer to the original layout to ensure you are not missing anything. It is at
+the moment not possible to reuse functions from the original route without
+copying and pasting its logic over to your new route file.
 
 :::

--- a/docs/04-api-reference/front-commerce-remix/defineRemixExtension.mdx
+++ b/docs/04-api-reference/front-commerce-remix/defineRemixExtension.mdx
@@ -40,7 +40,7 @@ defineRemixExtension({
   name: "acme",
   theme: "./extensions/acme/theme",
   // highlight-next-line
-  routes: "extensions/acme",
+  routes: import.meta.url,
 });
 ```
 
@@ -75,25 +75,9 @@ convention is the same as using the `routes` directory in a Remix application.
 {
   name: "acme",
   theme: "./extensions/acme/theme",
-  routes: "extensions/acme",
+  routes: import.meta.url,
 }
 ```
-
-:::caution
-
-The `flatRoutes` from Remix requires a placeholder `root.tsx` file at the same
-level as the `routes` directory.
-
-```
-extensions
-└─ acme
-   ├─ root.tsx
-   └─ routes
-      ├─ acme.tsx
-      └─ index.tsx
-```
-
-:::
 
 #### Config based routes:
 

--- a/docs/100-upgrade/migration-guides/3.3-3.4.mdx
+++ b/docs/100-upgrade/migration-guides/3.3-3.4.mdx
@@ -173,6 +173,34 @@ export default defineExtension({
 
 :::
 
+### Refactor of `routes`
+
+In this version we updated how `routes` parameter from `defineRemixExtension` is
+resolved. When using folder based routing, you should pass `import.meta.url` to
+the `routes` in your extension definition:
+
+```js
+{
+  name: "acme",
+  theme: "./extensions/acme/theme",
+  routes: import.meta.url,
+}
+```
+
+:::info
+
+`root.tsx` files in your extensions aren't needed anymore, and can now be
+removed.<br /> For more information, see
+[`defineRemixExtension`'s API reference](/docs/3.x/api-reference/front-commerce-remix/defineRemixExtension#routes)
+
+:::
+
+Additionally, we removed the `UNSTABLE_routes` API. If you were previously
+extending a layout or route file using `UNSTABLE_routes`, you will have to
+remove its usage and instead copy the original file entirely and apply your
+override on it.<br /> For more information about this change, see the
+[Extend a route layout guide](/docs/3.x/guides/extend-route-layout).
+
 ## Code changes
 
 ### Requisition list related theme changes


### PR DESCRIPTION
This MR updates the docs followings changes regarding routes in `definedRemixExtension` API.

