### PR TITLE
3.6: Document the `pnpm` version update

### DIFF
--- a/docs/100-upgrade/migration-guides/3.5-3.6.mdx
+++ b/docs/100-upgrade/migration-guides/3.5-3.6.mdx
@@ -10,6 +10,19 @@ import TabItem from "@theme/TabItem";
 
 <p>{frontMatter.description}</p>
 
+## Use the latest `pnpm` version
+
+We now support `pnpm` version 9 and above. In the past, we may have recommended
+to stick to `pnpm` version 8. This is no longer the case.
+
+Please make sure to update your `pnpm` version to the latest one.
+
+```shell
+$ pnpm add -g pnpm
+$ pnpm -v
+9.7.0 # or higher
+```
+
 ## Update dependencies
 
 Update all your `@front-commerce/*` dependencies to this version:


### PR DESCRIPTION
So developers can use the latest version.

# Why?

Because using an old `pnpm` version on the latest FC Cloud versions can cause issues with FC 3.6.0.

FC supports pnpm 9 since 3.6 ([MR!3497](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/3497)).

# What?

This PR adds a note in the migration guide so integrators can update their local version.

# Preview

[**Migration guide**](https://deploy-preview-931--heuristic-almeida-1a1f35.netlify.app/docs/3.x/upgrade/migration-guides/3.5-3.6#use-the-latest-pnpm-version)