### PR TITLE
docs: Update migration guide about missing ESM migration points

### DIFF
--- a/docs/100-upgrade/migration-guides/3.3-3.4.mdx
+++ b/docs/100-upgrade/migration-guides/3.3-3.4.mdx
@@ -92,15 +92,25 @@ export default defineConfig((env) => {
 });
 ```
 
-### Update `package.json` commands
+### Update `package.json`
+
+#### Add `"type": "module"`
+
+```diff file="./package.json"
+{
+  "sideEffects": false,
++ "type": "module",
+  // ...
+}
+```
+
+#### Update commands
 
 We have deprecated the internal `build` and `dev` cli commands in favor of the
 normal commands used in `remix`.
 
 ```diff file="./package.json"
 {
-  "sideEffects": false,
-+ "type": "module",
   "scripts": {
 -   "build": "front-commerce build",
 -   "dev": "front-commerce dev --manual -c \"pnpm run dev:server\"",

--- a/docs/migration/manual-migration.mdx
+++ b/docs/migration/manual-migration.mdx
@@ -15,13 +15,15 @@ parts, or debug issues in the migration CLI output.
 
 Starting 3.0, in a effort to modernize the codebase, we transitioned to ESM.
 This migration allows a better alignment with browsers standards, an improved
-static analysis, enhenced language features and overall a better consistency in
+static analysis, enhanced language features and overall a better consistency in
 the JavaScript ecosystem. To learn more about it, see:
 
 - [What is ESM](https://dev.to/iggredible/what-the-heck-are-cjs-amd-umd-and-esm-ikm)
-- [NodeJS docmentation](https://nodejs.org/api/esm.html)
+- [NodeJS documentation](https://nodejs.org/api/esm.html)
 
 ### Updates in your codebase
+
+#### Updating exports
 
 To cope with this transition, you should check that your code does not use
 `module.exports = ` or `module.exports.someNamedExport =` syntax, and replace it
@@ -37,6 +39,23 @@ grep "module.exports" src/ -r
 ```
 
 :::
+
+#### Uses of `__dirname`
+
+`__dirname` isn't available anymore in ESM. To cope with this change, you will
+need to replace its usage. For example:
+
+```ts
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+```
+
+For more information about alternatives to `__dirname`, see:
+
+- https://blog.logrocket.com/alternatives-dirname-node-js-es-modules/.
+- https://dev.to/brcontainer/alternative-for-dirname-in-node-when-using-ecmascript-modules-5gni
 
 ### Updates in your dependencies
 


### PR DESCRIPTION
This MR adds missing migrations point to take into account while migrating to FC 3.4.

Also fixed a typo in the ESM paragraph.

[Preview](https://deploy-preview-877--heuristic-almeida-1a1f35.netlify.app/docs/3.x/migration/manual-migration#transitioning-to-esm)