### PR TITLE
docs(migration): Documented transition to ESM

### DIFF
--- a/docs/migration/manual-migration.mdx
+++ b/docs/migration/manual-migration.mdx
@@ -11,6 +11,31 @@ This manual migration process should be run after the
 [automated migration process](./automated-migration), to complete the missing
 parts, or debug issues in the migration CLI output.
 
+## Transitioning to ESM
+
+Starting 3.0, in a effort to modernize the codebase, we transitioned to ESM.
+This migration allows a better alignment with browsers standards, an improved
+static analysis, enhenced language features and overall a better consistency in
+the JavaScript ecosystem. To learn more about it, see:
+
+- [What is ESM](https://dev.to/iggredible/what-the-heck-are-cjs-amd-umd-and-esm-ikm)
+- [NodeJS docmentation](https://nodejs.org/api/esm.html)
+
+To cope with this transition, you should check that your code does not use
+`module.exports = ` or `module.exports.someNamedExport =` syntax, and replace it
+with `export default` or `export {}` otherwise.
+
+:::info
+
+On linux-based systems, you can use the `grep` command on your project to find
+those occurences:
+
+```bash
+grep "module.exports" src/ -r
+```
+
+:::
+
 ## Components
 
 ### SEO Components


### PR DESCRIPTION
This MR documents the transition to ESM in 3.x in the migration guide. 

[Preview](https://deploy-preview-874--heuristic-almeida-1a1f35.netlify.app/docs/3.x/migration/manual-migration#transitioning-to-esm)