### PR TITLE
docs: Documented changes on entry.worker.ts following the offline page support

### DIFF
--- a/docs/02-guides/pwa-setup.mdx
+++ b/docs/02-guides/pwa-setup.mdx
@@ -44,9 +44,12 @@ export default defineConfig({
     appName: "ACME Store",
     shortName: "ACME Store",
     themeColor: "#fbb03b",
-    icon: "public/pwa-icon.png",
-    maskableIcon: "public/pwa-masked-icon",
-    cacheTTLInMs: 7 * 24 * 60 * 60 * 1000,
+    icon: "public/favicon.svg", // we suggest using a svg which can be resized without losing quality
+    maskableIcon: "public/maskable.svg", // we suggest using a svg which can be resized without losing quality
+    offline: {
+      pageFallback: "__front-commerce/offline",
+      imageFallback: "images/Logo.svg", // image url (relative to public folder)
+    },
   },
   // highlight-end
 });
@@ -54,14 +57,14 @@ export default defineConfig({
 
 Here is a list of the available options:
 
-| Option         | Type     | Description                                                                                                          |
-| -------------- | -------- | -------------------------------------------------------------------------------------------------------------------- |
-| `appName`      | `string` | The name of your PWA                                                                                                 |
-| `shortName`    | `string` | The short name of your PWA, it will be displayed on the home screen of your customer                                 |
-| `themeColor`   | `string` | The theme color of your PWA, it will define theme for your App, we recommend you to use your website primary color   |
-| `icon`         | `string` | The icon of your PWA, it will be displayed on the home screen of your end user device, it must be at least 512x512   |
-| `maskableIcon` | `string` | The maskable icon of your PWA, it will be displayed on the home screen of your customer, it must be at lease 512x512 |
-| `cacheTTLInMs` | `number` | The time to live of your PWA Cache in milliseconds, the default value is of 7 days                                   |
+| Option         | Type                                                                                                                       | Description                                                                                                          |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `appName`      | `string`                                                                                                                   | The name of your PWA                                                                                                 |
+| `shortName`    | `string`                                                                                                                   | The short name of your PWA, it will be displayed on the home screen of your customer                                 |
+| `themeColor`   | `string`                                                                                                                   | The theme color of your PWA, it will define theme for your App, we recommend you to use your website primary color   |
+| `icon`         | `string`                                                                                                                   | The icon of your PWA, it will be displayed on the home screen of your end user device, it must be at least 512x512   |
+| `maskableIcon` | `string`                                                                                                                   | The maskable icon of your PWA, it will be displayed on the home screen of your customer, it must be at lease 512x512 |
+| `offline`      | [`OfflineFallbackOptions`](https://developer.chrome.com/docs/workbox/modules/workbox-recipes/#type-OfflineFallbackOptions) | The offline configuration of your PWA                                                                                |
 
 ### Icons setup
 

--- a/docs/100-upgrade/migration-guides/3.3-3.4.mdx
+++ b/docs/100-upgrade/migration-guides/3.3-3.4.mdx
@@ -1026,3 +1026,50 @@ index d55c47369..0c65e479a 100644
 ```
 
 </details>
+
+<details>
+  <summary><code>entry.worker.ts</code> file</summary>
+
+To learn more about this, see the
+[commit that introduced the change](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/3342),
+or our guide on
+[how to customize the offline page](/docs/3.x/extensions/theme-chocolatine/how-to/customize-the-offline-page).
+
+```diff
+diff --git a/app/entry.worker.ts b/app/entry.worker.ts
+index b4189b162..e188ed201 100644
+--- a/app/entry.worker.ts
++++ b/app/entry.worker.ts
+@@ -1,27 +1,3 @@
+-/// <reference lib="WebWorker" />
+-import type { WorkerDataFunctionArgs } from "@remix-pwa/sw";
+-import { synchronizeStorefrontContentFromResponse } from "theme/modules/StorefrontContent/serviceWorker";
++import { setupPwa } from "@front-commerce/remix/service-worker";
+
+-export type {};
+-declare let self: ServiceWorkerGlobalScope;
+-
+-self.addEventListener("install", (event: ExtendableEvent) => {
+-  event.waitUntil(self.skipWaiting());
+-});
+-
+-self.addEventListener("activate", (event: ExtendableEvent) => {
+-  event.waitUntil(self.clients.claim());
+-});
+-
+-export const defaultFetchHandler = async ({
+-  request,
+-}: WorkerDataFunctionArgs) => {
+-  // we MUST return the fetch response promise directly so that streams are supported
+-  const responsePromise = fetch(request);
+-
+-  responsePromise.then((response) => {
+-    synchronizeStorefrontContentFromResponse(response, self.clients);
+-  });
+-
+-  return responsePromise;
+-};
++setupPwa();
+```
+
+</details>


### PR DESCRIPTION
This MR follows [!3295](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/3295) and documents the changes made to `entry.worker.ts` following the addition of the Offline page.

[Preview ](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/packages/remix/config/defineFrontCommerceRoutes.ts#L248)