### PR TITLE
docs(migration): Documented removal of remix-pwa in migration guide

### DIFF
--- a/docs/100-upgrade/migration-guides/3.3-3.4.mdx
+++ b/docs/100-upgrade/migration-guides/3.3-3.4.mdx
@@ -268,6 +268,30 @@ remove its usage and instead copy the original file entirely and apply your
 override on it.<br /> For more information about this change, see the
 [Extend a route layout guide](/docs/3.x/guides/extend-route-layout).
 
+## Replacement of `remix-pwa` in favor of `vite-pwa`
+
+In this version we have moved PWA concerns to standard building tools. It
+implied the replacement of `remix-pwa` with `vite-pwa`. You will need to remove
+the packages and their usage from your project:
+
+```shell
+pnpm remove remix-pwa @remix-pwa/dev @remix-pwa/worker-runtime @remix-pwa/cache @remix-pwa/strategy @remix-pwa/sw
+```
+
+In order to find the uses of those package in your project, you can use this
+command:
+
+```shell
+grep "remix-pwa" src/ -r
+```
+
+You will also need to add additional packages used in the service worker to your
+project:
+
+```shell
+pnpm add workbox-window workbox-routing
+```
+
 ## From `graphql.unstable_module` to `graphql.module`
 
 In Front-Commerce v3.4 we've created a brand new GraphQL module API. The

--- a/docs/100-upgrade/migration-guides/3.3-3.4.mdx
+++ b/docs/100-upgrade/migration-guides/3.3-3.4.mdx
@@ -98,7 +98,7 @@ We have introduced vitest in the skeleton, to benefit from the new testing you
 need to add the following to your project
 
 - Add
-  [`vitest.config.ts`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/skeleton/vite.config.ts?ref_type=heads)
+  [`vitest.config.ts`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/skeleton/vitest.config.ts?ref_type=heads)
   configuration file
 - Add
   [`vitest.setup.ts`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/skeleton/vitest.setup.ts?ref_type=heads)


### PR DESCRIPTION
This MR documents the removal of `remix-pwa` packages in the migration guide, as well as the requirement to install `workbox-window`.

[Preview](https://deploy-preview-875--heuristic-almeida-1a1f35.netlify.app/docs/3.x/upgrade/migration-guides/3.3-3.4#removal-of-remix-pwa-in-favor-of-vite-pwa)