### PR TITLE
feat(feature-flags): add simple documentation about feature flags

### DIFF
--- a/docs/02-guides/extension-features/feature-flags.mdx
+++ b/docs/02-guides/extension-features/feature-flags.mdx
@@ -1,0 +1,89 @@
+---
+title: Feature Flags
+description:
+  Feature flags are a way to enable or disable certain features in your
+  extension.
+---
+
+<SinceVersion tag="3.9" />
+
+## Overview
+
+<p>{frontMatter.description}</p>
+
+For instance feature flags can be useful for display or not a banner in your
+application.
+
+## Using feature flags
+
+### Declaring a feature flag
+
+To declare a feature flag, you must include a `featureFlags` property in your
+extension declaration.
+
+```ts title="extension/acme/index.ts"
+export default defineExtension({
+...
+  unstable_lifecycleHooks: {
+    onServerServicesInit: async (services, _request, config, user) => {
+      onFeaturesInit: (hooks) => {
+        hooks.registerFeature("order", {
+          flags: {
+            canOrderFooBar: true,
+          }
+        });
+      }
+    },
+  }
+...
+```
+
+This example will allow you to know if you can order a `FooBar` product.
+
+### Using a feature flag
+
+To use a feature flag, you must use the `useExtensionFeatureFlags` hook.
+
+The `useExtensionFeatureFlags` hook takes three arguments:
+
+- The extension name
+- The feature flag name
+- The default value
+
+```tsx title="extension/acme/pages/OrderFooBarPage.tsx"
+import { useExtensionFeatureFlags } from "@front-commerce/core/react";
+
+export function OrderFooBarPage() {
+  const canOrderFooBar = useExtensionFeatureFlags(
+    "order",
+    "canOrderFooBar",
+    false
+  );
+
+  return (
+    <div>
+      <h1>Order FooBar</h1>
+      {canOrderFooBar ? (
+        <button>Order FooBar</button>
+      ) : (
+        <p>You cannot order FooBar</p>
+      )}
+    </div>
+  )
+}
+```
+
+## Implemented Features and Flags
+
+### `newsletter` Feature
+
+| Flag name | Description                                     |
+| --------- | ----------------------------------------------- |
+| `enabled` | Is the newsletter related actions are available |
+
+### `accountInformation` Feature
+
+| Flag name       | Description                                                           |
+| --------------- | --------------------------------------------------------------------- |
+| `phoneRequired` | Should the phone number must be required in the user information form |
+| `canEditEmail`  | Can the user edit it's email address                                  |

--- a/docs/04-api-reference/front-commerce-core/extension-features.mdx
+++ b/docs/04-api-reference/front-commerce-core/extension-features.mdx
@@ -28,6 +28,9 @@ export default defineExtension({
   unstable_lifecycleHooks: {
     onFeaturesInit: (hooks) => {
       hooks.registerFeature("acme-feature", {
+        flags: {
+          canFooBar: false,
+        },
         ui: {
           componentsMap: {
             Header: new URL("./components/AcmeHeader.tsx", import.meta.url),

--- a/docs/04-api-reference/front-commerce-core/react.mdx
+++ b/docs/04-api-reference/front-commerce-core/react.mdx
@@ -284,3 +284,31 @@ const AcmeModule = () => {
   );
 };
 ```
+
+## `useExtensionFeatureFlags`
+
+This hook is used to get a feature flag registered through the through an
+[extension feature](./extension-features#registerfeature).
+
+```tsx
+import { useExtensionFeatureFlags } from "@front-commerce/core/react";
+
+export function OrderFooBarPage() {
+  const canOrderFooBar = useExtensionFeatureFlags(
+    "order",
+    "canOrderFooBar",
+    false
+  );
+
+  return (
+    <div>
+      <h1>Order FooBar</h1>
+      {canOrderFooBar ? (
+        <button>Order FooBar</button>
+      ) : (
+        <p>You cannot order FooBar</p>
+      )}
+    </div>
+  );
+}
+```


### PR DESCRIPTION
# What

This PR implement documentation about feature flags

# Preview

[Preview link](https://deploy-preview-1003--heuristic-almeida-1a1f35.netlify.app/docs/3.x/guides/extension-features/feature-flags)