### PR TITLE
Migration guides: fix typos in the 3.6 guide, and add a section for 2.31.0

### DIFF
--- a/docs/100-upgrade/migration-guides/3.5-3.6.mdx
+++ b/docs/100-upgrade/migration-guides/3.5-3.6.mdx
@@ -101,7 +101,7 @@ To enable `Cache-Control` headers on those routes (if you already overrode
 them), you will need to add the usage of this new service in these routes'
 loaders like so:
 
-```ts title="_main._index.tsx
+```ts title="_main._index.tsx"
 export const loader: LoaderFunction = ({ context }) => {
   const app = new FrontCommerceApp(context.frontCommerce);
   // highlight-start
@@ -126,7 +126,7 @@ For more information about this change, see
 
 In this version we introduced a new `ServerTimings` service that is used to
 generate and append
-[`Server-Timing`](https://linear.app/front-commerce/issue/FC-1725/server-timing-headers)
+[`Server-Timing`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing)
 headers to reponses.
 
 This contains a change to `app/entry.server.tsx`, which you will have to update
@@ -162,6 +162,10 @@ index 7783303fd..a8f621d20 100644
          },
          onError(error: unknown) {
 ```
+
+Learn how to use this new feature for your own code in the
+[Add your own server timings](/docs/3.x/guides/adding-your-own-server-timings)
+guide.
 
 ## Payzen Module
 

--- a/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
@@ -18,10 +18,14 @@ To update Front-Commerce in your project, use the command below _(with the exact
 version you need)_:
 
 ```
-npm install git+ssh://git@gitlab.blackswift.cloud/front-commerce/front-commerce.git#2.28.0
+npm install git+ssh://git@gitlab.blackswift.cloud/front-commerce/front-commerce.git#2.31.0
 ```
 
 :::
+
+## `2.30.0` -> `2.31.0`
+
+No manual migration steps are required for this release.
 
 ## `2.29.0` -> `2.30.0`
 


### PR DESCRIPTION

Preview: 
- [3.6](https://deploy-preview-925--heuristic-almeida-1a1f35.netlify.app/docs/3.x/upgrade/migration-guides/3.5-3.6#server-timings)
- [2.31.0](https://deploy-preview-925--heuristic-almeida-1a1f35.netlify.app/docs/2.x/appendices/migration-guides/)