### PR TITLE
Add Migration Guide for Upgrading from Front-Commerce 3.8 to 3.9

### DIFF
--- a/docs/100-upgrade/migration-guides/3.8-3.9.mdx
+++ b/docs/100-upgrade/migration-guides/3.8-3.9.mdx
@@ -1,0 +1,69 @@
+---
+title: 3.8 -> 3.9
+description:
+  This page lists the highlights for upgrading a project from Front-Commerce 3.8
+  to 3.9
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<p>{frontMatter.description}</p>
+
+## Update dependencies
+
+Update all your `@front-commerce/*` dependencies to this version:
+
+```shell
+pnpm update "@front-commerce/*@3.9.0"
+```
+
+## Automated Migration
+
+We provide a codemod to automatically update your codebase to the latest version
+of Front-Commerce. This tool will update your code when possible and flag the
+places where you need to manually update your code (with `// TODO Codemod`
+comments).
+
+```shell
+pnpm run front-commerce migrate --transform 3.9.0
+```
+
+## Manual Migration
+
+### Remix entrypoints
+
+In this release, we improved features that required to hook into your Remix
+application files created with the initial skeleton. You must update these files
+in your application, as detailed below **or copy the ones from the latest
+skeleton.**
+
+<details>
+  <summary><code>app/root.tsx</code> file</summary>
+
+```diff
+diff --git a/skeleton/app/root.tsx b/skeleton/app/root.tsx
+index 7346671ea..1f0463927 100644
+--- a/skeleton/app/root.tsx
++++ b/skeleton/app/root.tsx
+@@ -21,16 +21,11 @@ import config from "~/config/website";
+ import { pwaAssetsHead } from "virtual:pwa-assets/head";
+ import { RootErrorBoundary } from "theme/pages/Error";
+ import { usePublicConfig } from "@front-commerce/core/react";
+-import { generateRouteErrorMeta } from "theme/pages/Error/meta";
+
+ export const loader = async ({ context }: LoaderFunctionArgs) => {
+   const app = new FrontCommerceApp(context.frontCommerce);
+
+-  return json({
+-    ...app.rootLoaderContext,
+-    // TODO: see if we can do this directly in the frontCommerceContext.rootLoaderContext
+-    routeErrorMeta: generateRouteErrorMeta(app.intl),
+-  });
++  return json(app.rootLoaderContext);
+ };
+
+ export const shouldRevalidate = () => false;
+```
+
+</details>


### PR DESCRIPTION
## What?

A new migration guide has been added to assist users in upgrading their projects from Front-Commerce version 3.8 to 3.9. The guide includes instructions for updating dependencies, utilizing an automated migration tool, and performing manual migrations. It provides specific details on updating Remix entrypoints, including a code snippet for changes in the `app/root.tsx` file. 

## NOTES

This might not be required depending on https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/3703