### PR TITLE
chore: document react 18.3 canary update

### DIFF
--- a/docs/100-upgrade/migration-guides/3.5-3.6.mdx
+++ b/docs/100-upgrade/migration-guides/3.5-3.6.mdx
@@ -18,6 +18,35 @@ Update all your `@front-commerce/*` dependencies to this version:
 pnpm update "@front-commerce/*@3.6.0"
 ```
 
+:::info REACT 18 CANARY
+
+We have pinned the `react` and `react-dom` version to `18.3.0-canary`, this
+resolves an issue with hydration during HMR changes. See
+[issue](https://github.com/remix-run/remix/issues/4822#issuecomment-2130006831)
+for more details.
+
+To update your project, you can do the following:
+
+```shell
+pnpm update react@18.3.0-canary-2023-05-11 react-dom@18.3.0-canary-2023-05-11
+```
+
+We also suggest adding resolutions to your package.json to ensure the same
+version of React is used in your project:
+
+```json title="package.json"
+{
+  "resolutions": {
+    "react": "18.3.0-canary-2023-05-11",
+    "react-dom": "18.3.0-canary-2023-05-11"
+  }
+}
+```
+
+We suspect that this will only release in version `19` of React.
+
+:::
+
 ## Automated Migration
 
 We provide a codemod to automatically update your codebase to the latest version

--- a/docs/100-upgrade/migration-guides/3.5-3.6.mdx
+++ b/docs/100-upgrade/migration-guides/3.5-3.6.mdx
@@ -43,7 +43,7 @@ version of React is used in your project:
 }
 ```
 
-We suspect that this will only release in version `19` of React.
+We suspect that this fix will only be released in React 19.
 
 :::
 


### PR DESCRIPTION
Documents react canary version update