### PR TITLE
docs(stripe): adding docs for stripe

### DIFF
--- a/docs/03-extensions/stripe/_category_.yml
+++ b/docs/03-extensions/stripe/_category_.yml
@@ -1,0 +1,5 @@
+label: "Stripe"
+position: 8
+link:
+  type: doc
+  id: index

--- a/docs/03-extensions/stripe/how-to/_category_.yml
+++ b/docs/03-extensions/stripe/how-to/_category_.yml
@@ -1,0 +1,3 @@
+label: "How-to"
+position: 1
+collapsible: true

--- a/docs/03-extensions/stripe/how-to/apple-pay-google-pay.mdx
+++ b/docs/03-extensions/stripe/how-to/apple-pay-google-pay.mdx
@@ -1,0 +1,22 @@
+---
+title: Enable Apple Pay and/or Google Pay
+description:
+  "This explain how Apple Pay and/or Google Pay can be used with Stripe in
+  Front-Commerce"
+sidebar_position: 2
+---
+
+<p>{frontMatter.description}</p>
+
+If enabled in your Stripe account, Apple Pay and Google Pay payment methods are
+supported and can be used in your Front-Commerce store. Please refer to
+[the Google Pay with Stripe](https://stripe.com/docs/google-pay) and
+[the Apple Pay with Stripe](https://stripe.com/docs/apple-pay) documentation to
+learn how to configure those payment methods.
+
+:::tip
+
+For those payment methods to show up, your Front-Commerce store must use the
+https protocol even in a test environment.
+
+:::

--- a/docs/03-extensions/stripe/how-to/customize-data.mdx
+++ b/docs/03-extensions/stripe/how-to/customize-data.mdx
@@ -1,0 +1,32 @@
+---
+title: Customize data sent to Stripe
+description: "This guide explains how to Customize data sent to Stripe"
+sidebar_position: 1
+---
+
+<p>{frontMatter.description}</p>
+
+:::caution WIP
+
+<span>
+  This advanced pattern must be documented with further details. While we are
+  working on it, please <ContactLink /> if you need further assistance.
+</span>
+
+See the tests for an example (while a detailed documentation is being written):
+
+- https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/fc-2160-stripe-payment-extension-for-magento2/packages/stripe/modules/__tests__/loader.spec.js#L101
+- https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/fc-2160-stripe-payment-extension-for-magento2/packages/stripe/modules/__tests__/loader.spec.js#L254
+
+:::
+
+The Stripe payment module is extensible. It leverages Front-Commerce's
+[data transform](/docs/3.x/api-reference/front-commerce-core/makeCustomizableData)
+pattern to allow developers to customize payloads sent to Stripe for Customer
+and Cart content.
+
+Both the `Customer` and `PaymentIntent` Stripe objects can be customized at
+application level. It allows to add additional metadata depending on your own
+logic. For this, you can use the `registerCustomerDataTransform` and
+`registerPaymentIntentDataTransform` methods of the Stripe loader to add your
+custom transformers.

--- a/docs/03-extensions/stripe/how-to/disable-automatic-capture.mdx
+++ b/docs/03-extensions/stripe/how-to/disable-automatic-capture.mdx
@@ -1,0 +1,21 @@
+---
+title: Disable automatic capture
+description:
+  "This guide explains how to disable Automatic capture of Stripe payments"
+sidebar_position: 3
+---
+
+<p>{frontMatter.description}</p>
+
+Optionally the environment variable `FRONT_COMMERCE_STRIPE_DISABLE_CAPTURE` can
+be set to `true` to configure the Stripe module so that the payment is not
+automatically captured. You can opt-in to this behavior, by adding the variable
+to your `.env`:
+
+```diff title=".env"
+# Stripe payment
+# API Keys from https://dashboard.stripe.com/account/apikeys
+FRONT_COMMERCE_WEB_STRIPE_PUBLISHABLE_KEY=pk_xxxxxx
+FRONT_COMMERCE_STRIPE_SECRET_KEY=sk_xxxxxx
++FRONT_COMMERCE_STRIPE_DISABLE_CAPTURE=true
+```

--- a/docs/03-extensions/stripe/index.mdx
+++ b/docs/03-extensions/stripe/index.mdx
@@ -1,0 +1,81 @@
+---
+title: "Stripe"
+description:
+  "This extension allows the usage of Stripe in your Front-Commerce application."
+---
+
+<SinceVersion tag="3.5" />
+
+<p>{frontMatter.description}</p>
+
+## Installation
+
+First ensure you have installed the package:
+
+```bash
+$ pnpm install @front-commerce/stripe
+```
+
+## Front-Commerce configuration
+
+[After installing the Stripe package](/docs/3.x/extensions/stripe/#installation),
+you need to enable the corresponding extension. For that, you need to tweak your
+`front-commerce.config.ts` file like this:
+
+```typescript title="front-commerce.config.ts"
+import { defineConfig } from "@front-commerce/core/config";
+import themeChocolatine from "@front-commerce/theme-chocolatine";
+import magento2 from "@front-commerce/magento2";
+// highlight-next-line
+import stripe from "@front-commerce/stripe";
+import storesConfig from "./app/config/stores";
+import cacheConfig from "./app/config/caching";
+
+export default defineConfig({
+  extensions: [
+    themeChocolatine(),
+    magento2({ storesConfig }),
+    // highlight-next-line
+    stripe(), // ⚠️ needs to be after themeChocolatine()
+  ],
+  stores: storesConfig,
+  cache: cacheConfig,
+  configuration: {
+    providers: [],
+  },
+});
+```
+
+## Register your Stripe payment components
+
+:::note
+
+The current method for configuring payment components is an interim solution. We
+recognize that it may be cumbersome for users. Please be assured that this
+process will undergo significant improvements in the future, as Front-Commerce
+evolves to include more versatile extension points for Payment systems.
+
+:::
+
+1. Override the file that lets you register additional payments methods in
+   Front-Commerce
+
+   ```shell
+   mkdir -p app/theme/modules/Checkout/Payment/AdditionalPaymentInformation/
+   cp -u node_modules/@front-commerce/theme-chocolatine/theme/modules/Checkout/Payment/AdditionalPaymentInformation/getAdditionalDataComponent.js app/theme/modules/Checkout/Payment/AdditionalPaymentInformation/getAdditionalDataComponent.js
+   ```
+
+2. Register Stripe
+
+   ```diff title="app/theme/modules/Checkout/Payment/AdditionalPaymentInformation/getAdditionalDataComponent.js"
+   +import StripeCheckout from "theme/modules/Checkout/Payment/AdditionalPaymentInformation/StripeCheckout";
+
+   const ComponentMap = {
+   +  stripe: StripeCheckout,
+   };
+
+   ...
+   ```
+
+After restarting Front-Commerce, you should be able to see a new payment method
+called "credit card" in your checkout step.

--- a/docs/03-extensions/stripe/reference/_category_.yml
+++ b/docs/03-extensions/stripe/reference/_category_.yml
@@ -1,0 +1,3 @@
+label: "Reference"
+position: 2
+collapsible: true

--- a/docs/03-extensions/stripe/reference/environment-variables.mdx
+++ b/docs/03-extensions/stripe/reference/environment-variables.mdx
@@ -1,0 +1,22 @@
+---
+title: "Environment variables"
+description:
+  "This reference lists environment variables used by the Stripe extension."
+sidebar_position: 1
+---
+
+<p>{frontMatter.description}</p>
+
+:::info
+
+Your API keys can be found on your
+[Stripe Dashboard](https://dashboard.stripe.com/account/apikeys)
+
+:::
+
+| Name                                    | Description                                                                                                                                                                                                        | Default value |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
+| FRONT_COMMERCE_STRIPE_SECRET_KEY        | **Required** Your Stripe Secret key                                                                                                                                                                                |               |
+| FRONT_COMMERCE_STRIPE_PUBLISHABLE_KEY   | **Required** Your Stripe Secret key                                                                                                                                                                                |               |
+| FRONT_COMMERCE_STRIPE_MAX_NETWORK_RETRY | The maximum number of network tries should be made to the Stripe network before the call is considered a failure. See [Stripe Documentation](https://github.com/stripe/stripe-node#network-retries) for more infos | `3`           |
+| FRONT_COMMERCE_STRIPE_DISABLE_CAPTURE   | Advanced feature to disable Stripe payment capture see [this guide](/docs/3.x/extensions/stripe/how-to/disable-automatic-capture) to learn more                                                                    | `false`       |


### PR DESCRIPTION
# What

This PR implement documentation for Stripe

[Preview](https://deploy-preview-863--heuristic-almeida-1a1f35.netlify.app/docs/3.x/extensions/stripe/)