### PR TITLE
feat(payzen): adding docs about payzen as a front-commerce payment fo…

### DIFF
--- a/docs/03-extensions/payzen/how-to/front-commerce.mdx
+++ b/docs/03-extensions/payzen/how-to/front-commerce.mdx
@@ -27,8 +27,12 @@ export default defineConfig({
   extensions: [
     magento2({ storesConfig }),
     themeChocolatine(),
-    // highlight-next-line
-    payzen(), // ⚠️ need to be after themeChocolatine()
+    // highlight-start
+    // For Magento 1 usage
+    payzen("front-commerce-magento1"), // ⚠️ need to be after themeChocolatine()
+    // For Magento 2 usage
+    payzen("front-commerce-magento2"), // ⚠️ need to be after themeChocolatine()
+    // highlight-end
   ],
   stores: storesConfig,
   cache: cacheConfig,

--- a/docs/03-extensions/payzen/index.mdx
+++ b/docs/03-extensions/payzen/index.mdx
@@ -9,13 +9,6 @@ The implementation use
 [PayZen embedded form / Javascript with REST API](https://payzen.io/fr-FR/rest/V4.0/javascript/)
 to create payments.
 
-:::danger
-
-This extension is only compatible with Magento1/OpenMage, we are working on
-Magento2 compatibility for 3.6.0.
-
-:::
-
 :::info
 
 If you intend to use Payzen as a Magento 2 Payment with native Magento module,

--- a/docs/100-upgrade/migration-guides/3.5-3.6.mdx
+++ b/docs/100-upgrade/migration-guides/3.5-3.6.mdx
@@ -123,3 +123,23 @@ index 7783303fd..a8f621d20 100644
          },
          onError(error: unknown) {
 ```
+## Payzen Module
+
+In this version, we introduced Payzen compatibility for Magento 2. You now need to pass a parameter to the Payzen extension in your `.front-commerce.config.ts` file:
+
+```ts title=".front-commerce.config.ts"
+// ...
+import payzen from "@front-commerce/payzen";
+
+export default defineConfig({
+  // ...
+  extensions: [
+    // ...
+    // For Magento 1 usage
+    payzen("front-commerce-magento1")
+    // For Magento 2 usage
+    payzen("front-commerce-magento2")
+    // ...
+  ]
+  // ...
+});


### PR DESCRIPTION
# What

This add documentation about configuration of Payzen as a Front-Commerce payment for magento 2

# How
- Add documentation on how to use Payzen with Magento1/2 using flavor parameter
- Add Migration guide about adding flavor to payzen extension declaration