### PR TITLE
chore: document consent options and migration guide for google

### DIFF
--- a/docs/02-guides/analytics/getting-started.mdx
+++ b/docs/02-guides/analytics/getting-started.mdx
@@ -34,6 +34,21 @@ This means that once you have correctly configured events in your React
 Components, adding new tracking services is less risky: it has no impact on what
 is being tracked.
 
+# Analytics Overview
+
+Front-Commerce uses [`analytics`](https://getanalytics.io/) to track events
+across your React application. Events are dispatched to configured plugins,
+making it easier to add new tracking services without changing your tracking
+code.
+
+## Key Features
+
+- Track events with `trackEvent`
+- Track page views with `trackPage` and `useTrackPage`
+- Track component mounts with `useTrackOnMount`
+- GDPR-compliant consent management
+- Pluggable architecture for multiple analytics services
+
 ## Configure analytics
 
 :::info
@@ -125,6 +140,8 @@ If your plugins need consent of the user before running, you need to setup the
 trackings services are used within your application and will let the user chose
 which tracking service to allow.
 
+### Configuration
+
 ```js title="app/config/cookiesServices.js"
 export default {
   default_en: [
@@ -149,6 +166,33 @@ export default {
             "__utmt",
             "__utmz",
           ],
+          // Display a more granular consent control per service
+          consentOptions: [
+            {
+              name: "ad_storage",
+              title: "Ads Storage",
+              description:
+                "Enables storage of advertising-related data like conversion measurement and remarketing",
+            },
+            {
+              name: "ad_user_data",
+              title: "Ads User Data",
+              description:
+                "Allows collection and processing of user data for advertising purposes",
+            },
+            {
+              name: "ad_personalization",
+              title: "Ads Personalization",
+              description:
+                "Enables personalized advertising based on user behavior and interests",
+            },
+            {
+              name: "analytics_storage",
+              title: "Analytics Storage",
+              description:
+                "Enables storage of analytics data to measure site usage and performance",
+            },
+          ],
           description:
             "Google Analytics cookies, from Google, are meant to gather statistics about visits.",
           link: "https://support.google.com/analytics/answer/6004245",
@@ -159,16 +203,30 @@ export default {
 };
 ```
 
-The consent is stored in 2 separate cookies:
+The consent is stored in 3 separate cookies:
 
 1. `hasConsent` - If the user provided a consent answer (`authorized` or
    `denied`) for all services.
 2. `authorizations` - a JSON string of all consents given in the following
-   format `{ [service_name]: true | false, ... }`
+   format
+   ```ts
+     {
+       [service_name]: true | false,
+     }
+   ```
+3. `consentAuthorizations` - a JSON string of all consents given for a specific
+   service in the following format
+   ```ts
+   {
+     [service_name]: {
+       [consent_name]: true | false,
+     }
+   }
+   ```
 
 :::info Important
 
-The expiration for these two cookies' should be configured in
+The expiration for these three cookies' should be configured in
 [`app/config/website.js`](/docs/2.x/reference/configurations#configwebsitejs).
 
 ```js title="app/config/website.js"
@@ -184,3 +242,49 @@ export default {
 ```
 
 :::
+
+### Granular Consent Updates
+
+When using custom consent options defined in your `cookiesServices.js` file, you
+can implement granular consent updates by adding an `updateConsent` method to
+your analytics plugin. This method allows you to handle consent changes for
+specific tracking features.
+
+The `updateConsent` method is already included in the built-in
+`google-analytics` and `google-tag-manager` plugins, but you'll need to
+implement it yourself for custom plugins.
+
+Here's how to add consent updates to your plugin:
+
+```ts title="app/config/analytics.ts"
+import { type AnalyticsConfig } from "@front-commerce/core/react";
+
+export default {
+  analytics: {
+    // ...
+    plugins: [
+      // ...
+      {
+        name: "my-service",
+        // ...
+        script: () => () => {
+          return {
+            name: "my-service",
+            initialize: () => {...},
+            track: () => {...},
+            page: () => {...},
+            // highlight-start
+            methods: {
+              updateConsent: (consent: Record<string, boolean>) => {
+                // handle consent update for your service
+                // eg: {ad_storage:true, ad_user_data:false, ad_personalization:true, analytics_storage:true}
+              },
+            },
+            // highlight-end
+          };
+        }
+      },
+    ],
+  } satisfies AnalyticsConfig,
+};
+```

--- a/docs/100-upgrade/migration-guides/3.8-3.9.mdx
+++ b/docs/100-upgrade/migration-guides/3.8-3.9.mdx
@@ -78,3 +78,36 @@ If you have overriden `theme/modules/Layer/LayerFacets/LayerFacets`, you will
 need to apply the changes from its latest version to also support this feature.
 See
 [related commit](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/fdfe1d60a46e5040b788c4a43e10483a342607ea).
+
+### Google Consent V2 Support
+
+In this release, we've added support for
+[Google's Consent Mode v2](https://developers.google.com/tag-platform/security/guides/consent?hl=en&consentmode=advanced#upgrade-consent-v2)
+which provides more granular control over user consent preferences. This change
+affects applications using either the
+[Google Analytics 4](/docs/3.x/guides/analytics/plugins/google-analytics-4) or
+[Google Tag Manager](/docs/3.x/guides/analytics/plugins/google-tag-manager)
+plugins.
+
+To enable this feature, add the
+[`consentOptions`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/skeleton/app/config/cookiesServices.js?ref_type=heads#L21-46)
+to your service configuration in `cookiesServices.js`
+
+:::tip
+
+You can also take advantage of the `consentOptions` in your custom plugins by
+following the
+[Granular Consent Updates](/docs/3.x/guides/analytics/getting-started#granular-consent-updates)
+guide.
+
+:::
+
+If you have overriden any of these files, please make sure you apply the changes
+to your overrides:
+
+- [theme/modules/Cookie/CookieLink/CookieLink.jsx](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/c0be11c81601d0b3f4be4ed2fc11d6121552a8ef/packages/theme-chocolatine/theme/modules/Cookie/CookieLink/CookieLink.jsx)
+- [theme/modules/Cookie/CookieModal/CookieModal.jsx](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/c0be11c81601d0b3f4be4ed2fc11d6121552a8ef/packages/theme-chocolatine/theme/modules/Cookie/CookieModal/CookieModal.jsx)
+- [theme/modules/Cookie/CookiePage/CookieGrid/CookieGrid.tsx](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/c0be11c81601d0b3f4be4ed2fc11d6121552a8ef/packages/theme-chocolatine/theme/modules/Cookie/CookiePage/CookieGrid/CookieGrid.tsx)
+- [theme/modules/Cookie/CookiePage/CookieLine/CookieLine.tsx](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/c0be11c81601d0b3f4be4ed2fc11d6121552a8ef/packages/theme-chocolatine/theme/modules/Cookie/CookiePage/CookieLine/CookieLine.tsx)
+- [theme/modules/Cookie/CookiePage/CookieLine/CookieLine.scss](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/c0be11c81601d0b3f4be4ed2fc11d6121552a8ef/packages/theme-chocolatine/theme/modules/Cookie/CookiePage/CookieLine/CookieLine.scss)
+- [theme/modules/Cookie/CookiePage/CookiePage.tsx](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/c0be11c81601d0b3f4be4ed2fc11d6121552a8ef/packages/theme-chocolatine/theme/modules/Cookie/CookiePage/CookiePage.tsx)

--- a/versioned_docs/version-2.x/advanced/analytics/getting-started.mdx
+++ b/versioned_docs/version-2.x/advanced/analytics/getting-started.mdx
@@ -126,8 +126,10 @@ If your plugins need consent of the user before running, you need to setup the
 trackings services are used within your application and will let the user chose
 which tracking service to allow.
 
-```js title="config/cookiesServices.js"
-export default {
+### Configuration
+
+```js title="app/config/cookiesServices.js"
+module.exports = {
   default_en: [
     {
       // Category of cookies to allow the user to accept all the plugins at once in a specific category
@@ -150,6 +152,33 @@ export default {
             "__utmt",
             "__utmz",
           ],
+          // Display a more granular consent control per service
+          consentOptions: [
+            {
+              name: "ad_storage",
+              title: "Ads Storage",
+              description:
+                "Enables storage of advertising-related data like conversion measurement and remarketing",
+            },
+            {
+              name: "ad_user_data",
+              title: "Ads User Data",
+              description:
+                "Allows collection and processing of user data for advertising purposes",
+            },
+            {
+              name: "ad_personalization",
+              title: "Ads Personalization",
+              description:
+                "Enables personalized advertising based on user behavior and interests",
+            },
+            {
+              name: "analytics_storage",
+              title: "Analytics Storage",
+              description:
+                "Enables storage of analytics data to measure site usage and performance",
+            },
+          ],
           description:
             "Google Analytics cookies, from Google, are meant to gather statistics about visits.",
           link: "https://support.google.com/analytics/answer/6004245",
@@ -160,16 +189,30 @@ export default {
 };
 ```
 
-The consent for the cookies is stored in 2 cookies:
+The consent is stored in 3 separate cookies:
 
-1. `hasConsent` cookie which stores if the user provided consent answer
-   (authorized or denied) for all services.
-2. `authorizations` cookie which stores a JSON string of all consents given in
-   the following format `{ [service_name]: true | false, ... }`
+1. `hasConsent` - If the user provided a consent answer (`authorized` or
+   `denied`) for all services.
+2. `authorizations` - a JSON string of all consents given in the following
+   format
+   ```ts
+     {
+       [service_name]: true | false,
+     }
+   ```
+3. `consentAuthorizations` - a JSON string of all consents given for a specific
+   service in the following format
+   ```ts
+   {
+     [service_name]: {
+       [consent_name]: true | false,
+     }
+   }
+   ```
 
 :::info Important
 
-The expiration for these two cookies' should be configured in
+The expiration for these three cookies' should be configured in
 [`src/config/website.js`](/docs/2.x/reference/configurations#configwebsitejs).
 
 ```js title="src/config/website.js"
@@ -185,3 +228,47 @@ module.exports = {
 ```
 
 :::
+
+### Granular Consent Updates
+
+When using custom consent options defined in your `cookiesServices.js` file, you
+can implement granular consent updates by adding an `updateConsent` method to
+your analytics plugin. This method allows you to handle consent changes for
+specific tracking features.
+
+The `updateConsent` method is already included in the built-in
+`google-analytics` and `google-tag-manager` plugins, but you'll need to
+implement it yourself for custom plugins.
+
+Here's how to add consent updates to your plugin:
+
+```ts title="app/config/analytics.js"
+module.exports = {
+  analytics: {
+    // ...
+    plugins: [
+      // ...
+      {
+        name: "my-service",
+        // ...
+        script: () => () => {
+          return {
+            name: "my-service",
+            initialize: () => {...},
+            track: () => {...},
+            page: () => {...},
+            // highlight-start
+            methods: {
+              updateConsent: (consent: Record<string, boolean>) => {
+                // handle consent update for your service
+                // eg: {ad_storage:true, ad_user_data:false, ad_personalization:true, analytics_storage:true}
+              },
+            },
+            // highlight-end
+          };
+        }
+      },
+    ],
+  }
+};
+```

--- a/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
+++ b/versioned_docs/version-2.x/appendices/migration-guides/index.mdx
@@ -23,6 +23,41 @@ npm install git+ssh://git@gitlab.blackswift.cloud/front-commerce/front-commerce.
 
 :::
 
+## `2.33.0` -> `2.34.0`
+
+### Google Consent V2 Support
+
+In this release, we've added support for
+[Google's Consent Mode v2](https://developers.google.com/tag-platform/security/guides/consent?hl=en&consentmode=advanced#upgrade-consent-v2)
+which provides more granular control over user consent preferences. This change
+affects applications using either the
+[Google Analytics 4](/docs/2.x/advanced/analytics/plugins#google-analytics-4) or
+[Google Tag Manager](/docs/2.x/advanced/analytics/plugins#google-tag-manager)
+plugins.
+
+To enable this feature, add the
+[`consentOptions`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2.x/src/config/cookiesServices.js#L11-36)
+to your service configuration in `cookiesServices.js`
+
+:::tip
+
+You can also take advantage of the `consentOptions` in your custom plugins by
+following the
+[Granular Consent Updates](/docs/2.x/advanced/analytics/getting-started#granular-consent-updates)
+guide.
+
+:::
+
+If you have overriden any of these files, please make sure you apply the changes
+to your overrides:
+
+- [theme/modules/Cookie/CookieLink/CookieLink.js](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/cbf7cbd7908fe23f2a8dd6304bd3452eeb1cddd0/src/web/theme/modules/Cookie/CookieLink/CookieLink.js)
+- [theme/modules/Cookie/CookieModal/CookieModal.js](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/cbf7cbd7908fe23f2a8dd6304bd3452eeb1cddd0/src/web/theme/modules/Cookie/CookieModal/CookieModal.js)
+- [theme/modules/Cookie/CookiePage/CookieGrid/CookieGrid.js](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/cbf7cbd7908fe23f2a8dd6304bd3452eeb1cddd0/src/web/theme/modules/Cookie/CookiePage/CookieGrid/CookieGrid.js)
+- [theme/modules/Cookie/CookiePage/CookieLine/CookieLine.js](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/cbf7cbd7908fe23f2a8dd6304bd3452eeb1cddd0/src/web/theme/modules/Cookie/CookiePage/CookieLine/CookieLine.js)
+- [theme/modules/Cookie/CookiePage/CookieLine/\_CookieLine.scss](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/cbf7cbd7908fe23f2a8dd6304bd3452eeb1cddd0/src/web/theme/modules/Cookie/CookiePage/CookieLine/_CookieLine.scss)
+- [theme/modules/Cookie/CookiePage/CookiePage.js](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/cbf7cbd7908fe23f2a8dd6304bd3452eeb1cddd0/src/web/theme/modules/Cookie/CookiePage/CookiePage.js)
+
 ## `2.32.0` -> `2.33.0`
 
 No manual migration steps are required for this release.


### PR DESCRIPTION
## What?
documents [🎟️ FC-3021](https://docs.google.com/document/d/1axv-l-X-LCDj82msnbqCGOPOsKbJ7iRDZXGpTsgE78U/edit?tab=t.0)

## Preview?
- 3.x
  - [Migration Guide](https://deploy-preview-996--heuristic-almeida-1a1f35.netlify.app/docs/3.x/upgrade/migration-guides/3.8-3.9#google-consent-v2-support)
  - [Granular Consent Updates Guide](https://deploy-preview-996--heuristic-almeida-1a1f35.netlify.app/docs/3.x/upgrade/migration-guides/3.8-3.9#google-consent-v2-support)
- 2.x
  - [Migration Guide](https://deploy-preview-996--heuristic-almeida-1a1f35.netlify.app/docs/2.x/appendices/migration-guides/#google-consent-v2-support)
  - [Granular Consent Updates Guide](https://deploy-preview-996--heuristic-almeida-1a1f35.netlify.app/docs/2.x/advanced/analytics/getting-started#granular-consent-updates)