### PR TITLE
Dynamic Routing documentation updates

### DIFF
--- a/docs/02-guides/dynamic-routing.mdx
+++ b/docs/02-guides/dynamic-routing.mdx
@@ -59,6 +59,12 @@ const hardcodedRoutes = [
     path: "/acme-product.html",
     identifier: "sku-6",
   },
+  {
+    type: "product"
+    path: "/baz-product.html",
+    redirectTo: "/acme-product.html",
+    redirectType: 301
+  },
 ];
 
 class UrlMatcher implements DynamicRouteUrlMatcher {
@@ -193,6 +199,69 @@ requirements.
 </Step>
 
 </Steps>
+
+## Batching and Prioritizing URL Matchers
+
+When multiple URL matchers are registered without any `matcherOptions`, it will
+default the batchOrder and priority to 0. This means that the order in which the
+URL matchers are registered will determine the order in which they are executed.
+
+Let's say we have the following list of URL Matchers:
+
+```bash
+A → fast API (cached)
+B → no API (static)
+C → slow API (not cached)
+D → no API (static)
+```
+
+We would ideally want this to first try to run `B` and `D` then `A` and finally
+`C`. To achieve this we can set the `batchOrder` and `priority` fields in the
+`matcherOptions` object.
+
+```ts title="extension/index.ts"
+services.DynamicRoutes.registerUrlMatcher("A", () => new UrlMatcher(), {
+  // highlight-start
+  batchOrder: 1,
+  priority: 1,
+  // highlight-end
+});
+
+services.DynamicRoutes.registerUrlMatcher("B", () => new UrlMatcher(), {
+  // highlight-start
+  batchOrder: 0,
+  priority: 2,
+  // highlight-end
+});
+
+services.DynamicRoutes.registerUrlMatcher("C", () => new UrlMatcher(), {
+  // highlight-start
+  batchOrder: 2, // only run if no other batches have matched
+  priority: 1,
+  // highlight-end
+});
+
+services.DynamicRoutes.registerUrlMatcher("D", () => new UrlMatcher(), {
+  // highlight-start
+  batchOrder: 0,
+  priority: 1,
+  // highlight-end
+});
+```
+
+This would result in the following order of execution:
+
+```bash
+# batch 0
+D → no API (static)
+B → no API (static)
+
+  # batch 1
+  A → fast API (cached)
+
+     # batch 2 (only run if no other batches have matched)
+     C → slow API (not cached)
+```
 
 ## Extending the type declarations
 

--- a/docs/02-guides/dynamic-routing.mdx
+++ b/docs/02-guides/dynamic-routing.mdx
@@ -220,28 +220,28 @@ We would ideally want this to first try to run `B` and `D` then `A` and finally
 `matcherOptions` object.
 
 ```ts title="extension/index.ts"
-services.DynamicRoutes.registerUrlMatcher("A", () => new UrlMatcher(), {
+services.DynamicRoutes.registerUrlMatcher("A", () => new UrlMatcherA(), {
   // highlight-start
   batchOrder: 1,
   priority: 1,
   // highlight-end
 });
 
-services.DynamicRoutes.registerUrlMatcher("B", () => new UrlMatcher(), {
+services.DynamicRoutes.registerUrlMatcher("B", () => new UrlMatcherB(), {
   // highlight-start
   batchOrder: 0,
   priority: 2,
   // highlight-end
 });
 
-services.DynamicRoutes.registerUrlMatcher("C", () => new UrlMatcher(), {
+services.DynamicRoutes.registerUrlMatcher("C", () => new UrlMatcherC(), {
   // highlight-start
   batchOrder: 2, // only run if no other batches have matched
   priority: 1,
   // highlight-end
 });
 
-services.DynamicRoutes.registerUrlMatcher("D", () => new UrlMatcher(), {
+services.DynamicRoutes.registerUrlMatcher("D", () => new UrlMatcherD(), {
   // highlight-start
   batchOrder: 0,
   priority: 1,

--- a/docs/migration/manual-migration.mdx
+++ b/docs/migration/manual-migration.mdx
@@ -915,3 +915,34 @@ The page loader has been deprecated in favor of the DynamicRoutes service.
 
 - `registerUrlMatcher` → see
   [Register a `DynamicRouteUrlMatcher`](../guides/dynamic-routing#register-a-dynamicrouteurlmatcher)
+
+The `Routable` types in the schema will eventually be deprecated, as
+`UrlMatchers` no longer use `GraphQL` as they are decoupled into a service.
+
+This also means that the `route` query will be deprecated, if you still require
+this functionality you can implement it using the `DynamicRoutes` service:
+
+```ts
+import { createGraphQLRuntime } from "@front-commerce/core/graphql";
+
+export default createGraphQLRuntime({
+  resolvers: {
+    Query: {
+      route: async (_, { url }, { services, loaders }) => {
+        const route = await services.DynamicRoutes.matchUrl(url);
+        if (!route) {
+          return null;
+        }
+
+        if (route.type === "category") {
+          return loaders.Category.load(route.params.id);
+        } else if (route.type === "product") {
+          return loaders.Product.load(route.params.id);
+        }
+
+        //...
+      },
+    },
+  },
+});
+```


### PR DESCRIPTION
This pull request adds documentation for batching and prioritizing URL matchers in the codebase. It explains how to set the `batchOrder` and `priority` fields in the `matcherOptions` object to control the order of execution for multiple URL matchers. Additionally, it includes an example of the desired order of execution for a list of URL matchers. 

This also includes better migration guide for the deprecated page loader