### PR TITLE
docs: Documented Offline page migration

### DIFF
--- a/docs/03-extensions/theme-chocolatine/how-to/customize-the-offline-page.mdx
+++ b/docs/03-extensions/theme-chocolatine/how-to/customize-the-offline-page.mdx
@@ -1,0 +1,21 @@
+---
+title: "Customize the offline page"
+description: "This guide explains how to customize the offline page."
+sidebar_position: 3
+---
+
+<p>{frontMatter.description}</p>
+
+The offline page is accessible when you disable your network while navigating in
+your shop. You can preview it at `/__front-commerce/offline`. You can then edit
+the `theme/pages/Offline` component to make sure that this page suits your
+brand.
+
+1. Override the Offline page component:
+
+```shell
+mkdir -p app/theme/pages/Offline
+cp -u node_modules/@front-commerce/theme-chocolatine/pages/Offline/Offline.tsx app/theme/pages/Offline/Offline.tsx
+```
+
+2. Customize the page with your brand's identity.

--- a/docs/100-upgrade/migration-guides/3.3-3.4.mdx
+++ b/docs/100-upgrade/migration-guides/3.3-3.4.mdx
@@ -29,7 +29,7 @@ Here are the commands to run:
 ```shell
 pnpm remove remix-pwa @remix-pwa/dev @remix-pwa/worker-runtime @remix-pwa/cache @remix-pwa/strategy @remix-pwa/sw
 pnpm add -D vite
-pnpm add sharp workbox-window workbox-routing
+pnpm add sharp workbox-window workbox-routing workbox-recipes workbox-strategies
 pnpm update "@remix-run/*@2.8.1"
 
 # And finally update all your Front-Commerce dependencies

--- a/docs/migration/manual-migration.mdx
+++ b/docs/migration/manual-migration.mdx
@@ -631,6 +631,11 @@ export function Header() {
 
 ## Environment variables
 
+### Front-Commerce
+
+In V3, the `FRONT_COMMERCE_DISABLE_OFFLINE_MODE` environment variable has been
+removed completely.
+
 ### Magento
 
 In V2, Magento1 and Magento2 environment variables were prefixed the same way.


### PR DESCRIPTION
[Related MR](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/3282).

This MR documents the Offline page migration to v3.

- How to customize the offline page
- `FRONT_COMMERCE_DISABLE_OFFLINE_MODE` removal (migration guide)

[Preview how-to](https://deploy-preview-872--heuristic-almeida-1a1f35.netlify.app/docs/3.x/extensions/theme-chocolatine/how-to/customize-the-offline-page)

[Preview migration guide](https://deploy-preview-872--heuristic-almeida-1a1f35.netlify.app/docs/3.x/migration/manual-migration#front-commerce)