### PR TITLE
docs: Documented magento 2.4.6 issue with grouped products

### DIFF
--- a/docs/03-extensions/magento2/index.mdx
+++ b/docs/03-extensions/magento2/index.mdx
@@ -145,3 +145,20 @@ export default defineConfig({
   ],
 });
 ```
+
+## Known issues
+
+### Magento 2.4.6: Grouped product options aren't visible
+
+_See related issue: https://github.com/magento/magento2/issues/37774_
+
+On Magento 2.4.6, Front-Commerce may display a Grouped product with a price of
+0€ without any options.
+
+In this version, if products that are part of a grouped product are set to "Not
+Visible Individually", they won't be returned by Magento when retrieving the
+grouped product along with its options. Instead, the returned option will be an
+array of items with `product: null`.
+
+This issue isn't present in Magento 2.4.5, and as been fixed in Magento
+2.4.7-p1.

--- a/versioned_docs/version-2.x/magento2/installation.mdx
+++ b/versioned_docs/version-2.x/magento2/installation.mdx
@@ -115,3 +115,20 @@ To check that the API is properly configured, you can try to request:
 - `http://magento.url/rest/V1/store/storeViews`
 - `http://magento.url/rest/V1/frontcommerce/urls/match?urls[]=<url>` where
   `<url>` is one of the URL key of your products
+
+## Known issues
+
+### Magento 2.4.6: Grouped product options aren't visible
+
+_See related issue: https://github.com/magento/magento2/issues/37774_
+
+On Magento 2.4.6, Front-Commerce may display a Grouped product with a price of
+0€ without any options.
+
+In this version, if products that are part of a grouped product are set to "Not
+Visible Individually", they won't be returned by Magento when retrieving the
+grouped product along with its options. Instead, the returned option will be an
+array of items with `product: null`.
+
+This issue isn't present in Magento 2.4.5, and as been fixed in Magento
+2.4.7-p1.


### PR DESCRIPTION
**_[bugsfc #52003 Magento 2.4.6: Les produits "Grouped" ne se chargent pas](https://tuleap.lundimatin.biz/plugins/tracker/?aid=52003)_**

This MR documents an issue in Magento 2.4.6 that causes grouped product options to be `null` if the related products are set to `Not Visible Individually`.

Previews:
- [V3](https://github.com/front-commerce/developers.front-commerce.com/pull/949)
- [V2](https://deploy-preview-949--heuristic-almeida-1a1f35.netlify.app/docs/2.x/magento2/installation#known-issues)