### PR TITLE
docs: Documented the list of environment variables used by Contentful extension

### DIFF
--- a/docs/03-extensions/contentful/reference/_category_.yml
+++ b/docs/03-extensions/contentful/reference/_category_.yml
@@ -1,0 +1,3 @@
+label: "Reference"
+position: 2
+collapsible: true

--- a/docs/03-extensions/contentful/reference/api.mdx
+++ b/docs/03-extensions/contentful/reference/api.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference"
+title: "API Reference"
 description:
   "A reference to the API specification for the `@front-commerce/contentful`
   package."
@@ -17,7 +17,7 @@ For more details, see:
 
 - [ContentType](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/packages/contentful/graphql/core/domain/ContentType.js)
   API
-- [Add Content Types](./how-to/add-content-types) Documentation
+- [Add Content Types](../how-to/add-content-types) Documentation
 
 ### `BlocksContentType`
 
@@ -25,7 +25,7 @@ For more details, see:
 
 - [BlocksContentType](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/packages/contentful/graphql/core/domain/BlocksContentType.js)
   API
-- [Integrating ContentTypes with BlocksContentType](./how-to/add-content-types#integrating-contenttypes-with-blockscontenttype)
+- [Integrating ContentTypes with BlocksContentType](../how-to/add-content-types#integrating-contenttypes-with-blockscontenttype)
   Documentation
 
 ### `StorefrontContentType`
@@ -34,7 +34,7 @@ For more details, see:
 
 - [StorefrontContentType](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/packages/contentful/graphql/core/domain/StorefrontContentType.js)
   API
-- [X-Ray compatibility](./how-to/add-x-ray-compatibility) Documentation
+- [X-Ray compatibility](../how-to/add-x-ray-compatibility) Documentation
 
 ## Client API
 
@@ -44,7 +44,7 @@ For more details, see:
 
 - [ContentBlock](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/packages/contentful/react/ContentBlock.jsx)
   API
-- [Add Content Blocks](./how-to/add-content-blocks) Documentation
+- [Add Content Blocks](../how-to/add-content-blocks) Documentation
 
 ### `makeContentBlockLibrary`
 
@@ -52,5 +52,5 @@ For more details, see:
 
 - [makeContentBlockLibrary](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/packages/contentful/react/makeContentBlockLibrary.jsx)
   API
-- [Define the Block library](./how-to/add-content-blocks#define-the-block-library)
+- [Define the Block library](../how-to/add-content-blocks#define-the-block-library)
   Documentation

--- a/docs/03-extensions/contentful/reference/environment-variables.mdx
+++ b/docs/03-extensions/contentful/reference/environment-variables.mdx
@@ -1,0 +1,17 @@
+---
+title: "Environment variables"
+description:
+  "This reference lists environment variables used by the Contentful extension."
+sidebar_position: 1
+---
+
+<p>{frontMatter.description}</p>
+
+| Name                                                  | Description                                                             |
+| ----------------------------------------------------- | ----------------------------------------------------------------------- |
+| `FRONT_COMMERCE_CONTENTFUL_SPACE_ID`                  | **Required** The Contentful space id                                    |
+| `FRONT_COMMERCE_CONTENTFUL_ACCESS_TOKEN`              | **Required** The Contentful access token                                |
+| `FRONT_COMMERCE_CONTENTFUL_PREVIEW_ACCESS_TOKEN`      | **Required** The Contentful preview access token                        |
+| `FRONT_COMMERCE_CONTENTFUL_ENVIRONMENT`               | The Contentful environment (default: `master`)                          |
+| `FRONT_COMMERCE_CONTENTFUL_DANGEROUSLY_FORCED_LOCALE` | The Contentful locale                                                   |
+| `FRONT_COMMERCE_CONTENTFUL_DOMAIN`                    | The Contentful domain URL (default: `"https://graphql.contentful.com"`) |

--- a/static/_redirects
+++ b/static/_redirects
@@ -3,6 +3,7 @@
 /blog/:year/:month/:day/:slug                           /changelog/:slug                                        301
 /docs/advanced/features/advanced-external-logins        /docs/2.x/advanced/features/external-logins/advanced    301
 /docs/advanced/theme/wysiwyg-legacy                     /docs/2.x/advanced/theme/wysiwyg/legacy                 301
+/docs/3.x/extensions/contentful/reference               /docs/3.x/extensions/contentful/reference/api           301
 
 # Redirects (temporary)
 /docs                                                   /docs/2.x/welcome	                                      302


### PR DESCRIPTION
This MR refactors the "Reference" section of our Contentful doc to feature a new "Environment variables" section for listing all variables used by the Contentful extension.

[Preview ](https://deploy-preview-891--heuristic-almeida-1a1f35.netlify.app/docs/3.x/extensions/contentful/reference/environment-variables)