### PR TITLE
docs: documents changes on useExtensionComponentMap

### DIFF
--- a/docs/04-api-reference/front-commerce-core/react.mdx
+++ b/docs/04-api-reference/front-commerce-core/react.mdx
@@ -263,11 +263,17 @@ React components.
 This hook is used to get the components map registered through an
 [extension feature](./extension-features#registerfeature).
 
+As an optional second parameter, a default value can be provided. This value
+will be merged with the existing components map.
+
 ```tsx
 import { useExtensionComponentMap } from "@front-commerce/core/react";
 
 const AcmeModule = () => {
-  const AcmeFeature = useExtensionComponentMap("acme-feature");
+  const AcmeFeature = useExtensionComponentMap("acme-feature", {
+    // This will be used if no `AcmeHeader` component was registered in `acme-feature` feature, or if `acme-feature` is not registered.
+    AcmeHeader: () => <h1>Acme Header</h1>,
+  });
 
   return (
     <div>


### PR DESCRIPTION
This PR documents the optional "fallback" parameter to `useExtensionComponentMap` following some changes in [!3803](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/3803).