### PR TITLE
Improve unclear documentation

### DIFF
--- a/docs/02-guides/maintenance-mode/automatic-detection-with-service-health-checks.mdx
+++ b/docs/02-guides/maintenance-mode/automatic-detection-with-service-health-checks.mdx
@@ -74,7 +74,7 @@ export default defineExtension({
       // highlight-start
       services.MaintenanceMode.addHealthCheckService("acme", async () => {
         const response = await fetch("https://acme.com/api/health-check");
-        return response.status !== 200;
+        return response.status === 200;
       });
       // highlight-end
     },

--- a/docs/04-api-reference/front-commerce-core/create-resized-image-response.mdx
+++ b/docs/04-api-reference/front-commerce-core/create-resized-image-response.mdx
@@ -44,15 +44,14 @@ const fetchRemoteImage = async (imagePath: string) => {
 
 export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const imagePath = params["*"] as string;
-
-  const ONE_WEEK = 7 * 24 * 60 * 60; // the default cache duration is set to one year
+  const ONE_WEEK = 7 * 24 * 60 * 60;
 
   // highlight-start
   return createResizedImageResponse(
     request,
     () => fetchRemoteImage(imagePath),
     {
-      cacheDuration: ONE_WEEK,
+      cacheDuration: ONE_WEEK, // by default, cache duration is one year. This overrides it.
     }
   );
   // highlight-end


### PR DESCRIPTION
This PR improves some content that appeared to be unclear (from user feedback)

- Clarify the image resizing example about duration
- Fix return value for the healtcheck service example (logic was incorrect)