### PR TITLE
docs: Documentated Maps extensions and shipping methods changes

### DIFF
--- a/docs/02-guides/display-a-map.mdx
+++ b/docs/02-guides/display-a-map.mdx
@@ -1,0 +1,151 @@
+---
+title: Display a map
+description:
+  Front-Commerce has a generic map component that modules can use to display
+  maps. This guide explains how to use the feature in your application.
+---
+
+<p>{frontMatter.description}</p>
+
+Since we are well aware that different shops come with different needs, we
+provide several implementations for Front-Commerce's generic Map component. Out
+of the box, Front-Commerce supports:
+
+- [Component Props](#component-props)
+  - [Map Component](#map-component)
+  - [Marker Component](#marker-component)
+- [Install a map extension](#install-a-map-extension)
+- [Display a map](#display-a-map)
+- [Override the map component](#override-the-map-component)
+
+The goal is to choose one to make sure that all maps across the website look the
+same.
+
+### Component Props
+
+We have homogenized the props of the map components to make sure that they are
+consistent across different components.
+
+#### Map Component
+
+| Property        | Description                              | Type                                                                                                                                                                                              |
+| --------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| locations       | A list of locations used for the markers | [`LocationInputShape[]`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2174f8f1636a42ce558d842082e06716a0e3724c/src/web/theme/components/organisms/Map/location.js#L65-74) |
+| getMarker       | The marker node for locations            | `(location) => ReactNode`                                                                                                                                                                         |
+| zoom            | Default zoom level                       | `number`                                                                                                                                                                                          |
+| defaultBounds   | The default map bounds                   | [`CoordinatesShape[]`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2174f8f1636a42ce558d842082e06716a0e3724c/src/web/theme/components/organisms/Map/location.js#L59-62)   |
+| defaultCenter   | The default center for the map.          | [`CoordinatesShape` ](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2174f8f1636a42ce558d842082e06716a0e3724c/src/web/theme/components/organisms/Map/location.js#L59-62)    |
+| onBoundsChanged | Event handler for bound changes          | `(event) => void`                                                                                                                                                                                 |
+
+#### Marker Component
+
+| Property      | Description                            | Type                                                                                                                                                                                            |
+| ------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| location      | Location for the marker                | [`LocationInputShape`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2174f8f1636a42ce558d842082e06716a0e3724c/src/web/theme/components/organisms/Map/location.js#L65-74) |
+| icon          | Allows you to override the marker icon | [`object`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2174f8f1636a42ce558d842082e06716a0e3724c/src/web/theme/components/organisms/Map/index.js#L25-31)                |
+| isPopupOpened | Controlled method for marker popup     | `boolean`                                                                                                                                                                                       |
+| onClick       | Event handler on marker click          | `(event) => void`                                                                                                                                                                               |
+
+### Install a map extension
+
+Follow the installation instruction of the map extension you want to use:
+
+- [Open Street Map (OSM) with Leaflet](/docs/3.x/extensions/leaflet#installation)
+- [Google Maps](/docs/3.x/extensions/google-maps#installation)
+
+After this, you should be able to use the Map component. See
+[Map.stories.tsx](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/2df15404cb74d9e52440f9c02ea43cea521cdd3c/packages/leaflet/theme/Leaflet/Map.stories.tsx)
+for details.
+
+:::note
+
+_Please keep in mind, that the Map component should be used in an element with a
+fixed height._
+
+:::
+
+### Display a map
+
+Using
+[`useExtensionComponentMap`](/docs/3.x/api-reference/front-commerce-core/react#useextensioncomponentmap),
+you can retrieve the registered map components and use it in your application:
+
+```tsx title="theme/myMapComponent.tsx"
+import { useCallback } from "react";
+import { useExtensionComponentMap } from "@front-commerce/core/react";
+
+export default function MyMapComponent() {
+  const MapComponents = useExtensionComponentMap("maps");
+  const locations = [
+    {
+      lat: 48.8566,
+      lng: 2.3522,
+    },
+    {
+      lat: 48.8536,
+      lng: 2.3523,
+    },
+  ];
+
+  return (
+    <div style={{ height: "500px" }}>
+      <MapComponents.Map
+        locations={locations}
+        getMarker={useCallback((location) => {
+          const LocationMarkerComponent = location.getMarkerComponent();
+          return <MapComponents.Marker key={location.id} location={location} />;
+        }, [])}
+      />
+    </div>
+  );
+}
+```
+
+For more advanced usage, see the
+[Map component documentation](/docs/3.x/extensions/theme-chocolatine/reference/maps).
+
+### Override the map component
+
+If you wish to override the Map or Marker components, you can use the
+[`registerFeature`](/docs/3.x/api-reference/front-commerce-core/extension-features#registerfeature)
+hook to do so:
+
+```tsx title="extensions/myMapExtension/index.ts"
+import { defineExtension } from "@front-commerce/core";
+
+export default defineExtension({
+  name: "myMapExtension",
+  meta: import.meta,
+  unstable_lifecycleHooks: {
+    onFeaturesInit: (hooks) => {
+      hooks.registerFeature("maps", {
+        ui: {
+          componentsMap: {
+            Map: new Url("theme/myMapComponent.tsx", import.meta.url),
+            Map: new Url("theme/myMarkerComponent.tsx", import.meta.url),
+          },
+        },
+      });
+    },
+  },
+});
+```
+
+Note that your `myMapExtension` extension should be registered after the maps
+extension you are willing to override in your `front-commerce.config.ts` (e.g.
+`@front-commerce/leaflet`):
+
+```ts title="front-commerce.config.ts"
+//...
+import leaflet from "@front-commerce/leaflet";
+import myMapExtension from "./extensions/myMapExtension";
+
+export default defineConfig({
+  extensions: [
+    leaflet(),
+    // ...
+    myMapExtension(),
+  ],
+  //...
+});
+```

--- a/docs/03-extensions/google-maps/index.mdx
+++ b/docs/03-extensions/google-maps/index.mdx
@@ -1,0 +1,45 @@
+---
+title: "Google Maps"
+description:
+  "This extension allow you to use Google Maps to display maps in your
+  Front-Commerce store."
+---
+
+<p>{frontMatter.description}</p>
+
+## Installation
+
+Install the `@front-commerce/google-maps` package:
+
+```bash
+pnpm add @front-commerce/google-maps
+```
+
+Add the Google Maps extension to your `front-commerce.config.ts`:
+
+```ts title="front-commerce.config.ts"
+//...
+import googleMaps from "@front-commerce/google-maps";
+
+export default defineConfig({
+  extensions: [
+    // ...
+    googleMaps(),
+  ],
+  //...
+});
+```
+
+Provide a Google Maps API key in your `.env` file. To get your API key, please
+follow the
+[Google Maps documentation](https://developers.google.com/maps/documentation/javascript/get-api-key).
+
+```bash title=".env"
+FRONT_COMMERCE_GOOGLE_MAPS_API_KEY="YOUR_GOOGLE_MAPS_API_KEY"
+```
+
+Google Maps map components should now be ready to be used in your application!
+
+## Next steps
+
+- [Display a map](/docs/3.x/guides/display-a-map)

--- a/docs/03-extensions/leaflet/index.mdx
+++ b/docs/03-extensions/leaflet/index.mdx
@@ -1,0 +1,37 @@
+---
+title: "Leaflet"
+description:
+  "This extension allow you to use Leaflet to display maps in your
+  Front-Commerce store."
+---
+
+<p>{frontMatter.description}</p>
+
+## Installation
+
+Install the `@front-commerce/leaflet` package:
+
+```bash
+pnpm add @front-commerce/leaflet
+```
+
+Add the Leaflet extension to your `front-commerce.config.ts`:
+
+```ts title="front-commerce.config.ts"
+//...
+import leaflet from "@front-commerce/leaflet";
+
+export default defineConfig({
+  extensions: [
+    // ...
+    leaflet(),
+  ],
+  //...
+});
+```
+
+Leaflet map components should now be ready to be used in your application!
+
+## Next steps
+
+- [Display a map](/docs/3.x/guides/display-a-map)

--- a/docs/03-extensions/theme-chocolatine/reference/features.mdx
+++ b/docs/03-extensions/theme-chocolatine/reference/features.mdx
@@ -35,3 +35,24 @@ This is used to easily customize the components used to render facets filters.
 - [`AttributeFacet`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/b296fa59c8001bd8f3099cd1351cf9735aaf3f8c/packages/theme-chocolatine/theme/components/atoms/PickerFacet/PickerFacet.tsx)
 - `CategoryFacet`, defaulted to `null` as it this type of facet is not rendered
   in `LayerFacet` by default
+
+## `maps`
+
+Extendable feature for the `Map` and `Marker` components. See
+[`PostalAddressSelector`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/packages/theme-chocolatine/theme/components/organisms/PostalAddressSelector/PostalAddressSelector.jsx#L34)
+
+### `ui.componentsMap`
+
+- [`Map`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/packages/theme-chocolatine/theme/components/organisms/Map/Map.jsx#10):
+- [`Marker`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/packages/theme-chocolatine/theme/components/organisms/Map/Map.jsx#31):
+
+## `shippingMethodAdditionalData`
+
+Extendable feature for the `AdditionalShippingInformation` component. See
+[`getAddtionalDataComponent`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/packages/theme-chocolatine/theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js#L7-13).
+
+### `ui.componentsMap`
+
+The registered component name should be the same as the
+`shippingMethod.method_type` value provided in the schema's `ShippingMethod`
+object.

--- a/docs/03-extensions/theme-chocolatine/reference/maps.mdx
+++ b/docs/03-extensions/theme-chocolatine/reference/maps.mdx
@@ -5,9 +5,32 @@ description: "This reference explains how to use the Map component."
 
 <p>{frontMatter.description}</p>
 
-:::info WIP
+The goal is to choose one to make sure that all maps across the website look the
+same.
 
-See
-https://developers.front-commerce.com/docs/2.x/advanced/features/display-a-map
+<SinceVersion tag="3.10" />
 
-:::
+## Component Props
+
+We have homogenized the props of the map components to make sure that they are
+consistent across different components.
+
+### Map Component
+
+| Property        | Description                              | Type                                                                                                                                                                    |
+| --------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| locations       | A list of locations used for the markers | [`TLocation[]`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/packages/theme-chocolatine/theme/components/organisms/Map/location.ts#L73)    |
+| getMarker       | The marker node for locations            | `(location) => ReactNode`                                                                                                                                               |
+| zoom            | Default zoom level                       | `number`                                                                                                                                                                |
+| defaultBounds   | The default map bounds                   | [`TCoordinates[]`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/packages/theme-chocolatine/theme/components/organisms/Map/location.ts#L78) |
+| defaultCenter   | The default center for the map.          | [`TCoordinates` ](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/packages/theme-chocolatine/theme/components/organisms/Map/location.ts#L78)  |
+| onBoundsChanged | Event handler for bound changes          | `(event) => void`                                                                                                                                                       |
+
+### Marker Component
+
+| Property      | Description                            | Type                                                                                                                                                               |
+| ------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| location      | Location for the marker                | [`TLocation`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/packages/theme-chocolatine/theme/components/organisms/Map/location.ts#L73) |
+| icon          | Allows you to override the marker icon | [`object`](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/blob/main/packages/theme-chocolatine/theme/components/organisms/Map/Map.jsx#L45-51)     |
+| isPopupOpened | Controlled method for marker popup     | `boolean`                                                                                                                                                          |
+| onClick       | Event handler on marker click          | `(event) => void`                                                                                                                                                  |

--- a/docs/100-upgrade/migration-guides/3.9-3.10.mdx
+++ b/docs/100-upgrade/migration-guides/3.9-3.10.mdx
@@ -1,0 +1,42 @@
+---
+title: 3.9 -> 3.10
+description:
+  This page lists the highlights for upgrading a project from Front-Commerce 3.9
+  to 3.10
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<p>{frontMatter.description}</p>
+
+## Update dependencies
+
+Update all your `@front-commerce/*` dependencies to this version:
+
+```shell
+pnpm update "@front-commerce/*@3.10.0"
+```
+
+## Manual Migration
+
+### Shipping methods
+
+In this release, we reworked the way additional data component can be retrieved
+during the shipping method selection at checkout time.
+
+In v2, these component were registered by overriding the
+`theme/modules/Checkout/ShippingMethod/AdditionalShippingInformation/getAdditionalDataComponent.js`
+file.
+
+In v3, we're now leveraging on the
+[feature registration hook](/docs/3.x/api-reference/front-commerce-core/extension-features#registerfeature)
+so that any extension can register its own component without having to override
+theme files, which greatly enhance maintainability.
+
+Although this change is backward compatible, we recommend that you update your
+`getAdditionalDataComponent` file to take advantage of the latest way of using
+additional data components.
+
+For more informations, please refer to the
+[related change](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/commit/2de78fd7361cf92295582ac5a39beaee39b5a860?merge_request_iid=3855).


### PR DESCRIPTION
This MR follows [!3852](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/3852), [!3855](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/3855) and [!3862](https://gitlab.blackswift.cloud/front-commerce/front-commerce/-/merge_requests/3862), and documents changes made related to shipping method additional data collection:

- New `features`: `shippingMethodAdditionalData` and `maps`
  - Also documented the related migration guide for this.
- Added `Leaflet` package
- Added `Google Maps` package